### PR TITLE
Validate remote Pact files on publish

### DIFF
--- a/src/publisher.js
+++ b/src/publisher.js
@@ -28,10 +28,10 @@ Publisher.prototype.publish = function () {
 	var uris = _.chain(options.pactUrls)
 		.map(function (uri) {
 			var localFileOrDir = path.normalize(uri);
-			if (!(/^http/.test(uri)) && fs.statSync(localFileOrDir).isDirectory()) {
+			if (!(/^http/.test(uri)) && fs.statSync(localFileOrDir) && fs.statSync(localFileOrDir).isDirectory()) {
 				uri = localFileOrDir;
 				return _.map(fs.readdirSync(uri, ''), function (file) {
-					if (/.json$/.test(file)) {
+					if (/\.json$/.test(file)) {
 						return path.join(uri, file);
 					}
 				});
@@ -62,7 +62,7 @@ Publisher.prototype.publish = function () {
 			var getPactCollaborators;
 
 			// Parse the Pact file to extract consumer/provider names
-			if (/.json$/.test(uri)) {
+			if (/\.json$/.test(uri)) {
 				var readFile = q.nfbind(fs.readFile);
 				getPactCollaborators = readFile(uri, 'utf8')
 					.then(function(data) {

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -27,11 +27,10 @@ Publisher.prototype.publish = function () {
 	// publish template $pactHost/pacts/provider/$provider/consumer/$client/$version
 	var uris = _.chain(options.pactUrls)
 		.map(function (uri) {
-			uri = path.normalize(uri);
-			if (fs.statSync(uri).isDirectory()) {
-				logger.debug('we are a dir: ' + uri);
+			var localFileOrDir = path.normalize(uri);
+			if (!(/^http/.test(uri)) && fs.statSync(localFileOrDir).isDirectory()) {
+				uri = localFileOrDir;
 				return _.map(fs.readdirSync(uri, ''), function (file) {
-					// Ends with .json
 					if (/.json$/.test(file)) {
 						return path.join(uri, file);
 					}
@@ -46,42 +45,83 @@ Publisher.prototype.publish = function () {
 
 	// Return a merge of all promises...
 	return q.all(_.map(uris, function (uri) {
+		// Authentication
+		var auth = null;
+
+		if (options.pactBrokerUsername && options.pactBrokerPassword) {
+			auth = {
+				user: options.pactBrokerUsername,
+				pass: options.pactBrokerPassword
+			}
+		}
+
 		try {
-			var data = JSON.parse(fs.readFileSync(uri, 'utf8')),
-				provider = data.provider.name,
-				consumer = data.consumer.name,
-				deferred = q.defer();
+			var deferred = q.defer();
 
-			var config = {
-				uri: urlJoin(options.pactBroker, 'pacts/provider', provider, 'consumer', consumer, 'version', options.consumerVersion),
-				method: 'PUT',
-				headers: {
-					'Content-Type': 'application/json',
-					'Accept': 'application/json'
-				},
-				body: data,
-				json: true
-			};
+			// Promise to update provider/consumer
+			var getPactCollaborators;
 
-			// Authentication
-			if (options.pactBrokerUsername && options.pactBrokerPassword) {
-				config.auth = {
-					user: options.pactBrokerUsername,
-					pass: options.pactBrokerPassword
-				}
+			// Parse the Pact file to extract consumer/provider names
+			if (/.json$/.test(uri)) {
+				var readFile = q.nfbind(fs.readFile);
+				getPactCollaborators = readFile(uri, 'utf8')
+					.then(function(data) {
+						return JSON.parse(data)
+					}, function(err) {
+						return q.reject(err);
+					})
+			} else {
+				var request = q.denodeify(http);
+				var config = {
+					uri: uri,
+					method: 'GET',
+					headers: {
+						'Accept': 'application/json'
+					},
+					json: true,
+					auth: auth
+				};
+				getPactCollaborators = request(config)
+					.then(function(data) {
+						var body = data[0].body;
+						if (data[0].statusCode != 200) {
+							return q.reject(new Error('Cannot GET ' + uri + '. Nested exception: ' + body))
+						}
+						return body;
+					}, function(err) {
+						return q.reject(err);
+					})
 			}
 
-			http(config, function (error, response) {
-				if (!error && response.statusCode == 200) {
-					deferred.resolve();
-				} else {
-					deferred.reject();
-				}
-			});
+			return getPactCollaborators
+				.then(function(data) {
+					var config = {
+						uri: urlJoin(options.pactBroker, 'pacts/provider', data.provider, 'consumer', data.consumer, 'version', options.consumerVersion),
+						method: 'PUT',
+						headers: {
+							'Content-Type': 'application/json',
+							'Accept': 'application/json'
+						},
+						body: data,
+						json: true,
+						auth: auth
+					};
 
-			return deferred.promise;
+					http(config, function (error, response) {
+						if (!error && response.statusCode == 200) {
+							deferred.resolve();
+						} else {
+							deferred.reject();
+						}
+					});
+
+					return deferred.promise;
+				}, function(err) {
+					return q.reject(err);
+				})
+
 		} catch (e) {
-			return q.reject("Invalid Pact file: " + uri);
+			return q.reject("Invalid Pact file: " + uri + ". Nested exception: " + e.message);
 		}
 	}))
 };

--- a/test/integration/brokerMock.js
+++ b/test/integration/brokerMock.js
@@ -32,6 +32,11 @@ var auth = function (req, res, next) {
 	}
 };
 
+server.get('/somepact', function(req, res) {
+	console.log('pact get!!')
+	res.json({'consumer': {'name': 'anotherclient'}, 'provider': {'name': 'they'}});
+});
+
 // Pretend to be a Pact Broker (https://github.com/bethesque/pact_broker) for integration tests
 server.put('/pacts/provider/:provider/consumer/:consumer/version/:version', pactFunction);
 

--- a/test/publisher.integration.spec.js
+++ b/test/publisher.integration.spec.js
@@ -128,4 +128,35 @@ describe("Publish Spec", function () {
 			});
 		});
 	});
+	context("when publishing Pacts from an http-based URL", function () {
+		context("and the pact files are valid", function () {
+			it("should asynchronously send the Pact files to the broker", function () {
+				var publisher = publisherFactory({
+					pactBroker: pactBrokerBaseUrl,
+					pactUrls: [pactBrokerBaseUrl + '/somepact'],
+					consumerVersion: "1.0.0"
+				});
+
+				return expect(publisher.publish()).to.eventually.be.fulfilled;
+			});
+		});
+
+		context("and the pact files are invalid", function () {
+			it("should return a rejected promise", function () {
+				var publisher = publisherFactory({
+					pactBroker: pactBrokerBaseUrl,
+					pactUrls: [pactBrokerBaseUrl + '/somepacturlthatdoesntexist'],
+					consumerVersion: "1.0.0"
+				});
+
+				return publisher.publish()
+					.then(function() {
+						throw new Error("Expected an error but got none");
+					})
+					.catch(function(err) {
+						expect(err.message).to.contain("Nested exception: Cannot GET /somepacturlthatdoesntexist")
+					})
+			});
+		});
+	});
 });


### PR DESCRIPTION
Addresses comment: https://github.com/pact-foundation/pact-node/commit/a5afdb17e2c3ca8acf6c6a2051e7575cc4bcb4b2?diff=unified#commitcomment-17854867

New checks:
* Existence of remote files (will use basic auth if provided)
* Sanity check that a consumer/provider has been added to the Pact file