### PR TITLE
adding tagging capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ var opts = {
 	pactUrls: <Array>,               // Array of local Pact files or directories containing them. Required.
 	pactBroker: <String>,            // URL to fetch the provider states for the given provider API. Optional.
 	pactBrokerUsername: <String>,    // Username for Pact Broker basic authentication. Optional
-	pactBrokerPassword: <String>     // Password for Pact Broker basic authentication. Optional
+	pactBrokerPassword: <String>     // Password for Pact Broker basic authentication. Optional,
+  tags: <Array>,                   // An array of Strings to tag the Pacts being published. Optional
 };
 
 pact.publishPacts(opts)).then(function () {

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ var opts = {
 	pactBroker: <String>,            // URL to fetch the provider states for the given provider API. Optional.
 	pactBrokerUsername: <String>,    // Username for Pact Broker basic authentication. Optional
 	pactBrokerPassword: <String>     // Password for Pact Broker basic authentication. Optional,
-  tags: <Array>,                   // An array of Strings to tag the Pacts being published. Optional
+	tags: <Array>,                   // An array of Strings to tag the Pacts being published. Optional
 };
 
 pact.publishPacts(opts)).then(function () {

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -27,6 +27,10 @@ var constructPutUrl = function(options, data) {
 		throw new Error("Cannot construct Pact publish URL: 'pactBroker' not specified");
 	}
 
+	if (!_.has(options, 'consumerVersion')) {
+		throw new Error("Cannot construct Pact publish URL: 'consumerVersion' not specified");
+	}
+
 	if (!_.isObject(options)
 		|| !_.has(data, 'consumer')
 		|| !_.has(data, 'provider')
@@ -41,7 +45,11 @@ var constructPutUrl = function(options, data) {
 
 var constructTagUrl = function(options, tag, data) {
 	if (!_.has(options, 'pactBroker')) {
-		throw new Error("Cannot construct Pact publish URL: 'pactBroker' not specified");
+		throw new Error("Cannot construct Pact Tag URL: 'pactBroker' not specified");
+	}
+
+	if (!_.has(options, 'consumerVersion')) {
+		throw new Error("Cannot construct Pact Tag URL: 'consumerVersion' not specified");
 	}
 
 	if (!_.isObject(options)

--- a/src/publisher.spec.js
+++ b/src/publisher.spec.js
@@ -9,6 +9,7 @@ var publisherFactory = require('./publisher'),
 	rewire = require("rewire"),
 	publisher = rewire("./publisher.js"),
 	constructPutUrl = publisher.__get__('constructPutUrl'),
+	constructTagUrl = publisher.__get__('constructTagUrl'),
 	broker = require('../test/integration/brokerMock.js'),
 	chaiAsPromised = require("chai-as-promised");
 
@@ -130,6 +131,43 @@ describe("Publish Spec", function () {
 				expect(function() {
 					constructPutUrl(options, data);
 				}).to.throw(Error, "Invalid Pact file given. Unable to parse consumer and provider name");
+			});
+		});
+	});
+
+	context("constructTagUrl", function () {
+		context("when given a valid config object and pact JSON", function () {
+			it("should return a PUT url", function () {
+				var options = { 'pactBroker': 'http://foo', consumerVersion: '1.0' };
+				var data = { 'consumer': { 'name': 'consumerName' } };
+				expect(constructTagUrl(options, 'test', data)).to.eq('http://foo/pacticipants/consumerName/version/1.0/tags/test');
+			});
+		});
+		context("when given an invalid config object", function () {
+			it("should return a PUT url", function () {
+				var options = { 'someotherurl': 'http://foo', consumerVersion: '1.0' };
+				var data = { 'consumer': { 'name': 'consumerName' } };
+				expect(function() {
+					constructTagUrl(options, data);
+				}).to.throw(Error, "Cannot construct Pact publish URL: 'pactBroker' not specified");
+			});
+		});
+		context("when given an invalid pact file (no consumer key)", function () {
+			it("should return a PUT url", function () {
+				var options = { 'pactBroker': 'http://foo' };
+				var data = { };
+				expect(function() {
+					constructTagUrl(options, data);
+				}).to.throw(Error, "Invalid Pact file given. Unable to parse consumer name");
+			});
+		});
+		context("when given an invalid pact file (no name keys)", function () {
+			it("should return a PUT url", function () {
+				var options = { 'pactBroker': 'http://foo' };
+				var data = { 'consumer': {} };
+				expect(function() {
+					constructTagUrl(options, data);
+				}).to.throw(Error, "Invalid Pact file given. Unable to parse consumer name");
 			});
 		});
 	});

--- a/src/publisher.spec.js
+++ b/src/publisher.spec.js
@@ -101,23 +101,30 @@ describe("Publish Spec", function () {
 	context("constructPutUrl", function () {
 		context("when given a valid config object and pact JSON", function () {
 			it("should return a PUT url", function () {
-				var options = { 'pactBroker': 'http://foo' };
+				var options = { 'pactBroker': 'http://foo', 'consumerVersion': '1' };
 				var data = { 'consumer': { 'name': 'consumerName' }, 'provider': { 'name': 'providerName' } };
-				expect(constructPutUrl(options, data)).to.eq('http://foo/pacts/provider/providerName/consumer/consumerName/version/');
+				expect(constructPutUrl(options, data)).to.eq('http://foo/pacts/provider/providerName/consumer/consumerName/version/1');
 			});
 		});
 		context("when given an invalid config object", function () {
-			it("should return a PUT url", function () {
+			it("should throw Error when pactBroker is not specified", function () {
 				var options = { 'someotherurl': 'http://foo' };
 				var data = { 'consumer': { 'name': 'consumerName' }, 'provider': { 'name': 'providerName' } };
 				expect(function() {
 					constructPutUrl(options, data);
 				}).to.throw(Error, "Cannot construct Pact publish URL: 'pactBroker' not specified");
 			});
+			it("should throw Error when consumerVersion is not specified", function () {
+				var options = { 'pactBroker': 'http://foo' };
+				var data = { 'consumer': { 'name': 'consumerName' }, 'provider': { 'name': 'providerName' } };
+				expect(function() {
+					constructPutUrl(options, data);
+				}).to.throw(Error, "Cannot construct Pact publish URL: 'consumerVersion' not specified");
+			});
 		});
 		context("when given an invalid pact file (no consumer/provider keys)", function () {
 			it("should return a PUT url", function () {
-				var options = { 'pactBroker': 'http://foo' };
+				var options = { 'pactBroker': 'http://foo', 'consumerVersion': '1' };
 				var data = { };
 				expect(function() {
 					constructPutUrl(options, data);
@@ -126,7 +133,7 @@ describe("Publish Spec", function () {
 		});
 		context("when given an invalid pact file (no name keys)", function () {
 			it("should return a PUT url", function () {
-				var options = { 'pactBroker': 'http://foo' };
+				var options = { 'pactBroker': 'http://foo', 'consumerVersion': '1' };
 				var data = { 'consumer': {}, 'provider': {} };
 				expect(function() {
 					constructPutUrl(options, data);
@@ -144,17 +151,24 @@ describe("Publish Spec", function () {
 			});
 		});
 		context("when given an invalid config object", function () {
-			it("should return a PUT url", function () {
+			it("should throw Error when pactBroker is not specified", function () {
 				var options = { 'someotherurl': 'http://foo', consumerVersion: '1.0' };
 				var data = { 'consumer': { 'name': 'consumerName' } };
 				expect(function() {
 					constructTagUrl(options, data);
-				}).to.throw(Error, "Cannot construct Pact publish URL: 'pactBroker' not specified");
+				}).to.throw(Error, "Cannot construct Pact Tag URL: 'pactBroker' not specified");
+			});
+			it("should throw Error when consumerVersion is not specified", function () {
+				var options = { 'pactBroker': 'http://foo' };
+				var data = { 'consumer': { 'name': 'consumerName' }, 'provider': { 'name': 'providerName' } };
+				expect(function() {
+					constructTagUrl(options, data);
+				}).to.throw(Error, "Cannot construct Pact Tag URL: 'consumerVersion' not specified");
 			});
 		});
 		context("when given an invalid pact file (no consumer key)", function () {
 			it("should return a PUT url", function () {
-				var options = { 'pactBroker': 'http://foo' };
+				var options = { 'pactBroker': 'http://foo', consumerVersion: '1.0' };
 				var data = { };
 				expect(function() {
 					constructTagUrl(options, data);
@@ -163,7 +177,7 @@ describe("Publish Spec", function () {
 		});
 		context("when given an invalid pact file (no name keys)", function () {
 			it("should return a PUT url", function () {
-				var options = { 'pactBroker': 'http://foo' };
+				var options = { 'pactBroker': 'http://foo', consumerVersion: '1.0' };
 				var data = { 'consumer': {} };
 				expect(function() {
 					constructTagUrl(options, data);

--- a/test/integration/brokerMock.js
+++ b/test/integration/brokerMock.js
@@ -18,8 +18,7 @@ var pactFunction = function (req, res) {
 	) {
 		return res.sendStatus(400);
 	}
-	res.sendStatus(201);
-	res.json(req.body);
+	res.status(201).json(req.body);
 };
 
 var tagPactFunction = function (req, res) {

--- a/test/integration/brokerMock.js
+++ b/test/integration/brokerMock.js
@@ -22,6 +22,13 @@ var pactFunction = function (req, res) {
 	res.json(req.body);
 };
 
+var tagPactFunction = function (req, res) {
+	if (_.isEmpty(req.params.consumer) || _.isEmpty(req.params.version) || _.isEmpty(req.params.tag)) {
+		return res.sendStatus(400);
+	}
+	res.sendStatus(201);
+};
+
 // Let's add Auth for good measure
 var auth = function (req, res, next) {
 	var user = basicAuth(req);
@@ -46,5 +53,9 @@ server.put('/pacts/provider/:provider/consumer/:consumer/version/:version', pact
 
 // Authenticated calls...
 server.put('/auth/pacts/provider/:provider/consumer/:consumer/version/:version', auth, pactFunction);
+
+// Tagging
+server.put('/pacticipants/:consumer/version/:version/tags/:tag', tagPactFunction);
+server.put('/auth/pacticipants/:consumer/version/:version/tags/:tag', tagPactFunction);
 
 module.exports = server;

--- a/test/publisher.integration.spec.js
+++ b/test/publisher.integration.spec.js
@@ -42,6 +42,19 @@ describe("Publish Spec", function () {
 					expect(publisher).to.respondTo('publish');
 					return expect(publisher.publish()).to.eventually.be.fulfilled;
 				});
+
+				it("should successfully tag all Pacts with 'test' and 'latest'", function () {
+					var publisher = publisherFactory({
+						pactBroker: pactBrokerBaseUrl,
+						pactUrls: [path.resolve(__dirname, 'integration/publish/publish-success.json')],
+						consumerVersion: "1.0.0",
+						tags: ['test', 'latest']
+					});
+
+					expect(publisher).to.be.a('object');
+					expect(publisher).to.respondTo('publish');
+					return expect(publisher.publish()).to.eventually.be.fulfilled;
+				});
 			});
 			context("and the Pact file is invalid", function () {
 				it("should report an unsuccessful push", function () {
@@ -109,6 +122,22 @@ describe("Publish Spec", function () {
 						expect(res.length).to.eq(2);
 					})).to.eventually.be.fulfilled;
 			});
+
+			it("should successfully tag all Pacts sent with 'test' and 'latest'", function () {
+				var publisher = publisherFactory({
+					pactBroker: pactBrokerBaseUrl,
+					pactUrls: [path.resolve(__dirname, 'integration/publish/pactDirTests')],
+					consumerVersion: "1.0.0",
+					tags: ['test', 'latest']
+				});
+
+				expect(publisher).to.be.a('object');
+				expect(publisher).to.respondTo('publish');
+				return expect(publisher.publish()
+					.then(function (res) {
+						expect(res.length).to.eq(2);
+					})).to.eventually.be.fulfilled;
+			});
 		});
 
 		context("and the directory contains Pact and non-Pact files", function () {
@@ -135,6 +164,17 @@ describe("Publish Spec", function () {
 					pactBroker: pactBrokerBaseUrl,
 					pactUrls: [pactBrokerBaseUrl + '/somepact'],
 					consumerVersion: "1.0.0"
+				});
+
+				return expect(publisher.publish()).to.eventually.be.fulfilled;
+			});
+
+			it("should successfully tag all Pacts sent with 'test' and 'latest'", function () {
+				var publisher = publisherFactory({
+					pactBroker: pactBrokerBaseUrl,
+					pactUrls: [pactBrokerBaseUrl + '/somepact'],
+					consumerVersion: "1.0.0",
+					tags: ['test', 'latest']
 				});
 
 				return expect(publisher.publish()).to.eventually.be.fulfilled;

--- a/test/publisher.integration.spec.js
+++ b/test/publisher.integration.spec.js
@@ -194,7 +194,7 @@ describe("Publish Spec", function () {
 						throw new Error("Expected an error but got none");
 					})
 					.catch(function(results) {
-						expect(results[0].message).to.contain("Nested exception: Cannot GET /somepacturlthatdoesntexist")
+						expect(results[0].message).to.contain("Cannot GET /somepacturlthatdoesntexist")
 					})
 			});
 		});

--- a/test/publisher.integration.spec.js
+++ b/test/publisher.integration.spec.js
@@ -193,8 +193,8 @@ describe("Publish Spec", function () {
 					.then(function() {
 						throw new Error("Expected an error but got none");
 					})
-					.catch(function(err) {
-						expect(err.message).to.contain("Nested exception: Cannot GET /somepacturlthatdoesntexist")
+					.catch(function(results) {
+						expect(results[0].message).to.contain("Nested exception: Cannot GET /somepacturlthatdoesntexist")
 					})
 			});
 		});
@@ -210,8 +210,8 @@ describe("Publish Spec", function () {
 					.then(function() {
 						throw new Error("Expected an error but got none");
 					})
-					.catch(function(err) {
-						expect(err.message).to.contain("Invalid Pact file given. Unable to parse consumer and provider name");
+					.catch(function(results) {
+						expect(results[0].message).to.contain("Invalid Pact file given. Unable to parse consumer and provider name");
 					})
 			});
 		});


### PR DESCRIPTION
the pact broker allows for an endpoint that takes only one tag as specified here: https://github.com/bethesque/pact_broker/wiki/How-to-ensure-backwards-compatibility-by-tagging-pacts

This change creates an array of promises to loop through the array of tags and sends a PUT request to the Pact Broker accordingly, returning the original `deferred` object when all is done.

Feedback welcome.