### PR TITLE
fix(tag): fix URL for Pact tagging

### DIFF
--- a/src/publisher.js
+++ b/src/publisher.js
@@ -59,6 +59,7 @@ Publisher.prototype.publish = function () {
 							'Content-Type': 'application/json',
 							'Accept': 'application/json'
 						},
+						json: true,
 						body: data
 					}).fail(function (err) {
 						return q.reject(new Error('Unable to publish Pact to Broker. ' + err.message));
@@ -76,7 +77,6 @@ Publisher.prototype.publish = function () {
 							uri: constructTagUrl(options, tag, data),
 							method: 'PUT',
 							headers: {
-								'Accept': 'application/json',
 								'Content-Type': 'application/json'
 							}
 						}).fail(function () {
@@ -113,8 +113,7 @@ function callPact(options, config) {
 		method: 'GET',
 		headers: {
 			'Accept': 'application/json'
-		},
-		json: true
+		}
 	}, config);
 
 	// Authentication
@@ -147,7 +146,8 @@ function getPactFile(options, uri) {
 			})
 	} else {
 		return callPact(options, {
-			uri: uri
+			uri: uri,
+			json: true
 		}).fail(function (err) {
 			return q.reject(new Error('Cannot GET ' + uri + '. Nested exception: ' + err.message))
 		});
@@ -193,7 +193,7 @@ function constructTagUrl(options, tag, data) {
 			"Unable to parse consumer name");
 	}
 
-	return urlJoin(options.pactBroker, 'pacticipants', data.consumer.name, 'version', options.consumerVersion, 'tags', tag)
+	return urlJoin(options.pactBroker, 'pacticipants', data.consumer.name, 'versions', options.consumerVersion, 'tags', tag)
 }
 
 // Creates a new instance of the pact server with the specified option

--- a/src/publisher.spec.js
+++ b/src/publisher.spec.js
@@ -147,7 +147,7 @@ describe("Publish Spec", function () {
 			it("should return a PUT url", function () {
 				var options = { 'pactBroker': 'http://foo', consumerVersion: '1.0' };
 				var data = { 'consumer': { 'name': 'consumerName' } };
-				expect(constructTagUrl(options, 'test', data)).to.eq('http://foo/pacticipants/consumerName/version/1.0/tags/test');
+				expect(constructTagUrl(options, 'test', data)).to.eq('http://foo/pacticipants/consumerName/versions/1.0/tags/test');
 			});
 		});
 		context("when given an invalid config object", function () {

--- a/test/integration/brokerMock.js
+++ b/test/integration/brokerMock.js
@@ -54,7 +54,7 @@ server.put('/pacts/provider/:provider/consumer/:consumer/version/:version', pact
 server.put('/auth/pacts/provider/:provider/consumer/:consumer/version/:version', auth, pactFunction);
 
 // Tagging
-server.put('/pacticipants/:consumer/version/:version/tags/:tag', tagPactFunction);
-server.put('/auth/pacticipants/:consumer/version/:version/tags/:tag', tagPactFunction);
+server.put('/pacticipants/:consumer/versions/:version/tags/:tag', tagPactFunction);
+server.put('/auth/pacticipants/:consumer/versions/:version/tags/:tag', tagPactFunction);
 
 module.exports = server;


### PR DESCRIPTION
A couple of things:
First, the URL was wrong, oversight on my part as it should have been `../versions/..` instead of `../version/..`

Then the `json: true` configuration on the module `request` updates the headers with Accept and Content-Type pointing to JSON. Unfortunately the Pact Broker was rejecting this with a HTTP 406...

> 406 Not acceptable
> The resource is valid, but cannot be provided in a format specified in the Accept headers in the request.

Fixed that too.