### PR TITLE
feat(verifications): publish verifications to broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ var opts = {
 	providerStatesSetupUrl: <String>, // URL to send PUT requests to setup a given provider state. Optional.
 	pactBrokerUsername: <String>,    // Username for Pact Broker basic authentication. Optional
 	pactBrokerPassword: <String>,    // Password for Pact Broker basic authentication. Optional
+	publishVerificationResult: <Boolean> // Publish verification result to Broker. Optional
+	providerVersion: <Boolean>       // Provider version, required to publish verification result to Broker. Optional otherwise.
 	timeout: <Number>                // The duration in ms we should wait to confirm verification process was successful. Defaults to 30000, Optional.
 };
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	},
 	"dependencies": {
 		"@pact-foundation/pact-mock-service": "1.x.x",
-		"@pact-foundation/pact-provider-verifier": "1.x.x",
+		"@pact-foundation/pact-provider-verifier": "^1.1.1",
 		"bunyan": "^1.8.5",
 		"bunyan-prettystream": "^0.1.3",
 		"check-types": "~7.1.5",

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -12,7 +12,7 @@ var checkTypes = require('check-types'),
 	isWindows = process.platform === 'win32';
 
 // Constructor
-function Verifier(providerBaseUrl, pactUrls, providerStatesUrl, providerStatesSetupUrl, pactBrokerUsername, pactBrokerPassword, timeout) {
+function Verifier(providerBaseUrl, pactUrls, providerStatesUrl, providerStatesSetupUrl, pactBrokerUsername, pactBrokerPassword, publishVerificationResult, providerVersion, timeout) {
 	this._options = {};
 	this._options.providerBaseUrl = providerBaseUrl;
 	this._options.pactUrls = pactUrls;
@@ -20,6 +20,8 @@ function Verifier(providerBaseUrl, pactUrls, providerStatesUrl, providerStatesSe
 	this._options.providerStatesSetupUrl = providerStatesSetupUrl;
 	this._options.pactBrokerUsername = pactBrokerUsername;
 	this._options.pactBrokerPassword = pactBrokerPassword;
+	this._options.publishVerificationResult = publishVerificationResult;
+	this._options.providerVersion = providerVersion;
 	this._options.timeout = timeout;
 }
 
@@ -51,7 +53,9 @@ Verifier.prototype.verify = function () {
 			'providerStatesUrl': '--provider-states-url',
 			'providerStatesSetupUrl': '--provider-states-setup-url',
 			'pactBrokerUsername': '--broker-username',
-			'pactBrokerPassword': '--broker-password'
+			'pactBrokerPassword': '--broker-password',
+			'publishVerificationResult': '--publish-verification-results',
+			'providerVersion': '--provider-app-version'
 		});
 
 	var cmd = [verifierPath.file].concat(args).join(' ');
@@ -147,7 +151,19 @@ module.exports = function (options) {
 		checkTypes.assert.string(options.providerBaseUrl);
 	}
 
+	if (options.publishVerificationResult) {
+		checkTypes.assert.boolean(options.publishVerificationResult);
+	}
+
+	if (options.publishVerificationResult && !options.providerVersion) {
+		throw new Error('Must provide both or none of --publish-verification-results and --provider-app-version.');
+	}
+
+	if (options.providerVersion) {
+		checkTypes.assert.string(options.providerVersion);
+	}
+
 	checkTypes.assert.positive(options.timeout);
 
-	return new Verifier(options.providerBaseUrl, options.pactUrls, options.providerStatesUrl, options.providerStatesSetupUrl, options.pactBrokerUsername, options.pactBrokerPassword, options.timeout);
+	return new Verifier(options.providerBaseUrl, options.pactUrls, options.providerStatesUrl, options.providerStatesSetupUrl, options.pactBrokerUsername, options.pactBrokerPassword, options.publishVerificationResult, options.providerVersion, options.timeout);
 };

--- a/src/verifier.spec.js
+++ b/src/verifier.spec.js
@@ -22,14 +22,14 @@ describe("Verifier Spec", function () {
 		context("when given --provider-states-url and not --provider-states-setup-url", function () {
 			it("should fail with an error", function () {
 				expect(function () {
-					verifierFactory({"providerStatesUrl": "http://foo/provider-states"});
+					verifierFactory({ "providerStatesUrl": "http://foo/provider-states" });
 				}).to.throw(Error);
 			});
 		});
 		context("when given --provider-states-setup-url and not --provider-states-url", function () {
 			it("should fail with an error", function () {
 				expect(function () {
-					verifierFactory({"providerStatesSetupUrl": "http://foo/provider-states/setup"});
+					verifierFactory({ "providerStatesSetupUrl": "http://foo/provider-states/setup" });
 				}).to.throw(Error);
 			});
 		});
@@ -53,7 +53,8 @@ describe("Verifier Spec", function () {
 					});
 				}).to.throw(Error);
 			});
