### PR TITLE
fix(cmd): quote command line invocation arguments, fixes #22

### DIFF
--- a/src/verifier.js
+++ b/src/verifier.js
@@ -21,25 +21,27 @@ function Verifier(providerBaseUrl, pactUrls, providerStatesUrl, providerStatesSe
 	this.options.providerStatesSetupUrl = providerStatesSetupUrl;
 	this.options.pactBrokerUsername = pactBrokerUsername;
 	this.options.pactBrokerPassword = pactBrokerPassword;
+	this.options.args = [];
 }
 
 Verifier.prototype.verify = function () {
 	logger.info("Verifier verify()");
 	var deferred = q.defer();
-	
+
 	var output = ''; // Store output here in case of error
 	function outputHandler(data) {
 		logger.info(data);
 		output += data;
 	}
-	
+
 	var envVars = JSON.parse(JSON.stringify(process.env)); // Create copy of environment variables
 	// Remove environment variable if there
 	// This is a hack to prevent some weird Travelling Ruby behaviour with Gems
 	// https://github.com/pact-foundation/pact-mock-service-npm/issues/16
 	delete envVars['RUBYGEMS_GEMDEPS'];
-	
+
 	var file,
+		args,
 		opts = {
 			cwd: verifierPath.cwd,
 			detached: !isWindows,
@@ -53,13 +55,21 @@ Verifier.prototype.verify = function () {
 			'pactBrokerUsername': '--broker-username',
 			'pactBrokerPassword': '--broker-password'
 		};
-	
-	var args = _.compact(_.map(mapping, (function (value, key) {
-		return this.options[key] ? value + ' ' + (checkTypes.array(this.options[key]) ? this.options[key].join(',') : this.options[key]) : null;
-	}).bind(this)));
-	
-	var cmd = [verifierPath.file].concat(args).join(' ');
-	
+
+
+	this.options.args = _.compact(_.flatten(_.map(mapping, (function (value, key) {
+		if (this.options[key]) {
+			return [value, (checkTypes.array(this.options[key]) ? this.options[key].join(',') : this.options[key])]
+		}
+	}).bind(this))));
+
+	// Quote args
+	this.options.args = _.map(this.options.args, function(v) {
+		return '"' + v + '"';
+	});
+
+	var cmd = [verifierPath.file].concat(this.options.args).join(' ');
+
 	if (isWindows) {
 		file = 'cmd.exe';
 		args = ['/s', '/c', cmd];
@@ -69,19 +79,19 @@ Verifier.prototype.verify = function () {
 		file = '/bin/sh';
 		args = ['-c', cmd];
 	}
-	
+
 	this.instance = cp.spawn(file, args, opts);
-	
+
 	this.instance.stdout.setEncoding('utf8');
 	this.instance.stdout.on('data', outputHandler);
 	this.instance.stderr.setEncoding('utf8');
 	this.instance.stderr.on('data', outputHandler);
 	this.instance.on('error', logger.error.bind(logger));
-	
+
 	this.instance.once('close', function (code) {
 		code == 0 ? deferred.resolve(output) : deferred.reject(new Error(output));
 	});
-	
+
 	logger.info('Created Pact Verifier process with PID: ' + this.instance.pid);
 	return deferred.promise.timeout(10000, "Couldn't start Pact Verifier process with PID: " + this.instance.pid)
 		.then(function (data) {
@@ -97,14 +107,14 @@ module.exports = function (options) {
 	options.pactUrls = options.pactUrls || [];
 	options.providerStatesUrl = options.providerStatesUrl || '';
 	options.providerStatesSetupUrl = options.providerStatesSetupUrl || '';
-	
+
 	options.pactUrls = _.chain(options.pactUrls)
 		.map(function (uri) {
 			// only check local files
 			if (!/https?:/.test(url.parse(uri).protocol)) { // If it's not a URL, check if file is available
 				try {
 					fs.statSync(path.normalize(uri)).isFile();
-					
+
 					// Unixify the paths. Pact in multiple places uses URI and matching and
 					// hasn't really taken Windows into account. This is much easier, albeit
 					// might be a problem on non root-drives
@@ -119,37 +129,37 @@ module.exports = function (options) {
 		})
 		.compact()
 		.value();
-	
+
 	checkTypes.assert.nonEmptyString(options.providerBaseUrl, 'Must provide the --provider-base-url argument');
 	checkTypes.assert.not.emptyArray(options.pactUrls, 'Must provide the --pact-urls argument');
-	
+
 	if (options.providerStatesSetupUrl) {
 		checkTypes.assert.string(options.providerStatesSetupUrl);
 	}
-	
+
 	if (options.providerStatesUrl) {
 		checkTypes.assert.string(options.providerStatesUrl);
 	}
-	
+
 	if (options.pactBrokerUsername) {
 		checkTypes.assert.string(options.pactBrokerUsername);
 	}
-	
+
 	if (options.pactBrokerPassword) {
 		checkTypes.assert.string(options.pactBrokerPassword);
 	}
-	
+
 	if ((options.providerStatesUrl && !options.providerStatesSetupUrl) || (options.providerStatesSetupUrl && !options.providerStatesUrl)) {
 		throw new Error('Must provide both or none of --provider-states-url and --provider-states-setup-url.');
 	}
-	
+
 	if (options.pactUrls) {
 		checkTypes.assert.array.of.string(options.pactUrls);
 	}
-	
+
 	if (options.providerBaseUrl) {
 		checkTypes.assert.string(options.providerBaseUrl);
 	}
-	
+
 	return new Verifier(options.providerBaseUrl, options.pactUrls, options.providerStatesUrl, options.providerStatesSetupUrl, options.pactBrokerUsername, options.pactBrokerPassword);
 };

--- a/src/verifier.spec.js
+++ b/src/verifier.spec.js
@@ -3,6 +3,7 @@
 var verifierFactory = require('./verifier'),
 	logger = require('./logger'),
 	expect = require('chai').expect,
+	assert = require('chai').assert,
 	fs = require('fs'),
 	path = require('path'),
 	chai = require("chai"),
@@ -13,12 +14,25 @@ var verifierFactory = require('./verifier'),
 chai.use(chaiAsPromised);
 
 describe("Verifier Spec", function () {
-	
+
 	before(function () {
 		logger.level('debug');
 	});
-	
+
 	describe("Verifier", function () {
+		context("when provided any arguments", function () {
+			it("should wrap its arguments in quotes", function () {
+				var v = verifierFactory({
+					providerBaseUrl: "http://localhost",
+					pactUrls: ["http://idontexist"]
+				});
+				v.verify()
+				expect(v.options.args).to.include("\"--provider-base-url\"")
+				expect(v.options.args).to.include("\"http://localhost\"")
+				expect(v.options.args).to.include("\"--pact-urls\"")
+				expect(v.options.args).to.include("\"http://idontexist\"")
+			});
+		});
 		context("when not given --pact-urls or --provider-base-url", function () {
 			it("should fail with an error", function () {
 				expect(function () {
@@ -81,7 +95,7 @@ describe("Verifier Spec", function () {
 			});
 		});
 	});
-	
+
 	describe("verify", function () {
 		context("when given a successful scenario", function () {
 			context("with no provider States", function () {


### PR DESCRIPTION
Wraps all arguments to the verifier in quotation marks, to allow for arguments with special characters (see #22 for example with passwords).