### PR TITLE
Converting tabs to spaces and renaming dependency to avoid conflicts

### DIFF
--- a/src/pact.js
+++ b/src/pact.js
@@ -1,65 +1,64 @@
 'use strict';
 
-var check = require('check-types'),
-	serverFactory = require('./server'),
-	q = require('q');
+var serverFactory = require('./server'),
+  q = require('q');
 
 var servers = [];
 
 function create(options) {
 
-	if (options && options.port) {
-		for (var i = 0, len = servers.length; i < len; i++) {
-			if (servers[i].port == options.port) {
-				throw new Error('VERY WARNINGS! Port ' + options.port + ' much in use. Wow.');
-				return;
-			}
-		}
-	}
+  if (options && options.port) {
+    for (var i = 0, len = servers.length; i < len; i++) {
+      if (servers[i].port == options.port) {
+        throw new Error('VERY WARNINGS! Port ' + options.port + ' much in use. Wow.');
+        return;
+      }
+    }
+  }
 
-	var server = serverFactory(options);
-	servers.push(server);
+  var server = serverFactory(options);
+  servers.push(server);
 
-	// Listen to serverFactory events
-	function deleteFunc(server) {
-		for (var i = 0, len = servers.length; i < len; i++) {
-			if (servers[i] === server) {
-				servers.splice(i, 1);
-				break;
-			}
-		}
-		server.removeListener('delete', deleteFunc);
-	}
+  // Listen to serverFactory events
+  function deleteFunc(server) {
+    for (var i = 0, len = servers.length; i < len; i++) {
+      if (servers[i] === server) {
+        servers.splice(i, 1);
+        break;
+      }
+    }
+    server.removeListener('delete', deleteFunc);
+  }
 
-	server.on('delete', deleteFunc);
+  server.on('delete', deleteFunc);
 
-	return server;
+  return server;
 }
 
 function list() {
-	return servers;
+  return servers;
 }
 
 function removeAll() {
-	return q.all(servers.map(function (server) {
-		return server.delete();
-	}));
+  return q.all(servers.map(function (server) {
+    return server.delete();
+  }));
 }
 
 // Kill process on node exit
 var exitFunc = function () {
-	process.removeListener('SIGINT', exitFunc);
-	process.exit();
+  process.removeListener('SIGINT', exitFunc);
+  process.exit();
 };
 var deleteFunc = function () {
-	process.removeListener('exit', deleteFunc);
-	removeAll();
+  process.removeListener('exit', deleteFunc);
+  removeAll();
 };
 process.on('exit', deleteFunc);
 process.on('SIGINT', exitFunc);
 
 module.exports = {
-	create: create,
-	list: list,
-	removeAll: removeAll
+  create: create,
+  list: list,
+  removeAll: removeAll
 };

--- a/src/pact.spec.js
+++ b/src/pact.spec.js
@@ -1,215 +1,215 @@
 /* global describe:true, before:true, after:true, it:true, global:true, process:true */
 
 var expect = require('chai').expect,
