### PR TITLE
PROPOSAL: Allow user to specify verification timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ var opts = {
 	providerStatesSetupUrl: <String>, // URL to send PUT requests to setup a given provider state. Optional.
 	pactBrokerUsername: <String>,    // Username for Pact Broker basic authentication. Optional
 	pactBrokerPassword: <String>,    // Password for Pact Broker basic authentication. Optional
+	timeout: <Number>                // The duration in ms we should wait to confirm verification process was successful. Defaults to 30000, Optional.
 };
 
 pact.verifyPacts(opts).then(function () {

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -92,6 +92,7 @@ module.exports = function (options) {
 	options.pactUrls = options.pactUrls || [];
 	options.providerStatesUrl = options.providerStatesUrl || '';
 	options.providerStatesSetupUrl = options.providerStatesSetupUrl || '';
+	options.timeout = options.timeout || 30000;
 
 	options.pactUrls = _.chain(options.pactUrls)
 		.map(function (uri) {
@@ -146,11 +147,7 @@ module.exports = function (options) {
 		checkTypes.assert.string(options.providerBaseUrl);
 	}
 
-	if (options.timeout) {
-		checkTypes.assert.positive(options.timeout);
-	} else {
-		options.timeout = 30000;
-	}
+	checkTypes.assert.positive(options.timeout);
 
 	return new Verifier(options.providerBaseUrl, options.pactUrls, options.providerStatesUrl, options.providerStatesSetupUrl, options.pactBrokerUsername, options.pactBrokerPassword, options.timeout);
 };

--- a/src/verifier.spec.js
+++ b/src/verifier.spec.js
@@ -43,6 +43,17 @@ describe("Verifier Spec", function () {
 				}).to.throw(Error);
 			});
 		});
+		context("when given an invalid timeout", function () {
+			it("should fail with an error", function () {
+				expect(function () {
+					verifierFactory({
+						providerBaseUrl: "http://localhost",
+						pactUrls: ["http://idontexist"],
+						timeout: -10
+					});
+				}).to.throw(Error);
+			});
+		});		
 		context("when given remote Pact URLs that don't exist", function () {
 			it("should pass through to the Pact Verifier regardless", function () {
 				expect(function () {


### PR DESCRIPTION
Fixes #30, but please count this as a proposal rather than a full-blown PR. I haven't fully explored test coverage etc. at this point.

Adds ability for a user to specify a timeout on the verification process. Previously there was a 10s verification timeout.

Another alternative could be to remove the timeout altogether and simply allow the parent testing framework to perform the timeout.

Looking for your thoughts @mboudreau.