### PR TITLE
Added logging to fail handlers

### DIFF
--- a/src/publisher.js
+++ b/src/publisher.js
@@ -22,6 +22,8 @@ function Publisher(pactBroker, pactUrls, consumerVersion, pactBrokerUsername, pa
 
 Publisher.prototype.publish = function () {
 	var options = this._options;
+	var errorMsg;
+	
 	logger.info('Publishing pacts to broker at: ' + options.pactBroker);
 
 	// Stat all paths in pactUrls to make sure they exist
@@ -59,7 +61,9 @@ Publisher.prototype.publish = function () {
 						json: true,
 						body: data
 					}).fail(function (err) {
-						return q.reject(new Error('Unable to publish Pact to Broker. ' + err.message));
+						errorMsg = 'Unable to publish Pact to Broker. ' + err.message;
+						logger.warn(errorMsg);
+						return q.reject(new Error(errorMsg));
 					});
 				})
 				.tap(function (data) {
@@ -74,7 +78,9 @@ Publisher.prototype.publish = function () {
 								'Content-Type': 'application/json'
 							}
 						}).fail(function () {
-							return q.reject(new Error('Could not tag Pact with tag "' + tag + '"'));
+							errorMsg = 'Could not tag Pact with tag "' + tag + '"';
+							logger.warn(errorMsg);
+							return q.reject(new Error(errorMsg));
 						});
 					})).tap(function (results) {
 						_.each(results, function (result) {


### PR DESCRIPTION
I was having troubles getting my contracts published on CI, after much hair being pulled out I resorted to adding logs to publisher.js. Turned out it was failing because I made a typo in the provider name and the broker was returning the provider has not been created error.

To prevent other people from struggling with this I've added logs to the fail branches of the promises.