-	pact = require('./pact.js');
+  pact = require('./pact.js');
 
 describe("Pact Spec", function () {
-	afterEach(function (done) {
-		pact.removeAll().then(function () {
-			done();
-		});
-	});
+  afterEach(function (done) {
+    pact.removeAll().then(function () {
+      done();
+    });
+  });
 
-	describe("Create serverFactory", function () {
-		context("when no options are set", function () {
-			it("should use defaults and return serverFactory", function () {
-				var server = pact.create();
-				expect(server).to.be.an('object');
-				expect(server).to.contain.all.keys(['port', 'cors', 'ssl', 'host', 'dir', 'log', 'spec', 'consumer', 'provider']);
-				expect(server.start).to.be.a('function');
-				expect(server.stop).to.be.a('function');
-				expect(server.delete).to.be.a('function');
-			});
-		});
+  describe("Create serverFactory", function () {
+    context("when no options are set", function () {
+      it("should use defaults and return serverFactory", function () {
+        var server = pact.create();
+        expect(server).to.be.an('object');
+        expect(server).to.contain.all.keys(['port', 'cors', 'ssl', 'host', 'dir', 'log', 'spec', 'consumer', 'provider']);
+        expect(server.start).to.be.a('function');
+        expect(server.stop).to.be.a('function');
+        expect(server.delete).to.be.a('function');
+      });
+    });
 
-		context("when user specifies valid options", function () {
-			var fs = require('fs'),
-				path = require('path'),
-				dirPath = path.resolve(__dirname, '../.tmp' + Math.floor(Math.random() * 1000));
-			beforeEach(function (done) {
-				fs.mkdir(dirPath, done);
-			});
-			afterEach(function (done) {
-				fs.rmdir(dirPath, done);
-			});
+    context("when user specifies valid options", function () {
+      var fs = require('fs'),
+        path = require('path'),
+        dirPath = path.resolve(__dirname, '../.tmp' + Math.floor(Math.random() * 1000));
+      beforeEach(function (done) {
+        fs.mkdir(dirPath, done);
+      });
+      afterEach(function (done) {
+        fs.rmdir(dirPath, done);
+      });
 
-			it("should return serverFactory using specified options", function () {
-				var options = {
-					port: 9500,
-					host: 'localhost',
-					dir: dirPath,
-					ssl: true,
-					cors: true,
-					log: 'log.txt',
-					spec: 1,
-					consumer: 'consumerName',
-					provider: 'providerName'
-				};
-				var server = pact.create(options);
-				expect(server).to.be.an('object');
-				expect(server.port).to.equal(options.port);
-				expect(server.host).to.equal(options.host);
-				expect(server.dir).to.equal(options.dir);
-				expect(server.ssl).to.equal(options.ssl);
-				expect(server.cors).to.equal(options.cors);
-				expect(server.log).to.equal(options.log);
-				expect(server.spec).to.equal(options.spec);
-				expect(server.consumer).to.equal(options.consumer);
-				expect(server.provider).to.equal(options.provider);
-			});
-		});
+      it("should return serverFactory using specified options", function () {
+        var options = {
+          port: 9500,
+          host: 'localhost',
+          dir: dirPath,
+          ssl: true,
+          cors: true,
+          log: 'log.txt',
+          spec: 1,
+          consumer: 'consumerName',
+          provider: 'providerName'
+        };
+        var server = pact.create(options);
+        expect(server).to.be.an('object');
+        expect(server.port).to.equal(options.port);
+        expect(server.host).to.equal(options.host);
+        expect(server.dir).to.equal(options.dir);
+        expect(server.ssl).to.equal(options.ssl);
+        expect(server.cors).to.equal(options.cors);
+        expect(server.log).to.equal(options.log);
+        expect(server.spec).to.equal(options.spec);
+        expect(server.consumer).to.equal(options.consumer);
+        expect(server.provider).to.equal(options.provider);
+      });
+    });
 
-		context("when user specifies invalid port", function () {
-			it("should return an error on negative port number", function () {
-				expect(function () {
-					pact.create({port: -42})
-				}).to.throw(Error);
-			});
+    context("when user specifies invalid port", function () {
+      it("should return an error on negative port number", function () {
+        expect(function () {
+          pact.create({port: -42})
+        }).to.throw(Error);
+      });
 
-			it("should return an error on non-integer", function () {
-				expect(function () {
-					pact.create({port: 42.42});
-				}).to.throw(Error);
-			});
+      it("should return an error on non-integer", function () {
+        expect(function () {
+          pact.create({port: 42.42});
+        }).to.throw(Error);
+      });
 
-			it("should return an error on non-number", function () {
-				expect(function () {
-					pact.create({port: '99'});
-				}).to.throw(Error);
-			});
+      it("should return an error on non-number", function () {
+        expect(function () {
+          pact.create({port: '99'});
+        }).to.throw(Error);
+      });
 
-			it("should return an error on outside port range", function () {
-				expect(function () {
-					pact.create({port: 99999});
-				}).to.throw(Error);
-			});
-		});
+      it("should return an error on outside port range", function () {
+        expect(function () {
+          pact.create({port: 99999});
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies port that's currently in use", function () {
-			it("should return a port conflict error", function () {
-				pact.create({port: 5100});
-				expect(function () {
-					pact.create({port: 5100})
-				}).to.throw(Error);
-			});
-		});
+    context("when user specifies port that's currently in use", function () {
+      it("should return a port conflict error", function () {
+        pact.create({port: 5100});
+        expect(function () {
+          pact.create({port: 5100})
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid host", function () {
-			it("should return an error on non-string", function () {
-				expect(function () {
-					pact.create({host: 12});
-				}).to.throw(Error);
-			});
-		});
+    context("when user specifies invalid host", function () {
+      it("should return an error on non-string", function () {
+        expect(function () {
+          pact.create({host: 12});
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid pact directory", function () {
-			it("should return an error on invalid path", function () {
-				expect(function () {
-					pact.create({dir: 'M:/nms'});
-				}).to.throw(Error);
-			});
-		});
+    context("when user specifies invalid pact directory", function () {
+      it("should return an error on invalid path", function () {
+        expect(function () {
+          pact.create({dir: 'M:/nms'});
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid ssl", function () {
-			it("should return an error on non-boolean", function () {
-				expect(function () {
-					pact.create({ssl: 1});
-				}).to.throw(Error);
-			});
-		});
+    context("when user specifies invalid ssl", function () {
+      it("should return an error on non-boolean", function () {
+        expect(function () {
+          pact.create({ssl: 1});
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid cors", function () {
-			it("should return an error on non-boolean", function () {
-				expect(function () {
-					pact.create({cors: 1});
-				}).to.throw(Error);
-			});
-		});
+    context("when user specifies invalid cors", function () {
+      it("should return an error on non-boolean", function () {
+        expect(function () {
+          pact.create({cors: 1});
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid log", function () {
-			it("should return an error on invalid path", function () {
-				expect(function () {
-					pact.create({log: 'abc/123'});
-				}).to.throw(Error);
-			});
-		});
+    context("when user specifies invalid log", function () {
+      it("should return an error on invalid path", function () {
+        expect(function () {
+          pact.create({log: 'abc/123'});
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid spec", function () {
-			it("should return an error on non-number", function () {
-				expect(function () {
-					pact.create({spec: '1'});
-				}).to.throw(Error);
-			});
+    context("when user specifies invalid spec", function () {
+      it("should return an error on non-number", function () {
+        expect(function () {
+          pact.create({spec: '1'});
+        }).to.throw(Error);
+      });
 
-			it("should return an error on negative number", function () {
-				expect(function () {
-					pact.create({spec: -12});
-				}).to.throw(Error);
-			});
+      it("should return an error on negative number", function () {
+        expect(function () {
+          pact.create({spec: -12});
+        }).to.throw(Error);
+      });
 
-			it("should return an error on non-integer", function () {
-				expect(function () {
-					pact.create({spec: 3.14});
-				}).to.throw(Error);
-			});
-		});
+      it("should return an error on non-integer", function () {
+        expect(function () {
+          pact.create({spec: 3.14});
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid consumer name", function () {
-			it("should return an error on non-string", function () {
-				expect(function () {
-					pact.create({consumer: 1234});
-				}).to.throw(Error);
-			});
-		});
+    context("when user specifies invalid consumer name", function () {
+      it("should return an error on non-string", function () {
+        expect(function () {
+          pact.create({consumer: 1234});
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid provider name", function () {
-			it("should return an error on non-string", function () {
-				expect(function () {
-					pact.create({provider: 2341});
-				}).to.throw(Error);
-			});
-		});
-	});
+    context("when user specifies invalid provider name", function () {
+      it("should return an error on non-string", function () {
+        expect(function () {
+          pact.create({provider: 2341});
+        }).to.throw(Error);
+      });
+    });
+  });
 
-	describe("List servers", function () {
-		context("when called and there are no servers", function () {
-			it("should return an empty list", function () {
-				expect(pact.list()).to.be.empty;
-			});
-		});
+  describe("List servers", function () {
+    context("when called and there are no servers", function () {
+      it("should return an empty list", function () {
+        expect(pact.list()).to.be.empty;
+      });
+    });
 
-		context("when called and there are servers in list", function () {
-			it("should return a list of all servers", function () {
-				pact.create({port: 9200});
-				pact.create({port: 9300});
-				pact.create({port: 9400});
-				expect(pact.list()).to.have.length(3);
-			});
-		});
+    context("when called and there are servers in list", function () {
+      it("should return a list of all servers", function () {
+        pact.create({port: 9200});
+        pact.create({port: 9300});
+        pact.create({port: 9400});
+        expect(pact.list()).to.have.length(3);
+      });
+    });
 
-		context("when server is removed", function () {
-			it("should update the list", function (done) {
-				pact.create({port: 9200});
-				pact.create({port: 9300});
-				pact.create({port: 9400}).delete().then(function () {
-					expect(pact.list()).to.have.length(2);
-					done();
-				});
-			});
-		});
-	});
+    context("when server is removed", function () {
+      it("should update the list", function (done) {
+        pact.create({port: 9200});
+        pact.create({port: 9300});
+        pact.create({port: 9400}).delete().then(function () {
+          expect(pact.list()).to.have.length(2);
+          done();
+        });
+      });
+    });
+  });
 
-	describe("Remove all servers", function () {
-		context("when removeAll() is called and there are servers to remove", function () {
-			it("should remove all servers", function (done) {
-				pact.create({port: 9200});
-				pact.create({port: 9300});
-				pact.create({port: 9400});
-				pact.removeAll().then(function () {
-					expect(pact.list()).to.be.empty;
-					done();
-				});
-			});
-		});
-	});
+  describe("Remove all servers", function () {
+    context("when removeAll() is called and there are servers to remove", function () {
+      it("should remove all servers", function (done) {
+        pact.create({port: 9200});
+        pact.create({port: 9300});
+        pact.create({port: 9400});
+        pact.removeAll().then(function () {
+          expect(pact.list()).to.be.empty;
+          done();
+        });
+      });
+    });
+  });
 });

--- a/src/server.js
+++ b/src/server.js
@@ -41,7 +41,7 @@ Server.prototype.start = function () {
   var amount = 0;
 
   function done() {
-    that.emit('stop', that);
+    that.emit('start', that);
     deferred.resolve(that);
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var check = require('check-types'),
-	path = require('path'),
-	fs = require('fs'),
-	cp = require('child_process'),
-	eventEmitter = require('events').EventEmitter,
-	http = require('http'),
-	https = require('https'),
-	q = require('q'),
-	util = require('util');
+var checkAssertion = require('check-types'),
+  path = require('path'),
+  fs = require('fs'),
+  cp = require('child_process'),
+  eventEmitter = require('events').EventEmitter,
+  http = require('http'),
+  https = require('https'),
+  q = require('q'),
+  util = require('util');
 var isWindows = process.platform === 'win32';
 
 var arch = "";
 if (process.platform === 'linux') {
-	arch = '-' + process.arch;
+  arch = '-' + process.arch;
 }
 var packageName = 'pact-mock-service-' + process.platform + arch;
 var packagePath = require.resolve(packageName);
@@ -21,272 +21,272 @@ var packagePath = require.resolve(packageName);
 var CHECKTIME = 500;
 
 function Server(port, host, dir, ssl, cors, log, spec, consumer, provider) {
-	this.port = port;
-	this.host = host;
-	this.dir = dir;
-	this.ssl = ssl;
-	this.cors = cors;
-	this.log = log;
-	this.spec = spec;
-	this.consumer = consumer;
-	this.provider = provider;
+  this.port = port;
+  this.host = host;
+  this.dir = dir;
+  this.ssl = ssl;
+  this.cors = cors;
+  this.log = log;
+  this.spec = spec;
+  this.consumer = consumer;
+  this.provider = provider;
 }
 
 util.inherits(Server, eventEmitter);
 
 Server.prototype.start = function () {
-	var deferred = q.defer();
-	var that = this;
-	// Wait for pact-mock-service to be initialized and ready
-	var amount = 0;
+  var deferred = q.defer();
+  var that = this;
+  // Wait for pact-mock-service to be initialized and ready
+  var amount = 0;
 
-	function done() {
-		that.emit('stop', that);
-		deferred.resolve(that);
-	}
+  function done() {
+    that.emit('stop', that);
+    deferred.resolve(that);
+  }
 
-	function check() {
-		amount++;
+  function check() {
+    amount++;
 
-		function retry() {
-			if (amount >= 10) {
-				deferred.reject(new Error("Pact startup failed; tried calling service 10 times with no result."));
-			}
-			setTimeout(check, CHECKTIME);
-		}
+    function retry() {
+      if (amount >= 10) {
+        deferred.reject(new Error("Pact startup failed; tried calling service 10 times with no result."));
+      }
+      setTimeout(check, CHECKTIME);
+    }
 
-		if (that.port) {
-			var options = {
-				host: that.host,
-				port: that.port,
-				path: '/',
-				method: 'GET',
-				headers: {
-					'X-Pact-Mock-Service': true,
-					'Content-Type': 'application/json'
-				}
-			};
-			var requester = http.request;
-			if (that.ssl) {
-				requester = https.request;
-				process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-				options.rejectUnauthorized = false;
-				options.requestCert = false;
-				options.agent = false;
-			}
-			requester(options, done).on('error', retry).end();
-		} else {
-			retry();
-		}
-	}
+    if (that.port) {
+      var options = {
+        host: that.host,
+        port: that.port,
+        path: '/',
+        method: 'GET',
+        headers: {
+          'X-Pact-Mock-Service': true,
+          'Content-Type': 'application/json'
+        }
+      };
+      var requester = http.request;
+      if (that.ssl) {
+        requester = https.request;
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+        options.rejectUnauthorized = false;
+        options.requestCert = false;
+        options.agent = false;
+      }
+      requester(options, done).on('error', retry).end();
+    } else {
+      retry();
+    }
+  }
 
-	if (that.instance && that.instance.connected) {
-		console.warn('You already have a process running with PID: ' + that.instance.pid);
-		check();
-		return;
-	}
-	var file,
-		args = [],
-		opts = {
-			cwd: path.resolve(packagePath, '..'),
-			detached: !isWindows
-		},
-		mapping = {
-			'port': '--port',
-			'host': '--host',
-			'log': '--log',
-			'ssl': '--ssl',
-			'cors': '--cors',
-			'dir': '--pact_dir',
-			'spec': '--pact_specification_version',
-			'consumer': '--consumer',
-			'provider': '--provider'
-		};
+  if (that.instance && that.instance.connected) {
+    console.warn('You already have a process running with PID: ' + that.instance.pid);
+    check();
+    return;
+  }
+  var file,
+    args = [],
+    opts = {
+      cwd: path.resolve(packagePath, '..'),
+      detached: !isWindows
+    },
+    mapping = {
+      'port': '--port',
+      'host': '--host',
+      'log': '--log',
+      'ssl': '--ssl',
+      'cors': '--cors',
+      'dir': '--pact_dir',
+      'spec': '--pact_specification_version',
+      'consumer': '--consumer',
+      'provider': '--provider'
+    };
 
-	for (var key in mapping) {
-		if (that[key]) {
-			args.push(mapping[key] + ' ' + that[key]);
-		}
-	}
+  for (var key in mapping) {
+    if (that[key]) {
+      args.push(mapping[key] + ' ' + that[key]);
+    }
+  }
 
-	var cmd = [packagePath.split(path.sep).pop()].concat(args).join(' ');
+  var cmd = [packagePath.split(path.sep).pop()].concat(args).join(' ');
 
-	if (isWindows) {
-		file = 'cmd.exe';
-		args = ['/s', '/c', cmd];
-		opts.windowsVerbatimArguments = true;
-	} else {
-		cmd = "./" + cmd;
-		file = '/bin/sh';
-		args = ['-c', cmd];
-	}
+  if (isWindows) {
+    file = 'cmd.exe';
+    args = ['/s', '/c', cmd];
+    opts.windowsVerbatimArguments = true;
+  } else {
+    cmd = "./" + cmd;
+    file = '/bin/sh';
+    args = ['-c', cmd];
+  }
 
-	that.instance = cp.spawn(file, args, opts);
+  that.instance = cp.spawn(file, args, opts);
 
-	that.instance.stdout.setEncoding('utf8');
-	that.instance.stdout.on('data', console.log);
-	that.instance.stderr.setEncoding('utf8');
-	that.instance.stderr.on('data', console.log);
-	that.instance.on('error', console.error);
+  that.instance.stdout.setEncoding('utf8');
+  that.instance.stdout.on('data', console.log);
+  that.instance.stderr.setEncoding('utf8');
+  that.instance.stderr.on('data', console.log);
+  that.instance.on('error', console.error);
 
-	// if port isn't specified, listen for it when pact runs
-	function catchPort(data) {
-		var match = data.match(/port=([0-9]+)/);
-		if (match && match[1]) {
-			that.port = parseInt(match[1]);
-			that.instance.stdout.removeListener('data', catchPort);
-			that.instance.stderr.removeListener('data', catchPort);
-		}
-	}
+  // if port isn't specified, listen for it when pact runs
+  function catchPort(data) {
+    var match = data.match(/port=([0-9]+)/);
+    if (match && match[1]) {
+      that.port = parseInt(match[1]);
+      that.instance.stdout.removeListener('data', catchPort);
+      that.instance.stderr.removeListener('data', catchPort);
+    }
+  }
 
-	if (!that.port) {
-		that.instance.stdout.on('data', catchPort);
-		that.instance.stderr.on('data', catchPort);
-	}
+  if (!that.port) {
+    that.instance.stdout.on('data', catchPort);
+    that.instance.stderr.on('data', catchPort);
+  }
 
-	console.info('Creating Pact with PID: ' + that.instance.pid);
+  console.info('Creating Pact with PID: ' + that.instance.pid);
 
-	that.instance.on('close', function (code) {
-		if (code !== 0) {
-			console.warn('Pact exited with code ' + code + '.');
-		}
-		that.stop();
-	});
+  that.instance.on('close', function (code) {
+    if (code !== 0) {
+      console.warn('Pact exited with code ' + code + '.');
+    }
+    that.stop();
+  });
 
-	// check service is available
-	check();
-	return deferred.promise.timeout(10000, "Couldn't start Pact with PID: " + that.instance.pid);
+  // check service is available
+  check();
+  return deferred.promise.timeout(10000, "Couldn't start Pact with PID: " + that.instance.pid);
 };
 
 Server.prototype.stop = function () {
-	var deferred = q.defer();
-	var that = this;
-	var amount = 0;
+  var deferred = q.defer();
+  var that = this;
+  var amount = 0;
 
-	function done() {
-		that.emit('stop', that);
-		deferred.resolve(that);
-	}
+  function done() {
+    that.emit('stop', that);
+    deferred.resolve(that);
+  }
 
-	function check() {
-		amount++;
-		if (that.port) {
-			var options = {
-				host: that.host,
-				port: that.port,
-				path: '/',
-				method: 'GET',
-				headers: {
-					'X-Pact-Mock-Service': true,
-					'Content-Type': 'application/json'
-				}
-			};
-			var requester = http.request;
-			if (that.ssl) {
-				requester = https.request;
-				process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-				options.rejectUnauthorized = false;
-				options.requestCert = false;
-				options.agent = false;
-			}
-			requester(options, function () {
-				if (amount >= 10) {
-					deferred.reject(new Error("Pact stop failed; tried calling service 10 times with no result."));
-				}
-				setTimeout(check, CHECKTIME);
-			}).on('error', done).end();
-		} else {
-			done();
-		}
-	}
+  function check() {
+    amount++;
+    if (that.port) {
+      var options = {
+        host: that.host,
+        port: that.port,
+        path: '/',
+        method: 'GET',
+        headers: {
+          'X-Pact-Mock-Service': true,
+          'Content-Type': 'application/json'
+        }
+      };
+      var requester = http.request;
+      if (that.ssl) {
+        requester = https.request;
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+        options.rejectUnauthorized = false;
+        options.requestCert = false;
+        options.agent = false;
+      }
+      requester(options, function () {
+        if (amount >= 10) {
+          deferred.reject(new Error("Pact stop failed; tried calling service 10 times with no result."));
+        }
+        setTimeout(check, CHECKTIME);
+      }).on('error', done).end();
+    } else {
+      done();
+    }
+  }
 
-	var pid = -1;
-	if (that.instance) {
-		pid = that.instance.pid;
-		console.info('Removing Pact with PID: ' + that.instance.pid);
-		that.instance.removeAllListeners();
-		// Killing instance, since windows can't send signals, must kill process forcefully
-		if (isWindows) {
-			cp.execSync('taskkill /f /t /pid ' + that.instance.pid);
-		} else {
-			process.kill(-that.instance.pid, 'SIGKILL');
-		}
-		that.instance = undefined;
-	}
+  var pid = -1;
+  if (that.instance) {
+    pid = that.instance.pid;
+    console.info('Removing Pact with PID: ' + that.instance.pid);
+    that.instance.removeAllListeners();
+    // Killing instance, since windows can't send signals, must kill process forcefully
+    if (isWindows) {
+      cp.execSync('taskkill /f /t /pid ' + that.instance.pid);
+    } else {
+      process.kill(-that.instance.pid, 'SIGKILL');
+    }
+    that.instance = undefined;
+  }
 
-	check();
-	return deferred.promise.timeout(10000, "Couldn't stop Pact with PID: " + pid);
+  check();
+  return deferred.promise.timeout(10000, "Couldn't stop Pact with PID: " + pid);
 };
 
 Server.prototype.delete = function () {
-	var that = this;
-	return that.stop().then(function () {
-		that.emit('delete', that);
-		return that;
-	});
+  var that = this;
+  return that.stop().then(function () {
+    that.emit('delete', that);
+    return that;
+  });
 };
 
 module.exports = function (options) {
-	options = options || {};
+  options = options || {};
 
-	// defaults
-	//options.port = options.port;
-	options.ssl = options.ssl || false;
-	options.cors = options.cors || false;
-	// options.spec = options.spec || 1;
-	options.dir = options.dir ? path.resolve(options.dir) : process.cwd(); // Use directory relative to cwd
-	// options.log = options.log || process.cwd();
-	options.host = options.host || 'localhost';
-	// options.consumer = options.consumer || 'consumer name';
-	// options.provider = options.provider || 'provider name';
+  // defaults
+  //options.port = options.port;
+  options.ssl = options.ssl || false;
+  options.cors = options.cors || false;
+  // options.spec = options.spec || 1;
+  options.dir = options.dir ? path.resolve(options.dir) : process.cwd(); // Use directory relative to cwd
+  // options.log = options.log || process.cwd();
+  options.host = options.host || 'localhost';
+  // options.consumer = options.consumer || 'consumer name';
+  // options.provider = options.provider || 'provider name';
 
-	// port checking
-	if (options.port) {
-		check.assert.number(options.port);
-		check.assert.integer(options.port);
-		check.assert.positive(options.port);
-		check.assert.inRange(options.port, 0, 65535);
+  // port checking
+  if (options.port) {
+    checkAssertion.assert.number(options.port);
+    checkAssertion.assert.integer(options.port);
+    checkAssertion.assert.positive(options.port);
+    checkAssertion.assert.inRange(options.port, 0, 65535);
 
-		if (check.not.inRange(options.port, 1024, 49151)) {
-			console.warn("Like a Boss, you used a port outside of the recommended range (1024 to 49151); I too like to live dangerously.");
-		}
-	}
+    if (checkAssertion.not.inRange(options.port, 1024, 49151)) {
+      console.warn("Like a Boss, you used a port outside of the recommended range (1024 to 49151); I too like to live dangerously.");
+    }
+  }
 
-	// ssl check
-	check.assert.boolean(options.ssl);
+  // ssl check
+  checkAssertion.assert.boolean(options.ssl);
 
-	// cors check'
-	check.assert.boolean(options.cors);
+  // cors check'
+  checkAssertion.assert.boolean(options.cors);
 
-	// spec checking
-	if (options.spec) {
-		check.assert.number(options.spec);
-		check.assert.integer(options.spec);
-		check.assert.positive(options.spec);
-	}
+  // spec checking
+  if (options.spec) {
+    checkAssertion.assert.number(options.spec);
+    checkAssertion.assert.integer(options.spec);
+    checkAssertion.assert.positive(options.spec);
+  }
 
-	// dir check
-	check.assert(fs.statSync(path.normalize(options.dir)).isDirectory(), "Error on pact directory, not a valid directory");
+  // dir check
+  checkAssertion.assert(fs.statSync(path.normalize(options.dir)).isDirectory(), "Error on pact directory, not a valid directory");
 
-	// log check
-	if (options.log) {
-		check.assert(fs.statSync(path.dirname(path.normalize(options.log))).isDirectory(), "Error on log, not a valid path");
-	}
+  // log check
+  if (options.log) {
+    checkAssertion.assert(fs.statSync(path.dirname(path.normalize(options.log))).isDirectory(), "Error on log, not a valid path");
+  }
 
-	// host check
-	if (options.host) {
-		check.assert.string(options.host);
-	}
+  // host check
+  if (options.host) {
+    checkAssertion.assert.string(options.host);
+  }
 
-	// consumer name check
-	if (options.consumer) {
-		check.assert.string(options.consumer);
-	}
+  // consumer name check
+  if (options.consumer) {
+    checkAssertion.assert.string(options.consumer);
+  }
 
-	// provider name check
-	if (options.provider) {
-		check.assert.string(options.provider);
-	}
+  // provider name check
+  if (options.provider) {
+    checkAssertion.assert.string(options.provider);
+  }
 
-	return new Server(options.port, options.host, options.dir, options.ssl, options.cors, options.log, options.spec, options.consumer, options.provider);
+  return new Server(options.port, options.host, options.dir, options.ssl, options.cors, options.log, options.spec, options.consumer, options.provider);
 };

--- a/src/server.spec.js
+++ b/src/server.spec.js
@@ -1,144 +1,143 @@
 /* global describe:true, before:true, after:true, it:true, global:true, process:true */
 
 var serverFactory = require('./server.js'),
-	expect = require('chai').expect,
-	fs = require('fs'),
-	path = require('path');
+  expect = require('chai').expect,
+  fs = require('fs'),
+  path = require('path');
 
 describe("Server Spec", function () {
-	var server;
+  var server;
 
-	afterEach(function (done) {
-		if (server) {
-			server.delete().then(function () {
-				done();
-			});
-		} else {
-			done();
-		}
-	});
+  afterEach(function (done) {
+    if (server) {
+      server.delete().then(function () {
+        done();
+      });
+    } else {
+      done();
+    }
+  });
 
-	describe("Start server", function () {
-		context("when no options are set", function () {
-			it("should start correctly with defaults", function (done) {
-				server = serverFactory();
-				server.start().then(function () {
-					done();
-				});
-			});
-		});
+  describe("Start server", function () {
+    context("when no options are set", function () {
+      it("should start correctly with defaults", function (done) {
+        server = serverFactory();
+        server.start().then(function () {
+          done();
+        });
+      });
+    });
 
-		context("when valid options are set", function () {
+    context("when valid options are set", function () {
 
-			var dirPath = path.resolve(__dirname, '../.tmp' + Math.floor(Math.random() * 1000));
+      var dirPath = path.resolve(__dirname, '../.tmp' + Math.floor(Math.random() * 1000));
 
-			beforeEach(function (done) {
-				fs.mkdir(dirPath, done);
-			});
+      beforeEach(function (done) {
+        fs.mkdir(dirPath, done);
+      });
 
-			afterEach(function (done) {
-				fs.rmdir(dirPath, done);
-			});
+      afterEach(function (done) {
+        fs.rmdir(dirPath, done);
+      });
 
-			// TODO: Fix SSL, some kind of horrible issues with Ruby 1.9.3 and SSL on the Pact Mock Service side
-			it("should start correctly with ssl", function (done) {
-				server = serverFactory({ssl: true});
-				server.start().then(function () {
-					expect(server.ssl).to.equal(true);
-					done();
-				});
-			});
+      // TODO: Fix SSL, some kind of horrible issues with Ruby 1.9.3 and SSL on the Pact Mock Service side
+      it("should start correctly with ssl", function (done) {
+        server = serverFactory({ssl: true});
+        server.start().then(function () {
+          expect(server.ssl).to.equal(true);
+          done();
+        });
+      });
 
-			it("should start correctly with cors", function (done) {
-				server = serverFactory({cors: true});
-				server.start().then(function () {
-					expect(server.cors).to.equal(true);
-					done();
-				});
-			});
+      it("should start correctly with cors", function (done) {
+        server = serverFactory({cors: true});
+        server.start().then(function () {
+          expect(server.cors).to.equal(true);
+          done();
+        });
+      });
 
-			it("should start correctly with port", function (done) {
-				server = serverFactory({port: 9500});
-				server.start().then(function () {
-					expect(server.port).to.equal(9500);
-					done();
-				});
-			});
+      it("should start correctly with port", function (done) {
+        server = serverFactory({port: 9500});
+        server.start().then(function () {
+          expect(server.port).to.equal(9500);
+          done();
+        });
+      });
 
-			it("should start correctly with host", function (done) {
-				server = serverFactory({host: 'localhost'});
-				server.start().then(function () {
-					expect(server.host).to.equal('localhost');
-					done();
-				});
-			});
+      it("should start correctly with host", function (done) {
+        server = serverFactory({host: 'localhost'});
+        server.start().then(function () {
+          expect(server.host).to.equal('localhost');
+          done();
+        });
+      });
 
-			it("should start correctly with spec", function (done) {
-				server = serverFactory({spec: 1});
-				server.start().then(function () {
-					expect(server.spec).to.equal(1);
-					done();
-				});
-			});
+      it("should start correctly with spec", function (done) {
+        server = serverFactory({spec: 1});
+        server.start().then(function () {
+          expect(server.spec).to.equal(1);
+          done();
+        });
+      });
 
-			it("should start correctly with dir", function (done) {
-				server = serverFactory({dir: dirPath});
-				server.start().then(function () {
-					expect(server.dir).to.equal(dirPath);
-					done();
-				});
-			});
+      it("should start correctly with dir", function (done) {
+        server = serverFactory({dir: dirPath});
+        server.start().then(function () {
+          expect(server.dir).to.equal(dirPath);
+          done();
+        });
+      });
 
-			it("should start correctly with log", function (done) {
-				server = serverFactory({log: 'log.txt'});
-				server.start().then(function () {
-					expect(server.log).to.equal('log.txt');
-					done();
-				});
-			});
+      it("should start correctly with log", function (done) {
+        server = serverFactory({log: 'log.txt'});
+        server.start().then(function () {
+          expect(server.log).to.equal('log.txt');
+          done();
+        });
+      });
 
-			it("should start correctly with consumer name", function (done) {
-				server = serverFactory({consumer: 'cName'});
-				server.start().then(function () {
-					expect(server.consumer).to.equal('cName');
-					done();
-				});
-			});
+      it("should start correctly with consumer name", function (done) {
+        server = serverFactory({consumer: 'cName'});
+        server.start().then(function () {
+          expect(server.consumer).to.equal('cName');
+          done();
+        });
+      });
 
-			it("should start correctly with provider name", function (done) {
-				server = serverFactory({provider: 'pName'});
-				server.start().then(function () {
-					expect(server.provider).to.equal('pName');
-					done();
-				});
-			});
-		});
-	});
+      it("should start correctly with provider name", function (done) {
+        server = serverFactory({provider: 'pName'});
+        server.start().then(function () {
+          expect(server.provider).to.equal('pName');
+          done();
+        });
+      });
+    });
+  });
 
-	describe("Stop server", function () {
-		context("when already started", function () {
-			it("should stop running", function (done) {
-				server = serverFactory();
-				server.start().then(function () {
-					return server.stop();
-				}).then(function () {
-					done();
-				});
-			});
-		});
-	});
+  describe("Stop server", function () {
+    context("when already started", function () {
+      it("should stop running", function (done) {
+        server = serverFactory();
+        server.start().then(function () {
+          return server.stop();
+        }).then(function () {
+          done();
+        });
+      });
+    });
+  });
 
-	describe("Delete server", function () {
-		context("when already running", function () {
-			it("should stop & delete server", function (done) {
-				server = serverFactory();
-				server.start().then(function () {
-					return server.delete();
-				}).then(function () {
-					done();
-				});
-			});
-		});
-	});
-
+  describe("Delete server", function () {
+    context("when already running", function () {
+      it("should stop & delete server", function (done) {
+        server = serverFactory();
+        server.start().then(function () {
+          return server.delete();
+        }).then(function () {
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
`check-types` requirement could conflict with the `check()` function in the code base. Fixed that and converted all tabs to spaces.