### PR TITLE
Return output to promise in verification process #8

### DIFF
--- a/src/verifier.js
+++ b/src/verifier.js
@@ -32,7 +32,11 @@ function Verifier(providerBaseUrl, pactUrls, providerStatesUrl, providerStatesSe
 Verifier.prototype.verify = function () {
 	logger.info("Verifier verify()");
 	var deferred = q.defer();
-
+	var stdout = ''; // Store output here in case of error
+	var outputHandler = function(data) {
+		logger.info(data)
+		stdout = stdout + data;
+	};
 	var envVars = JSON.parse(JSON.stringify(process.env)); // Create copy of environment variables
 	// Remove environment variable if there
 	// This is a hack to prevent some weird Travelling Ruby behaviour with Gems
@@ -73,22 +77,20 @@ Verifier.prototype.verify = function () {
 	this.instance = cp.spawn(file, args, opts);
 
 	this.instance.stdout.setEncoding('utf8');
-	this.instance.stdout.on('data', logger.debug.bind(logger));
+	this.instance.stdout.on('data', outputHandler);
 	this.instance.stderr.setEncoding('utf8');
-	this.instance.stderr.on('data', logger.debug.bind(logger));
+	this.instance.stderr.on('data', outputHandler);
 	this.instance.on('error', logger.error.bind(logger));
 
 	this.instance.once('close', function (code) {
-		code == 0 ? deferred.resolve() : deferred.reject();
+		code == 0 ? deferred.resolve(stdout) : deferred.reject(new Error(stdout));
 	});
 
 	logger.info('Created Pact Verifier process with PID: ' + this.instance.pid);
 	return deferred.promise.then(function () {
 		logger.info('Pact Verification succeeded.');
-	}, function () {
-		var msg = 'Pact Verification failed.';
-		logger.error(msg);
-		return q.reject(msg);
+	}, function (err) {
+		return q.reject(err);
 	});
 };
 

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -29,21 +29,6 @@ function Verifier(providerBaseUrl, pactUrls, providerStatesUrl, providerStatesSe
 	this.options.pactBrokerPassword = pactBrokerPassword;
 }
 
-// Converts a path to unixy stuff
-function sanitisePath(str) {
-	var isExtendedLengthPath = /^\\\\\?\\/.test(str);
-	var hasNonAscii = /[^\x00-\x80]+/.test(str);
-
-	if (isExtendedLengthPath || hasNonAscii) {
-		return str;
-	}
-
-	// var str = 'c:\\test\\pact.json';
-	str = str.replace(/\\/g, '/');
-	str = str.replace(/[a-zA-Z]+:/, '');
-	return str
-}
-
 Verifier.prototype.verify = function () {
 	logger.info("Verifier verify()");
 	var deferred = q.defer();

--- a/test/verifier.integration.spec.js
+++ b/test/verifier.integration.spec.js
@@ -138,11 +138,13 @@ describe("Verifier Integration Spec", function () {
 							pactBrokerUsername: 'foo',
 							pactBrokerPassword: 'baaoeur'
 						});
-						return expect(verifier.verify().catch(function(err) {
-							if (!_.isEmpty(err)) {
-								return Promise.reject(new Error("failed"));
-							}
-						})).to.eventually.be.rejectedWith(Error, "failed");
+						return verifier.verify()
+						.then(function() {
+							throw new Error("Expected an error but got none");
+						})
+						.catch(function(err) {
+							expect(err.message).to.contain("Unauthorized")
+						})
 					});
 				});
 			});


### PR DESCRIPTION
Fixes issue #7.

Essentially, we log all output as before, but we also store it in a string variable that is passed back to the promise chain. This allows clients (such as pact-foundation/pact-js) to provide better messaging to their users.

See https://github.com/pact-foundation/pact-node/pull/8/ (using branches in this repo so I can kill my old one).