### PR TITLE
Provider verification and Pact Publishing...on Windows!

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@pact-foundation/pact-mock-service": "0.8.7",
-    "@pact-foundation/pact-provider-verifier": "0.0.7",
+    "@pact-foundation/pact-provider-verifier": "0.0.12",
     "bluebird": "^3.3.5",
     "bunyan": "^1.8.0",
     "bunyan-prettystream": "^0.1.3",
@@ -55,10 +55,10 @@
     "@pact-foundation/pact-mock-service-win32": "0.8.7",
     "@pact-foundation/pact-mock-service-linux-x64": "0.8.7",
     "@pact-foundation/pact-mock-service-linux-ia32": "0.8.7",
-    "@pact-foundation/pact-provider-verifier-darwin": "0.0.7",
-    "@pact-foundation/pact-provider-verifier-linux-ia32": "0.0.7",
-    "@pact-foundation/pact-provider-verifier-linux-x64": "0.0.7",
-    "@pact-foundation/pact-provider-verifier-win32": "0.0.7"
+    "@pact-foundation/pact-provider-verifier-darwin": "0.0.12",
+    "@pact-foundation/pact-provider-verifier-linux-ia32": "0.0.12",
+    "@pact-foundation/pact-provider-verifier-linux-x64": "0.0.12",
+    "@pact-foundation/pact-provider-verifier-win32": "0.0.12"
   },
   "bin": {
     "pact": "./bin/pact-node"
@@ -74,6 +74,7 @@
     "jscs": "^2.1.0",
     "mocha": "^2.2.5",
     "nodemon": "^1.4.1",
+    "rewire": "^2.5.1",
     "rimraf": "^2.4.2",
     "sinon": "^1.15.4"
   },

--- a/src/verifier.spec.js
+++ b/src/verifier.spec.js
@@ -6,6 +6,9 @@ var verifierFactory = require('./verifier'),
 	fs = require('fs'),
 	path = require('path'),
 	chai = require("chai"),
+	rewire = require("rewire"),
+	verifier = rewire("./verifier.js");
+	sanitisePath = verifier.__get__("sanitisePath");
 	chaiAsPromised = require("chai-as-promised");
 
 chai.use(chaiAsPromised);
@@ -94,6 +97,38 @@ describe("Verifier Spec", function () {
 					});
 					return expect(verifier.verify()).to.eventually.be.resolved;
 				});
+			});
+		});
+	});
+
+	describe("sanitise", function () {
+		context("when given windows path", function () {
+			context("and the path is not an extended Windows path", function () {
+				it("should convert to an absolute linux path", function () {
+					expect(sanitisePath("c:\\test\\pact.json")).to.eq("/test/pact.json");
+				});
+				it('should convert backwards-slash paths to forward slash paths', function () {
+					expect(sanitisePath('c:/aaaa\\bbbb')).to.eq('/aaaa/bbbb');
+					expect(sanitisePath('c:\\aaaa\\bbbb')).to.eq('/aaaa/bbbb');
+				});
+			});
+			context("and the path is an extended Winows path", function () {
+				it('should not convert extended-length paths', function () {
+					var path = '\\\\?\\c:\\aaaa\\bbbb';
+					expect(sanitisePath(path)).to.eq(path);
+				});
+			});
+			context("and the path contains unicode", function () {
+				it('should not convert paths with Unicode', function () {
+					var path = 'c:\\aaaa\\bbbb\\★';
+					expect(sanitisePath(path)).to.eq(path);
+				});
+			})
+		});
+		context("when given a linux path", function () {
+			it("should not modify the path", function () {
+				var path = '/usr/local/foo.json';
+				expect(sanitisePath(path)).to.eq(path);
 			});
 		});
 	});


### PR DESCRIPTION
[It works](https://ci.appveyor.com/project/MichelBoudreau/pact-node/build/28)!

* A number of changes to the upstream projects (pact-provider-verifier and the npm module) to fix Windows encoding issues
* Sanitise URLs on Windows paths to work in Ruby land