### PR TITLE
Fetch from broker: Allow verifier to fetch pacts from a Broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,18 @@ Read more about [Verify Pacts](https://github.com/realestate-com-au/pact/wiki/Ve
 ```js
 var pact = require('@pact-foundation/pact-node');
 var opts = {
-	providerBaseUrl: <String>,       // Running API provider host endpoint. Required.
-	pactUrls: <Array>,               // Array of local Pact file paths or Pact Broker URLs (http based). Required.
-	providerStatesUrl: <String>,     // URL to fetch the provider states for the given provider API. Optional.
-	providerStatesSetupUrl: <String>, // URL to send PUT requests to setup a given provider state. Optional.
-	pactBrokerUsername: <String>,    // Username for Pact Broker basic authentication. Optional
-	pactBrokerPassword: <String>,    // Password for Pact Broker basic authentication. Optional
+	providerBaseUrl: <String>,           // Running API provider host endpoint. Required.
+	pactBrokerUrl: <String>              // URL of the Pact Broker to retrieve pacts from. Required if not using pactUrls.
+	provider: <String>                   // Name of the Provider. Required.
+	tags: <Array>                        // Array of tags, used to filter pacts from the Broker. Optional.
+	pactUrls: <Array>,                   // Array of local Pact file paths or HTTP-based URLs (e.g. from a broker). Required if not using a Broker.
+	providerStatesUrl: <String>,         // URL to fetch the provider states for the given provider API. Optional.
+	providerStatesSetupUrl: <String>,    // URL to send PUT requests to setup a given provider state. Optional.
+	pactBrokerUsername: <String>,        // Username for Pact Broker basic authentication. Optional
+	pactBrokerPassword: <String>,        // Password for Pact Broker basic authentication. Optional
 	publishVerificationResult: <Boolean> // Publish verification result to Broker. Optional
-	providerVersion: <Boolean>       // Provider version, required to publish verification result to Broker. Optional otherwise.
-	timeout: <Number>                // The duration in ms we should wait to confirm verification process was successful. Defaults to 30000, Optional.
+	providerVersion: <Boolean>           // Provider version, required to publish verification result to Broker. Optional otherwise.
+	timeout: <Number>                    // The duration in ms we should wait to confirm verification process was successful. Defaults to 30000, Optional.
 };
 
 pact.verifyPacts(opts).then(function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pact-foundation/pact-node",
-	"version": "4.8.3",
+	"version": "4.9.0",
 	"description": "A wrapper for the Ruby version of Pact to work within Node",
 	"main": "./src/pact.js",
 	"os": [
@@ -37,39 +37,39 @@
 		"url": "https://github.com/pact-foundation/pact-node/issues"
 	},
 	"dependencies": {
-		"@pact-foundation/pact-mock-service": "1.x.x",
-		"@pact-foundation/pact-provider-verifier": "^1.1.1",
-		"bunyan": "^1.8.5",
+		"@pact-foundation/pact-mock-service": "~1.2.0",
+		"@pact-foundation/pact-provider-verifier": "~1.1.1",
+		"bunyan": "^1.8.10",
 		"bunyan-prettystream": "^0.1.3",
 		"check-types": "~7.1.5",
 		"commander": "^2.9.0",
 		"mkdirp": "^0.5.1",
-		"q": "^1.4.1",
-		"request": "^2.79.0",
+		"q": "^1.5.0",
+		"request": "^2.81.0",
 		"traverson": "^6.0.3",
 		"traverson-hal": "^6.0.0",
 		"traverson-promise": "0.0.8",
 		"underscore": "^1.8.3",
-		"unixify": "^0.2.1",
-		"url-join": "^1.1.0"
+		"unixify": "^1.0.0",
+		"url-join": "^2.0.1"
 	},
 	"bin": {
 		"pact": "./bin/pact-node"
 	},
 	"devDependencies": {
 		"basic-auth": "^1.1.0",
-		"body-parser": "^1.16.0",
+		"body-parser": "^1.17.1",
 		"chai": "^3.5.0",
 		"chai-as-promised": "^6.0.0",
-		"cors": "^2.8.1",
-		"cross-env": "^3.1.4",
-		"express": "^4.14.1",
+		"cors": "^2.8.3",
+		"cross-env": "^4.0.0",
+		"express": "^4.15.2",
 		"jscs": "3.0.7",
-		"mocha": "^3.2.0",
+		"mocha": "^3.3.0",
 		"nodemon": "^1.11.0",
 		"rewire": "^2.5.2",
-		"rimraf": "^2.5.4",
-		"sinon": "^1.17.7"
+		"rimraf": "^2.6.1",
+		"sinon": "~2.2.0"
 	},
 	"scripts": {
 		"clean": "rimraf logs/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pact-foundation/pact-node",
-	"version": "4.9.0",
+	"version": "4.8.3",
 	"description": "A wrapper for the Ruby version of Pact to work within Node",
 	"main": "./src/pact.js",
 	"os": [
@@ -37,36 +37,39 @@
 		"url": "https://github.com/pact-foundation/pact-node/issues"
 	},
 	"dependencies": {
-		"@pact-foundation/pact-mock-service": "~1.2.0",
-		"@pact-foundation/pact-provider-verifier": "~1.1.1",
-		"bunyan": "^1.8.10",
+		"@pact-foundation/pact-mock-service": "1.x.x",
+		"@pact-foundation/pact-provider-verifier": "^1.1.1",
+		"bunyan": "^1.8.5",
 		"bunyan-prettystream": "^0.1.3",
 		"check-types": "~7.1.5",
 		"commander": "^2.9.0",
 		"mkdirp": "^0.5.1",
-		"q": "^1.5.0",
-		"request": "^2.81.0",
+		"q": "^1.4.1",
+		"request": "^2.79.0",
+		"traverson": "^6.0.3",
+		"traverson-hal": "^6.0.0",
+		"traverson-promise": "0.0.8",
 		"underscore": "^1.8.3",
-		"unixify": "^1.0.0",
-		"url-join": "^2.0.1"
+		"unixify": "^0.2.1",
+		"url-join": "^1.1.0"
 	},
 	"bin": {
 		"pact": "./bin/pact-node"
 	},
 	"devDependencies": {
 		"basic-auth": "^1.1.0",
-		"body-parser": "^1.17.1",
+		"body-parser": "^1.16.0",
 		"chai": "^3.5.0",
 		"chai-as-promised": "^6.0.0",
-		"cors": "^2.8.3",
-		"cross-env": "^4.0.0",
-		"express": "^4.15.2",
+		"cors": "^2.8.1",
+		"cross-env": "^3.1.4",
+		"express": "^4.14.1",
 		"jscs": "3.0.7",
-		"mocha": "^3.3.0",
+		"mocha": "^3.2.0",
 		"nodemon": "^1.11.0",
 		"rewire": "^2.5.2",
-		"rimraf": "^2.6.1",
-		"sinon": "~2.2.0"
+		"rimraf": "^2.5.4",
+		"sinon": "^1.17.7"
 	},
 	"scripts": {
 		"clean": "rimraf logs/*",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"url": "https://github.com/pact-foundation/pact-node/issues"
 	},
 	"dependencies": {
-		"@pact-foundation/pact-mock-service": "~1.2.0",
+		"@pact-foundation/pact-mock-service": "2.0.1",
 		"@pact-foundation/pact-provider-verifier": "~1.1.1",
 		"bunyan": "^1.8.10",
 		"bunyan-prettystream": "^0.1.3",

--- a/src/broker.js
+++ b/src/broker.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var checkTypes = require('check-types'),
+	logger = require('./logger'),
+	traverson = require('traverson-promise'),
+	JsonHalAdapter = require('traverson-hal');
+
+// register the traverson-hal plug-in for media type 'application/hal+json'
+traverson.registerMediaType(JsonHalAdapter.mediaType, JsonHalAdapter);
+
+var pactURLPattern = "/pacts/provider/%s/latest",
+	pactURLPatternWithTag = "/pacts/provider/%s/latest/%s";
+
+// Constructor
+function Broker(brokerUrl, provider, tags, username, password) {
+	this._options = {};
+	this._options.brokerUrl = brokerUrl;
+	this._options.provider = provider;
+	this._options.tags = tags;
+	this._options.username = username;
+	this._options.password = password;
+}
+
+// Find all consumers
+Broker.prototype.findConsumers = function () {
+	logger.debug("Finding consumers")
+	return traverson
+		.from('https://test.pact.dius.com.au/pacts/provider/bobby/latest/sit4')
+		.withRequestOptions(this.getRequestOptions())
+		.jsonHal()
+		.follow('pacts')
+		.get()
+		.result;
+};
+
+Broker.prototype.getRequestOptions = function () {
+	if (this._options.username && this._options.password) {
+		return {
+			'auth': {
+				'user': this._options.username,
+				'password': this._options.password
+			}
+		}
+	}
+	return {}
+}
+
+
+
+// Creates a new instance of the Pact Broker HAL client with the specified option
+module.exports = function (options) {
+	options = options || {};
+
+	// defaults
+	options.brokerUrl = options.brokerUrl || '';
+	options.provider = options.provider || '';
+	options.username = options.username || '';
+	options.password = options.password || '';
+	options.tags = options.tags || [];
+
+	checkTypes.assert.nonEmptyString(options.brokerUrl);
+	checkTypes.assert.nonEmptyString(options.provider);
+
+	if (options.tags) {
+		checkTypes.assert.array.of.string(options.tags);
+	}
+
+	if (options.username) {
+		checkTypes.assert.string(options.username);
+	}
+
+	if (options.password) {
+		checkTypes.assert.string(options.password);
+	}
+
+	return new Broker(options.provider, options.brokerUrl, options.tags, options.username, options.password);
+};

--- a/src/broker.js
+++ b/src/broker.js
@@ -19,16 +19,18 @@ function Broker(provider, brokerUrl, tags, username, password) {
 	this._options.tags = tags;
 	this._options.username = username;
 	this._options.password = password;
+	this._requestOptions = (this._options.username && this._options.password) ? { 'auth': { 'user': this._options.username, 'password': this._options.password } } : {};
 };
 
 // Find Pacts returns the raw response from the HAL resource
 Broker.prototype.findPacts = function (tag) {
-	logger.debug("finding pacts: ", tag)
-	var linkName = (tag) ? 'pb:latest-provider-pacts-with-tag' : 'pb:latest-provider-pacts';
+	logger.debug("finding pacts for Provider:", this._options.provider, ", Tag:", tag)
+
+	var linkName = tag ? 'pb:latest-provider-pacts-with-tag' : 'pb:latest-provider-pacts';
 	return traverson
 		.from(this._options.brokerUrl)
 		.withTemplateParameters({ provider: this._options.provider, tag: tag })
-		.withRequestOptions(this.getRequestOptions())
+		.withRequestOptions(this._requestOptions)
 		.jsonHal()
 		.follow(linkName)
 		.getResource()
@@ -38,8 +40,7 @@ Broker.prototype.findPacts = function (tag) {
 // Find all consumers collates all of the pacts for a given provider (with optional tags)
 // and removes duplicates (e.g. where multiple tags on the same pact)
 Broker.prototype.findConsumers = function () {
-	logger.debug("Finding consumers")
-
+	logger.debug("Finding consumers");
 	var promises = (this._options.tags.length > 0) ? this._options.tags.map(this.findPacts, this) : [this.findPacts()];
 
 	return Promise
@@ -47,27 +48,19 @@ Broker.prototype.findConsumers = function () {
 		.then(function (values) {
 			var pactUrls = {};
 			values.forEach(function (response) {
-				response._links.pacts.forEach(function (pact) {
-					pactUrls[pact.title] = pact.href;
-				})
+				if (response && response._links && response._links.pacts) {
+					response._links.pacts.forEach(function (pact) {
+						pactUrls[pact.title] = pact.href;
+					});
+				}
 			});
 			return Object.keys(pactUrls).reduce(function (pacts, key) {
-				pacts.push(pactUrls[key])
-				return pacts
-			}, [])
-		})
-};
-
-Broker.prototype.getRequestOptions = function () {
-	if (this._options.username && this._options.password) {
-		return {
-			'auth': {
-				'user': this._options.username,
-				'password': this._options.password
-			}
-		}
-	}
-	return {}
+				pacts.push(pactUrls[key]);
+				return pacts;
+			}, []);
+		}).catch(function (e) {
+			throw new Error("Unable to find pacts for given provider: '" + this._options.provider + "' and tags: '" + this._options.tags + "'");
+		}.bind(this));
 };
 
 // Creates a new instance of the Pact Broker HAL client with the specified option

--- a/src/broker.js
+++ b/src/broker.js
@@ -12,7 +12,7 @@ var pactURLPattern = "/pacts/provider/%s/latest",
 	pactURLPatternWithTag = "/pacts/provider/%s/latest/%s";
 
 // Constructor
-function Broker(brokerUrl, provider, tags, username, password) {
+function Broker(provider, brokerUrl, tags, username, password) {
 	this._options = {};
 	this._options.brokerUrl = brokerUrl;
 	this._options.provider = provider;
@@ -24,13 +24,25 @@ function Broker(brokerUrl, provider, tags, username, password) {
 // Find all consumers
 Broker.prototype.findConsumers = function () {
 	logger.debug("Finding consumers")
-	return traverson
-		.from('https://test.pact.dius.com.au/pacts/provider/bobby/latest/sit4')
+	var linkName = if (this._options.tags.length > 0) 'pb:latest-provider-pacts-with-tag' ? 'pb:latest-provider-pacts';
+	var pactUrls = {};
+
+	//
+	// var promises = tags.map(function () { /* create promise */ }
+	// Promise.all(promises).then(function (values) { /* collate all pacts and remove dupes */})
+
+	traverson
+		.from(this._options.brokerUrl)
+		// .from(this._options.brokerUrl + '/pacts/provider/' + this._options.provider + '/latest/' + tag)
+		.withTemplateParameters({provider: this._options.provider, tag: tag})
 		.withRequestOptions(this.getRequestOptions())
 		.jsonHal()
-		.follow('pacts')
-		.get()
-		.result;
+		.follow(linkName)
+		.getResource()
+		.result
+		.then(function (response) {
+			return response._links.pacts
+		});
 };
 
 Broker.prototype.getRequestOptions = function () {

--- a/src/broker.js
+++ b/src/broker.js
@@ -19,7 +19,7 @@ function Broker(provider, brokerUrl, tags, username, password) {
 	this._options.tags = tags;
 	this._options.username = username;
 	this._options.password = password;
-}
+};
 
 // Find Pacts returns the raw response from the HAL resource
 Broker.prototype.findPacts = function (tag) {
@@ -33,7 +33,7 @@ Broker.prototype.findPacts = function (tag) {
 		.follow(linkName)
 		.getResource()
 		.result
-}
+};
 
 // Find all consumers collates all of the pacts for a given provider (with optional tags)
 // and removes duplicates (e.g. where multiple tags on the same pact)
@@ -68,9 +68,7 @@ Broker.prototype.getRequestOptions = function () {
 		}
 	}
 	return {}
-}
-
-
+};
 
 // Creates a new instance of the Pact Broker HAL client with the specified option
 module.exports = function (options) {

--- a/src/broker.spec.js
+++ b/src/broker.spec.js
@@ -1,12 +1,25 @@
 var brokerFactory = require('./broker'),
 	expect = require('chai').expect,
 	chai = require("chai"),
-	// brokerMock = require('../test/integration/brokerMock.js'),
+	brokerMock = require('../test/integration/brokerMock.js'),
 	chaiAsPromised = require("chai-as-promised");
 
 chai.use(chaiAsPromised);
 
 describe("Broker Spec", function () {
+
+	var PORT = 9124,
+		pactBrokerBaseUrl = 'http://localhost:' + PORT,
+		authenticatedPactBrokerBaseUrl = 'http://localhost:' + PORT + '/auth';
+
+	before(function (done) {
+		brokerMock.listen(PORT, function () {
+			console.log('Broker (Mock) running on port: ' + PORT);
+			done();
+		});
+	});
+
+
 	describe("Broker", function () {
 		context("when not given a Pact Broker URL", function () {
 			it("should fail with an error", function () {
@@ -68,44 +81,33 @@ describe("Broker Spec", function () {
 	});
 
 	describe("Find Consumers", function () {
-		context.only("when given the provider name and tags", function (done) {
+		context("when given the provider name and tags", function (done) {
 			it("should find pacts from all known consumers of the provider given any of the tags", function (done) {
 				var broker = brokerFactory({
-					brokerUrl: "https://test.pact.dius.com.au",
-					provider: "bobby",
+					brokerUrl: pactBrokerBaseUrl,
+					provider: "they",
+					username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
+					password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
+					tags: ['prod']
+				});
+				var promise = broker.findConsumers()
+
+				expect(promise).to.eventually.have.lengthOf(2).notify(done)
+			});
+		});
+
+		context("when given the provider name without tags", function () {
+			it("should find pacts from all known consumers of the provider", function (done) {
+				var broker = brokerFactory({
+					brokerUrl: pactBrokerBaseUrl,
+					provider: "they",
 					username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
 					password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"
 				});
-				broker.findConsumers().then(function (pacts) {
-					console.log(pacts)
-					done()
-				})
-				expect(broker.findConsumers()).to.eventually.be.rejectedWith(Error).then(done);
-				// var traverson = require('traverson-promise'),
-				// 	JsonHalAdapter = require('traverson-hal');
+				var promise = broker.findConsumers()
 
-				// // register the traverson-hal plug-in for media type 'application/hal+json'
-				// traverson.registerMediaType(JsonHalAdapter.mediaType, JsonHalAdapter);
-				// traverson
-				// 	.from('http://haltalk.herokuapp.com/')
-				// 	.jsonHal()
-				// 	.withTemplateParameters({name: 'traverson'})
-				// 	.follow('ht:me', 'ht:posts')
-				// 	.getResource(function(error, document) {
-				// 	if (error) {
-				// 		console.error('No luck :-)')
-				// 	} else {
-				// 		console.log(JSON.stringify(document))
-				// 	}
-				// 	done()
-				// });
+				expect(promise).to.eventually.have.lengthOf(2).notify(done)
 			});
 		});
-
-		context("when given ", function () {
-			it("should find pacts from all known consumers of the provider", function () {
-			});
-		});
-
 	});
 });

--- a/src/broker.spec.js
+++ b/src/broker.spec.js
@@ -7,7 +7,6 @@ var brokerFactory = require('./broker'),
 chai.use(chaiAsPromised);
 
 describe("Broker Spec", function () {
-
 	var PORT = 9124,
 		pactBrokerBaseUrl = 'http://localhost:' + PORT,
 		authenticatedPactBrokerBaseUrl = 'http://localhost:' + PORT + '/auth';
@@ -18,7 +17,6 @@ describe("Broker Spec", function () {
 			done();
 		});
 	});
-
 
 	describe("Broker", function () {
 		context("when not given a Pact Broker URL", function () {

--- a/src/broker.spec.js
+++ b/src/broker.spec.js
@@ -1,0 +1,93 @@
+var brokerFactory = require('./broker'),
+	expect = require('chai').expect,
+	chai = require("chai"),
+	// brokerMock = require('../test/integration/brokerMock.js'),
+	chaiAsPromised = require("chai-as-promised");
+
+chai.use(chaiAsPromised);
+
+describe("Broker Spec", function () {
+	describe("Broker", function () {
+		context("when not given a Pact Broker URL", function () {
+			it("should fail with an error", function () {
+				expect(function () {
+					brokerFactory({
+						provider: "foobar"
+					});
+				}).to.throw(Error);
+			});
+		});
+		context("when not given a Provider name", function () {
+			it("should fail with an error", function () {
+				expect(function () {
+					brokerFactory({
+						brokerUrl: "http://test.pact.dius.com.au",
+					});
+				}).to.throw(Error);
+			});
+		});
+		context("when given a valid Pact Broker URL", function () {
+			it("should return a Broker object", function () {
+				expect(function () {
+					brokerFactory({
+						brokerUrl: "http://test.pact.dius.com.au",
+						provider: "foobar"
+					});
+				}).to.not.throw(Error);
+			});
+		});
+	});
+
+	describe("Get Request Options", function () {
+		context("when username and password are provided", function () {
+			it("should return a hash containing auth details", function () {
+				var broker = brokerFactory({
+					brokerUrl: "http://test.pact.dius.com.au",
+					provider: "foobar",
+					username: "username",
+					password: "password"
+				});
+				expect(broker.getRequestOptions()).to.eql({
+					'auth': {
+						'user': "username",
+						'password': "password"
+					}
+				})
+			});
+		});
+		context("when either a username or password are not provided", function () {
+			it("should return an empty object", function () {
+				var broker = brokerFactory({
+					brokerUrl: "http://test.pact.dius.com.au",
+					provider: "foobar",
+					password: "password"
+				});
+				expect(broker.getRequestOptions()).to.eql({})
+			});
+		});
+	});
+
+	describe("Find Consumers", function () {
+		context.only("when given the provider name and tags", function (done) {
+			it("should find pacts from all known consumers of the provider given any of the tags", function (done) {
+				var broker = brokerFactory({
+					brokerUrl: "http://test.pact.dius.com.au",
+					provider: "bobby",
+					username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
+					password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"
+				});
+				broker.findConsumers().then(function (response) {
+					console.log(response)
+					done()
+				})
+				// expect(broker.findConsumers()).to.eventually.be.rejectedWith(Error).then(done);
+			});
+		});
+
+		context("when given ", function () {
+			it("should find pacts from all known consumers of the provider", function () {
+			});
+		});
+
+	});
+});

--- a/src/broker.spec.js
+++ b/src/broker.spec.js
@@ -21,7 +21,7 @@ describe("Broker Spec", function () {
 			it("should fail with an error", function () {
 				expect(function () {
 					brokerFactory({
-						brokerUrl: "http://test.pact.dius.com.au",
+						brokerUrl: "http://test.pact.dius.com.au"
 					});
 				}).to.throw(Error);
 			});
@@ -71,16 +71,34 @@ describe("Broker Spec", function () {
 		context.only("when given the provider name and tags", function (done) {
 			it("should find pacts from all known consumers of the provider given any of the tags", function (done) {
 				var broker = brokerFactory({
-					brokerUrl: "http://test.pact.dius.com.au",
+					brokerUrl: "https://test.pact.dius.com.au",
 					provider: "bobby",
 					username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
 					password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"
 				});
-				broker.findConsumers().then(function (response) {
-					console.log(response)
+				broker.findConsumers().then(function (pacts) {
+					console.log(pacts)
 					done()
 				})
-				// expect(broker.findConsumers()).to.eventually.be.rejectedWith(Error).then(done);
+				expect(broker.findConsumers()).to.eventually.be.rejectedWith(Error).then(done);
+				// var traverson = require('traverson-promise'),
+				// 	JsonHalAdapter = require('traverson-hal');
+
+				// // register the traverson-hal plug-in for media type 'application/hal+json'
+				// traverson.registerMediaType(JsonHalAdapter.mediaType, JsonHalAdapter);
+				// traverson
+				// 	.from('http://haltalk.herokuapp.com/')
+				// 	.jsonHal()
+				// 	.withTemplateParameters({name: 'traverson'})
+				// 	.follow('ht:me', 'ht:posts')
+				// 	.getResource(function(error, document) {
+				// 	if (error) {
+				// 		console.error('No luck :-)')
+				// 	} else {
+				// 		console.log(JSON.stringify(document))
+				// 	}
+				// 	done()
+				// });
 			});
 		});
 

--- a/src/broker.spec.js
+++ b/src/broker.spec.js
@@ -1,6 +1,7 @@
 var brokerFactory = require('./broker'),
 	expect = require('chai').expect,
 	chai = require("chai"),
+	logger = require('./logger'),
 	brokerMock = require('../test/integration/brokerMock.js'),
 	chaiAsPromised = require("chai-as-promised");
 
@@ -13,7 +14,7 @@ describe("Broker Spec", function () {
 
 	before(function (done) {
 		brokerMock.listen(PORT, function () {
-			console.log('Broker (Mock) running on port: ' + PORT);
+			logger.debug('Broker (Mock) running on port: ' + PORT);
 			done();
 		});
 	});
@@ -49,62 +50,66 @@ describe("Broker Spec", function () {
 		});
 	});
 
-	describe("Get Request Options", function () {
-		context("when username and password are provided", function () {
-			it("should return a hash containing auth details", function () {
-				var broker = brokerFactory({
-					brokerUrl: "http://test.pact.dius.com.au",
-					provider: "foobar",
-					username: "username",
-					password: "password"
-				});
-				expect(broker.getRequestOptions()).to.eql({
-					'auth': {
-						'user': "username",
-						'password': "password"
-					}
-				})
-			});
-		});
-		context("when either a username or password are not provided", function () {
-			it("should return an empty object", function () {
-				var broker = brokerFactory({
-					brokerUrl: "http://test.pact.dius.com.au",
-					provider: "foobar",
-					password: "password"
-				});
-				expect(broker.getRequestOptions()).to.eql({})
-			});
-		});
-	});
-
 	describe("Find Consumers", function () {
-		context("when given the provider name and tags", function (done) {
-			it("should find pacts from all known consumers of the provider given any of the tags", function (done) {
-				var broker = brokerFactory({
-					brokerUrl: pactBrokerBaseUrl,
-					provider: "they",
-					username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
-					password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
-					tags: ['prod']
-				});
-				var promise = broker.findConsumers()
+		context("when provider 'notfound' does not exist", function () {
+			context("and given the provider name 'notfound'", function () {
+				it("should fail with an Error", function (done) {
+					var broker = brokerFactory({
+						brokerUrl: pactBrokerBaseUrl,
+						provider: "notfound",
+						username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
+						password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"
+					});
+					var promise = broker.findConsumers();
 
-				expect(promise).to.eventually.have.lengthOf(2).notify(done)
+					expect(promise).to.be.rejectedWith(Error).notify(done);
+				});
+			});
+		});
+		context("when no pacts exist for provider 'nolinks'", function () {
+			context("and given the provider name", function () {
+				it("should return an empty array of pact links", function (done) {
+					var broker = brokerFactory({
+						brokerUrl: pactBrokerBaseUrl,
+						provider: "nolinks",
+						username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
+						password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"
+					});
+					var promise = broker.findConsumers();
+
+					expect(promise).to.eventually.eql([]).notify(done);
+				});
 			});
 		});
 
-		context("when given the provider name without tags", function () {
-			it("should find pacts from all known consumers of the provider", function (done) {
-				var broker = brokerFactory({
-					brokerUrl: pactBrokerBaseUrl,
-					provider: "they",
-					username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
-					password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"
-				});
-				var promise = broker.findConsumers()
+		context("When pacts exist for provder 'they'", function (done) {
+			context("and given the provider name and tags", function (done) {
+				it("should find pacts from all known consumers of the provider given any of the tags", function (done) {
+					var broker = brokerFactory({
+						brokerUrl: pactBrokerBaseUrl,
+						provider: "they",
+						username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
+						password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1",
+						tags: ['prod']
+					});
+					var promise = broker.findConsumers();
 
-				expect(promise).to.eventually.have.lengthOf(2).notify(done)
+					expect(promise).to.eventually.have.lengthOf(2).notify(done);
+				});
+			});
+
+			context("and given the provider name without tags", function () {
+				it("should find pacts from all known consumers of the provider", function (done) {
+					var broker = brokerFactory({
+						brokerUrl: pactBrokerBaseUrl,
+						provider: "they",
+						username: "dXfltyFMgNOFZAxr8io9wJ37iUpY42M",
+						password: "O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1"
+					});
+					var promise = broker.findConsumers();
+
+					expect(promise).to.eventually.have.lengthOf(2).notify(done);
+				});
 			});
 		});
 	});

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -165,9 +165,7 @@ module.exports = function (options) {
 
 	if (options.pactUrls && !checkTypes.emptyArray(options.pactUrls)) {
 		checkTypes.assert.array.of.string(options.pactUrls);
-		retrievePactsPromise = new Promise(function (resolve) {
-			resolve(options.pactUrls);
-		});
+		retrievePactsPromise = Promise.resolve(options.pactUrls);
 	} else {
 		// If no pactUrls provided, we must fetch them from the broker!
 		var broker = require('./broker')({
@@ -177,11 +175,7 @@ module.exports = function (options) {
 			password: options.pactBrokerPassword,
 			tags: options.tags
 		});
-		retrievePactsPromise = broker
-			.findConsumers()
-			.then(function (pactUrls) {
-				return pactUrls
-			});
+		retrievePactsPromise = broker.findConsumers()
 	}
 	if (options.tags) {
 		checkTypes.assert.array.of.string(options.tags);

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -121,7 +121,7 @@ module.exports = function (options) {
 		.value();
 
 	checkTypes.assert.nonEmptyString(options.providerBaseUrl, 'Must provide the --provider-base-url argument');
-	checkTypes.assert.not.emptyArray(options.pactUrls, 'Must provide the --pact-urls argument');
+	checkTypes.assert.not.emptyArray(options.pactUrls, 'Must provide the --pact-urls argument if no broker provider');
 
 	if (options.providerStatesSetupUrl) {
 		checkTypes.assert.string(options.providerStatesSetupUrl);

--- a/src/verifier.spec.js
+++ b/src/verifier.spec.js
@@ -12,6 +12,40 @@ chai.use(chaiAsPromised);
 
 describe("Verifier Spec", function () {
 	describe("Verifier", function () {
+		context("when automatically finding pacts from a broker", function () {
+			context("when not given --pact-urls and only --provider", function () {
+				it("should fail with an error", function () {
+					expect(function () {
+						verifierFactory({
+							providerBaseUrl: "http://localhost",
+							provider: "someprovider"
+						});
+					}).to.throw(Error);
+				});
+			});
+			context("when not given --pact-urls and only --pact-broker-url", function () {
+				it("should fail with an error", function () {
+					expect(function () {
+						verifierFactory({
+							providerBaseUrl: "http://localhost",
+							pactBrokerUrl: "http://foo.com"
+						});
+					}).to.throw(Error);
+				});
+			});
+			context("when given valid arguments", function () {
+				it("should return a Verifier object", function () {
+					var verifier = verifierFactory({
+						providerBaseUrl: "http://localhost",
+						pactBrokerUrl: "http://foo.com",
+						provider: "someprovider"
+					});
+
+					expect(verifier).to.be.a('object');
+					expect(verifier).to.respondTo('verify');
+				});
+			});
+		})
 		context("when not given --pact-urls or --provider-base-url", function () {
 			it("should fail with an error", function () {
 				expect(function () {
@@ -104,8 +138,6 @@ describe("Verifier Spec", function () {
 				});
 			});
 		});
-
-
 
 		context("when given the correct arguments", function () {
 			it("should return a Verifier object", function () {

--- a/test/integration/brokerMock.js
+++ b/test/integration/brokerMock.js
@@ -65,15 +65,27 @@ server.get('/', function (req, res) {
 	res.json(obj);
 })
 
-// Get pacts by Provider and TAG
+// Get pacts by Provider 'notfound'
+server.get('/pacts/provider/notfound/latest', function (req, res) {
+	res.status(404).end();
+});
+
+// Get pacts by Provider 'nolinks'
+server.get('/pacts/provider/nolinks/latest', function (req, res) {
+	// var obj = JSON.parse('{ "_links": { "self": { "href": "' + BROKER_HOST + '/pacts/provider/nolinks/latest/sit4", "title": "Latest pact versions for the provider nolinks with tag \'sit4\'" }}}');
+	var obj = JSON.parse('{ "_links": { "self": { "href": "' + BROKER_HOST + '/pacts/provider/nolinks/latest/sit4", "title": "Latest pact versions for the provider nolinks with tag \'sit4\'" }, "provider": { "href": "' + BROKER_HOST + '/pacticipants/nolinks", "title": "bobby" }, "pacts": [] } }');
+	res.json(obj);
+});
+
+// Get pacts by Provider (all)
 server.get('/pacts/provider/:provider/latest', function (req, res) {
 	var obj = JSON.parse('{ "_links": { "self": { "href": "' + BROKER_HOST + '/pacts/provider/bobby/latest/sit4", "title": "Latest pact versions for the provider bobby with tag \'sit4\'" }, "provider": { "href": "' + BROKER_HOST + '/pacticipants/bobby", "title": "bobby" }, "pacts": [ { "href": "' + BROKER_HOST + '/pacts/provider/bobby/consumer/billy/version/1.0.0", "title": "Pact between billy (v1.0.0) and bobby", "name": "billy" }, { "href": "' + BROKER_HOST + '/pacts/provider/bobby/consumer/someotherguy/version/1.0.0", "title": "Pact between someotherguy (v1.0.0) and bobby", "name": "someotherguy" } ] } }');
 	res.json(obj);
 });
 
-// Get pacts by Provider
+// Get pacts by Provider and Tag
 server.get('/pacts/provider/:provider/latest/:tag', function (req, res) {
-	var obj = JSON.parse('{ "_links": { "self": { "href": "https://test.pact.dius.com.au/pacts/provider/bobby/latest", "title": "Latest pact versions for the provider bobby" }, "provider": { "href": "https://test.pact.dius.com.au/pacticipants/bobby", "title": "bobby" }, "pacts": [ { "href": "https://test.pact.dius.com.au/pacts/provider/bobby/consumer/billy/version/1.0.0", "title": "Pact between billy (v1.0.0) and bobby", "name": "billy" }, { "href": "https://test.pact.dius.com.au/pacts/provider/bobby/consumer/someotherguy/version/1.0.0", "title": "Pact between someotherguy (v1.0.0) and bobby", "name": "someotherguy" } ] } }');
+	var obj = JSON.parse('{ "_links": { "self": { "href": "https://test.pact.dius.com.au/pacts/provider/notfound/latest", "title": "Latest pact versions for the provider bobby" }, "provider": { "href": "https://test.pact.dius.com.au/pacticipants/bobby", "title": "bobby" }, "pacts": [ { "href": "https://test.pact.dius.com.au/pacts/provider/bobby/consumer/billy/version/1.0.0", "title": "Pact between billy (v1.0.0) and bobby", "name": "billy" }, { "href": "https://test.pact.dius.com.au/pacts/provider/bobby/consumer/someotherguy/version/1.0.0", "title": "Pact between someotherguy (v1.0.0) and bobby", "name": "someotherguy" } ] } }');
 	res.json(obj);
 })
 

--- a/test/integration/brokerMock.js
+++ b/test/integration/brokerMock.js
@@ -7,14 +7,16 @@ var cors = require('cors'),
 
 server.use(cors());
 server.use(bodyParser.json());
-server.use(bodyParser.urlencoded({extended: true}));
+server.use(bodyParser.urlencoded({ extended: true }));
+
+BROKER_HOST = 'http://localhost:9124';
 
 var pactFunction = function (req, res) {
 	if (
 		// 1. Is there a body?
-	_.isEmpty(req.body) ||
-	// 2. Is there a consumer, provider and version in the request?
-	_.isEmpty(req.params.consumer) || _.isEmpty(req.params.provider) || _.isEmpty(req.params.version)
+		_.isEmpty(req.body) ||
+		// 2. Is there a consumer, provider and version in the request?
+		_.isEmpty(req.params.consumer) || _.isEmpty(req.params.provider) || _.isEmpty(req.params.version)
 	) {
 		return res.sendStatus(400);
 	}
@@ -44,7 +46,7 @@ server.get('/somebrokenpact', function (req, res) {
 });
 
 server.get('/somepact', function (req, res) {
-	res.json({'consumer': {'name': 'anotherclient'}, 'provider': {'name': 'they'}});
+	res.json({ 'consumer': { 'name': 'anotherclient' }, 'provider': { 'name': 'they' } });
 });
 
 // Pretend to be a Pact Broker (https://github.com/bethesque/pact_broker) for integration tests
@@ -56,5 +58,33 @@ server.put('/auth/pacts/provider/:provider/consumer/:consumer/version/:version',
 // Tagging
 server.put('/pacticipants/:consumer/versions/:version/tags/:tag', tagPactFunction);
 server.put('/auth/pacticipants/:consumer/versions/:version/tags/:tag', tagPactFunction);
+
+// Get root HAL links
+server.get('/', function (req, res) {
+	var obj = JSON.parse('{"_links": { "self": { "href": "' + BROKER_HOST + '", "title": "Index", "templated": false }, "pb:publish-pact": { "href": "' + BROKER_HOST + '/pacts/provider/{provider}/consumer/{consumer}/version/{consumerApplicationVersion}", "title": "Publish a pact", "templated": true }, "pb:latest-pact-versions": { "href": "' + BROKER_HOST + '/pacts/latest", "title": "Latest pact versions", "templated": false }, "pb:pacticipants": { "href": "' + BROKER_HOST + '/pacticipants", "title": "Pacticipants", "templated": false }, "pb:latest-provider-pacts": { "href": "' + BROKER_HOST + '/pacts/provider/{provider}/latest", "title": "Latest pacts by provider", "templated": true }, "pb:latest-provider-pacts-with-tag": { "href": "' + BROKER_HOST + '/pacts/provider/{provider}/latest/{tag}", "title": "Latest pacts by provider with a specified tag", "templated": true }, "pb:webhooks": { "href": "' + BROKER_HOST + '/webhooks", "title": "Webhooks", "templated": false }, "curies": [ { "name": "pb", "href": "' + BROKER_HOST + '/doc/{rel}", "templated": true } ] }}');
+	res.json(obj);
+})
+
+// Get pacts by Provider and TAG
+server.get('/pacts/provider/:provider/latest', function (req, res) {
+	var obj = JSON.parse('{ "_links": { "self": { "href": "' + BROKER_HOST + '/pacts/provider/bobby/latest/sit4", "title": "Latest pact versions for the provider bobby with tag \'sit4\'" }, "provider": { "href": "' + BROKER_HOST + '/pacticipants/bobby", "title": "bobby" }, "pacts": [ { "href": "' + BROKER_HOST + '/pacts/provider/bobby/consumer/billy/version/1.0.0", "title": "Pact between billy (v1.0.0) and bobby", "name": "billy" }, { "href": "' + BROKER_HOST + '/pacts/provider/bobby/consumer/someotherguy/version/1.0.0", "title": "Pact between someotherguy (v1.0.0) and bobby", "name": "someotherguy" } ] } }');
+	res.json(obj);
+});
+
+// Get pacts by Provider
+server.get('/pacts/provider/:provider/latest/:tag', function (req, res) {
+	var obj = JSON.parse('{ "_links": { "self": { "href": "https://test.pact.dius.com.au/pacts/provider/bobby/latest", "title": "Latest pact versions for the provider bobby" }, "provider": { "href": "https://test.pact.dius.com.au/pacticipants/bobby", "title": "bobby" }, "pacts": [ { "href": "https://test.pact.dius.com.au/pacts/provider/bobby/consumer/billy/version/1.0.0", "title": "Pact between billy (v1.0.0) and bobby", "name": "billy" }, { "href": "https://test.pact.dius.com.au/pacts/provider/bobby/consumer/someotherguy/version/1.0.0", "title": "Pact between someotherguy (v1.0.0) and bobby", "name": "someotherguy" } ] } }');
+	res.json(obj);
+})
+
+server.get('/noauth/pacts/provider/they/consumer/me/latest', function (req, res) {
+	var obj = JSON.parse('{"consumer":{"name":"me"},"provider":{"name":"they"},"interactions":[{"description":"Provider state success","provider_state":"There is a greeting","request":{"method":"GET","path":"/somestate"},"response":{"status":200,"headers":{},"body":{"greeting":"State data!"}}}],"metadata":{"pactSpecificationVersion":"2.0.0"},"updatedAt":"2016-05-15T00:09:33+00:00","createdAt":"2016-05-15T00:09:06+00:00","_links":{"self":{"title":"Pact","name":"Pact between me (v1.0.0) and they","href":"' + BROKER_HOST + '/pacts/provider/they/consumer/me/version/1.0.0"},"pb:consumer":{"title":"Consumer","name":"me","href":"' + BROKER_HOST + '/pacticipants/me"},"pb:provider":{"title":"Provider","name":"they","href":"' + BROKER_HOST + '/pacticipants/they"},"pb:latest-pact-version":{"title":"Pact","name":"Latest version of this pact","href":"' + BROKER_HOST + '/pacts/provider/they/consumer/me/latest"},"pb:previous-distinct":{"title":"Pact","name":"Previous distinct version of this pact","href":"' + BROKER_HOST + '/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct"},"pb:diff-previous-distinct":{"title":"Diff","name":"Diff with previous distinct version of this pact","href":"' + BROKER_HOST + '/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct"},"pb:pact-webhooks":{"title":"Webhooks for the pact between me and they","href":"' + BROKER_HOST + '/webhooks/provider/they/consumer/me"},"pb:tag-prod-version":{"title":"Tag this version as \'production\'","href":"' + BROKER_HOST + '/pacticipants/me/versions/1.0.0/tags/prod"},"pb:tag-version":{"title":"Tag version","href":"' + BROKER_HOST + '/pacticipants/me/versions/1.0.0/tags/{tag}"},"curies":[{"name":"pb","href":"' + BROKER_HOST + '/doc/{rel}","templated":true}]}}');
+	res.json(obj);
+});
+
+server.get('/noauth/pacts/provider/they/consumer/anotherclient/latest', function (req, res) {
+	var obj = JSON.parse('{"consumer":{"name":"anotherclient"},"provider":{"name":"they"},"interactions":[{"description":"Provider state success","provider_state":"There is a greeting","request":{"method":"GET","path":"/somestate"},"response":{"status":200,"headers":{},"body":{"greeting":"State data!"}}}],"metadata":{"pactSpecificationVersion":"2.0.0"},"updatedAt":"2016-05-15T00:09:33+00:00","createdAt":"2016-05-15T00:09:06+00:00","_links":{"self":{"title":"Pact","name":"Pact between me (v1.0.0) and they","href":"' + BROKER_HOST + '/pacts/provider/they/consumer/me/version/1.0.0"},"pb:consumer":{"title":"Consumer","name":"anotherclient","href":"' + BROKER_HOST + '/pacticipants/me"},"pb:provider":{"title":"Provider","name":"they","href":"' + BROKER_HOST + '/pacticipants/they"},"pb:latest-pact-version":{"title":"Pact","name":"Latest version of this pact","href":"' + BROKER_HOST + '/pacts/provider/they/consumer/me/latest"},"pb:previous-distinct":{"title":"Pact","name":"Previous distinct version of this pact","href":"' + BROKER_HOST + '/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct"},"pb:diff-previous-distinct":{"title":"Diff","name":"Diff with previous distinct version of this pact","href":"' + BROKER_HOST + '/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct"},"pb:pact-webhooks":{"title":"Webhooks for the pact between me and they","href":"' + BROKER_HOST + '/webhooks/provider/they/consumer/me"},"pb:tag-prod-version":{"title":"Tag this version as \'production\'","href":"' + BROKER_HOST + '/pacticipants/me/versions/1.0.0/tags/prod"},"pb:tag-version":{"title":"Tag version","href":"' + BROKER_HOST + '/pacticipants/me/versions/1.0.0/tags/{tag}"},"curies":[{"name":"pb","href":"' + BROKER_HOST + '/doc/{rel}","templated":true}]}}');
+	res.json(obj);
+});
 
 module.exports = server;


### PR DESCRIPTION
This feature allows a user to simply point at a Pact Broker via `pactBrokerUrl` with a Provider name (`provider`), optionally passing in a set of `tags`, and the library will automatically pull in all pacts for the given Provider.

This is the ideal way of finding pacts, rather than hard coding locations per consumer/version/tag etc.

The integration tests aren't fully featured, but they do show the underlying Ruby process is actually being properly executed which was my intention. The unit tests should do the job in terms of functionality.