-		});		
+		});
+
 		context("when given remote Pact URLs that don't exist", function () {
 			it("should pass through to the Pact Verifier regardless", function () {
 				expect(function () {
@@ -74,6 +75,38 @@ describe("Verifier Spec", function () {
 				}).to.not.throw(Error);
 			});
 		});
+
+		context("when requested to publish verification results to a Pact Broker", function () {
+			context("and specifies a provider version", function () {
+				it("should pass through to the Pact Verifier", function () {
+					expect(function () {
+						verifierFactory({
+							providerBaseUrl: "http://localhost",
+							pactUrls: ["http://idontexist"],
+							publishVerificationResult: true,
+							providerVersion: "1.0.0"
+						});
+					}).to.not.throw(Error);
+				});
+			});
+		});
+
+		context("when requested to publish verification results to a Pact Broker", function () {
+			context("and does not specify provider version", function () {
+				it("should fail with an error", function () {
+					expect(function () {
+						verifierFactory({
+							providerBaseUrl: "http://localhost",
+							pactUrls: ["http://idontexist"],
+							publishVerificationResult: true
+						});
+					}).to.throw(Error);
+				});
+			});
+		});
+
+
+
 		context("when given the correct arguments", function () {
 			it("should return a Verifier object", function () {
 				var verifier = verifierFactory({

--- a/test/integration/provider.js
+++ b/test/integration/provider.js
@@ -6,33 +6,33 @@ var cors = require('cors'),
 var server = express();
 server.use(cors());
 server.use(bodyParser.json());
-server.use(bodyParser.urlencoded({extended: true}));
+server.use(bodyParser.urlencoded({ extended: true }));
 
 var stateData = "";
 
 server.get('/', function (req, res) {
-	res.json({greeting: 'Hello'});
+	res.json({ greeting: 'Hello' });
 });
 
 server.get('/fail', function (req, res) {
-	res.json({greeting: 'Oh noes!'});
+	res.json({ greeting: 'Oh noes!' });
 });
 
 server.get('/provider-states', function (req, res) {
-	res.json({me: ["There is a greeting"], anotherclient: ["There is a greeting"]});
+	res.json({ me: ["There is a greeting"], anotherclient: ["There is a greeting"] });
 });
 
 server.post('/provider-state', function (req, res) {
 	stateData = "State data!";
-	res.json({greeting: stateData});
+	res.json({ greeting: stateData });
 });
 
 server.get('/somestate', function (req, res) {
-	res.json({greeting: stateData});
+	res.json({ greeting: stateData });
 });
 
 server.post('/', function (req, res) {
-	res.json({greeting: "Hello " + req.body.name});
+	res.json({ greeting: "Hello " + req.body.name });
 });
 
 server.get('/contract/:name', function (req, res) {
@@ -67,6 +67,11 @@ var auth = function (req, res, next) {
 		return res.sendStatus(401);
 	}
 };
+
+// Verification result
+server.post('/pacts/provider/:provider/consumer/:consumer/pact-version/:version/verification-results', function (req, res) {
+	res.json({});
+});
 
 server.get('/pacts/provider/they/consumer/me/latest', auth, function (req, res) {
 	var obj = JSON.parse('{"consumer":{"name":"me"},"provider":{"name":"they"},"interactions":[{"description":"Provider state success","provider_state":"There is a greeting","request":{"method":"GET","path":"/somestate"},"response":{"status":200,"headers":{},"body":{"greeting":"State data!"}}}],"metadata":{"pactSpecificationVersion":"2.0.0"},"updatedAt":"2016-05-15T00:09:33+00:00","createdAt":"2016-05-15T00:09:06+00:00","_links":{"self":{"title":"Pact","name":"Pact between me (v1.0.0) and they","href":"http://pact.onegeek.com.au/pacts/provider/they/consumer/me/version/1.0.0"},"pb:consumer":{"title":"Consumer","name":"me","href":"http://pact.onegeek.com.au/pacticipants/me"},"pb:provider":{"title":"Provider","name":"they","href":"http://pact.onegeek.com.au/pacticipants/they"},"pb:latest-pact-version":{"title":"Pact","name":"Latest version of this pact","href":"http://pact.onegeek.com.au/pacts/provider/they/consumer/me/latest"},"pb:previous-distinct":{"title":"Pact","name":"Previous distinct version of this pact","href":"http://pact.onegeek.com.au/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct"},"pb:diff-previous-distinct":{"title":"Diff","name":"Diff with previous distinct version of this pact","href":"http://pact.onegeek.com.au/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct"},"pb:pact-webhooks":{"title":"Webhooks for the pact between me and they","href":"http://pact.onegeek.com.au/webhooks/provider/they/consumer/me"},"pb:tag-prod-version":{"title":"Tag this version as \'production\'","href":"http://pact.onegeek.com.au/pacticipants/me/versions/1.0.0/tags/prod"},"pb:tag-version":{"title":"Tag version","href":"http://pact.onegeek.com.au/pacticipants/me/versions/1.0.0/tags/{tag}"},"curies":[{"name":"pb","href":"http://pact.onegeek.com.au/doc/{rel}","templated":true}]}}');

--- a/test/integration/publish-verification-example-fail.json
+++ b/test/integration/publish-verification-example-fail.json
@@ -1,0 +1,83 @@
+{
+	"consumer": {
+		"name": "me"
+	},
+	"provider": {
+		"name": "they"
+	},
+	"interactions": [
+		{
+			"description": "Greeting",
+			"request": {
+				"method": "GET",
+				"path": "/"
+			},
+			"response": {
+				"status": 200,
+				"headers": {},
+				"body": {
+					"greeting": "Hello"
+				}
+			}
+		}
+	],
+	"metadata": {
+		"pactSpecificationVersion": "2.0.0"
+	},
+	"createdAt": "2017-05-08T22:56:48+00:00",
+	"_links": {
+		"self": {
+			"title": "Pact",
+			"name": "Pact between me (v1.0.0) and they",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/version/1.0.0"
+		},
+		"pb:consumer": {
+			"title": "Consumer",
+			"name": "me",
+			"href": "http://localhost:9123/pacticipants/me"
+		},
+		"pb:provider": {
+			"title": "Provider",
+			"name": "they",
+			"href": "http://localhost:9123/pacticipants/they"
+		},
+		"pb:latest-pact-version": {
+			"title": "Pact",
+			"name": "Latest version of this pact",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/latest"
+		},
+		"pb:previous-distinct": {
+			"title": "Pact",
+			"name": "Previous distinct version of this pact",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct"
+		},
+		"pb:diff-previous-distinct": {
+			"title": "Diff",
+			"name": "Diff with previous distinct version of this pact",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct"
+		},
+		"pb:pact-webhooks": {
+			"title": "Webhooks for the pact between me and they",
+			"href": "http://localhost:9123/webhooks/provider/they/consumer/me"
+		},
+		"pb:tag-prod-version": {
+			"title": "Tag this version as 'production'",
+			"href": "http://localhost:9123/pacticipants/me/versions/1.0.0/tags/prod"
+		},
+		"pb:tag-version": {
+			"title": "Tag version",
+			"href": "http://localhost:9123/pacticipants/me/versions/1.0.0/tags/{tag}"
+		},
+		"pb:publish-verification-results": {
+			"title": "Publish verification results",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/pact-version/404notfound/verification-results"
+		},
+		"curies": [
+			{
+				"name": "pb",
+				"href": "http://localhost:9123/doc/{rel}",
+				"templated": true
+			}
+		]
+	}
+}

--- a/test/integration/publish-verification-example-success.json
+++ b/test/integration/publish-verification-example-success.json
@@ -1,0 +1,83 @@
+{
+	"consumer": {
+		"name": "me"
+	},
+	"provider": {
+		"name": "they"
+	},
+	"interactions": [
+		{
+			"description": "Greeting",
+			"request": {
+				"method": "GET",
+				"path": "/"
+			},
+			"response": {
+				"status": 200,
+				"headers": {},
+				"body": {
+					"greeting": "Hello"
+				}
+			}
+		}
+	],
+	"metadata": {
+		"pactSpecificationVersion": "2.0.0"
+	},
+	"createdAt": "2017-05-08T22:56:48+00:00",
+	"_links": {
+		"self": {
+			"title": "Pact",
+			"name": "Pact between me (v1.0.0) and they",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/version/1.0.0"
+		},
+		"pb:consumer": {
+			"title": "Consumer",
+			"name": "me",
+			"href": "http://localhost:9123/pacticipants/me"
+		},
+		"pb:provider": {
+			"title": "Provider",
+			"name": "they",
+			"href": "http://localhost:9123/pacticipants/they"
+		},
+		"pb:latest-pact-version": {
+			"title": "Pact",
+			"name": "Latest version of this pact",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/latest"
+		},
+		"pb:previous-distinct": {
+			"title": "Pact",
+			"name": "Previous distinct version of this pact",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct"
+		},
+		"pb:diff-previous-distinct": {
+			"title": "Diff",
+			"name": "Diff with previous distinct version of this pact",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct"
+		},
+		"pb:pact-webhooks": {
+			"title": "Webhooks for the pact between me and they",
+			"href": "http://localhost:9123/webhooks/provider/they/consumer/me"
+		},
+		"pb:tag-prod-version": {
+			"title": "Tag this version as 'production'",
+			"href": "http://localhost:9123/pacticipants/me/versions/1.0.0/tags/prod"
+		},
+		"pb:tag-version": {
+			"title": "Tag version",
+			"href": "http://localhost:9123/pacticipants/me/versions/1.0.0/tags/{tag}"
+		},
+		"pb:publish-verification-results": {
+			"title": "Publish verification results",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/pact-version/618bea2e1221b48d59f4330e3788cdd8d196a8de/verification-results"
+		},
+		"curies": [
+			{
+				"name": "pb",
+				"href": "http://localhost:9123/doc/{rel}",
+				"templated": true
+			}
+		]
+	}
+}

--- a/test/verifier.integration.spec.js
+++ b/test/verifier.integration.spec.js
@@ -13,7 +13,7 @@ chai.use(chaiAsPromised);
 describe("Verifier Integration Spec", function () {
 
 	var server,
-		PORT = Math.floor(Math.random() * 999) + 9000,
+		PORT = 9123,
 		providerBaseUrl = 'http://localhost:' + PORT,
 		providerStatesUrl = providerBaseUrl + '/provider-states',
 		providerStatesSetupUrl = providerBaseUrl + '/provider-state/',
@@ -53,7 +53,7 @@ describe("Verifier Integration Spec", function () {
 			});
 		});
 
-    context("with POST data", function () {
+		context("with POST data", function () {
 			it("should return a successful promise", function () {
 				var verifier = verifierFactory({
 					providerBaseUrl: providerBaseUrl,
@@ -63,7 +63,7 @@ describe("Verifier Integration Spec", function () {
 			});
 		});
 
-    context("with POST data and regex validation", function () {
+		context("with POST data and regex validation", function () {
 			it("should return a successful promise", function () {
 				var verifier = verifierFactory({
 					providerBaseUrl: providerBaseUrl,
@@ -167,5 +167,34 @@ describe("Verifier Integration Spec", function () {
 				});
 			});
 		});
+	});
+
+	context("when publishing verification results to a Pact Broker", function () {
+		context("and there is a valid verification HAL link in the Pact file", function () {
+			it("should return a successful promise", function () {
+				var verifier = verifierFactory({
+					providerBaseUrl: providerBaseUrl,
+					pactUrls: [path.resolve(__dirname, "integration/publish-verification-example-success.json")],
+					providerStatesUrl: providerStatesUrl,
+					providerStatesSetupUrl: providerStatesSetupUrl,
+					publishVerificationResult: true,
+					providerVersion: "1.0.0"
+				});
+				return expect(verifier.verify()).to.eventually.be.fulfilled;
+			});
+		})
+		context("and there is an invalid verification HAL link in the Pact file", function () {
+			it("should fail with an error", function () {
+				var verifier = verifierFactory({
+					providerBaseUrl: providerBaseUrl,
+					pactUrls: [path.resolve(__dirname, "integration/publish-verification-example-fail.json")],
+					providerStatesUrl: providerStatesUrl,
+					providerStatesSetupUrl: providerStatesSetupUrl,
+					publishVerificationResult: true,
+					providerVersion: "1.0.0"
+				});
+				return expect(verifier.verify()).to.eventually.be.fulfilled;
+			});
+		})
 	});
 });


### PR DESCRIPTION
Adds support for a new feature of the broker - the ability to send provider verification results back to the Broker, allowing more intelligent CI practices.

The main use case this solves is allowing you (probably via a CI / CD processe) to detect Consumer changes that have not yet been verified by a provider. Publishing the status to the broker allows tooling to then query this status, and block a deployment if the contract has changed or has not been verified since last published.

See https://github.com/realestate-com-au/pact/blob/master/CHANGELOG.md#1110-8-may-2017 for more.

**Commit details**:
- Add flags to automatically publish verification results to
  Pact broker
- Had to hard code port in integration test as verifier reads
  broker URL dynamically from pact (see publish-verification-example-{success,fail}.json)
- Bump minimum requirement for pact-provider-verifier to 1.1.1