### PR TITLE
Deprecate providerStatesUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,8 @@ var opts = {
 	provider: <String>                   // Name of the Provider. Required.
 	tags: <Array>                        // Array of tags, used to filter pacts from the Broker. Optional.
 	pactUrls: <Array>,                   // Array of local Pact file paths or HTTP-based URLs (e.g. from a broker). Required if not using a Broker.
-	providerStatesUrl: <String>,         // URL to fetch the provider states for the given provider API. Optional.
 	providerStatesSetupUrl: <String>,    // URL to send PUT requests to setup a given provider state. Optional.
-	pactBrokerUsername: <String>,        // Username for Pact Broker basic authentication. Optional
+	pactBrokerUsername: <String>,        // Username for Pact Broker basic authentication. Optional.
 	pactBrokerPassword: <String>,        // Password for Pact Broker basic authentication. Optional
 	publishVerificationResult: <Boolean> // Publish verification result to Broker. Optional
 	providerVersion: <Boolean>           // Provider version, required to publish verification result to Broker. Optional otherwise.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pact-foundation/pact-node",
-	"version": "4.9.2",
+	"version": "4.10.0",
 	"description": "A wrapper for the Ruby version of Pact to work within Node",
 	"main": "./src/pact.js",
 	"os": [
@@ -37,8 +37,8 @@
 		"url": "https://github.com/pact-foundation/pact-node/issues"
 	},
 	"dependencies": {
-		"@pact-foundation/pact-mock-service": "~2.1.0",
-		"@pact-foundation/pact-provider-verifier": "~1.1.1",
+		"@pact-foundation/pact-mock-service": "^2.1.0",
+		"@pact-foundation/pact-provider-verifier": "^1.2.0",
 		"bunyan": "^1.8.10",
 		"bunyan-prettystream": "^0.1.3",
 		"check-types": "~7.1.5",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
 		"url": "https://github.com/pact-foundation/pact-node/issues"
 	},
 	"dependencies": {
-		"@pact-foundation/pact-mock-service": "^2.1.0",
-		"@pact-foundation/pact-provider-verifier": "^1.2.0",
+		"@pact-foundation/pact-mock-service": "~2.1.0",
+		"@pact-foundation/pact-provider-verifier": "~1.3.0",
 		"bunyan": "^1.8.10",
 		"bunyan-prettystream": "^0.1.3",
 		"check-types": "~7.1.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"clean": "rimraf logs/*",
 		"lint": "jscs .",
 		"pretest": "npm run clean && npm run lint",
-		"test": "./node_modules/.bin/cross-env LOGLEVEL=warn ./node_modules/.bin/mocha -R spec --timeout 10000 ./**/*.spec.js",
+		"test": "./node_modules/.bin/cross-env LOGLEVEL=warn ./node_modules/.bin/mocha  ./**/*.spec.js",
 		"watch": "nodemon -x npm run dev",
 		"watch:debug": "nodemon --debug -q -w assets/ --ext '.' --exec 'npm run lint'",
 		"dev": "npm test && node .",

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -26,13 +26,13 @@ function Verifier(providerBaseUrl, pactUrls, providerStatesUrl, providerStatesSe
 	this._options.tags = tags;
 	this._options.provider = provider;
 	this._options.timeout = timeout;
-	
+
 }
 
 Verifier.prototype.verify = function () {
 	logger.info("Verifier verify()");
 	var retrievePactsPromise;
-	
+
 	if (this._options.pactUrls.length > 0) {
 		retrievePactsPromise = Promise.resolve(this._options.pactUrls);
 	} else {
@@ -46,23 +46,23 @@ Verifier.prototype.verify = function () {
 		});
 		retrievePactsPromise = broker.findConsumers()
 	}
-	
+
 	return retrievePactsPromise.then(function (data) {
 		this._options.pactUrls = data;
-		
+
 		var deferred = q.defer();
 		var output = ''; // Store output here in case of error
 		function outputHandler(data) {
 			logger.info(data);
 			output += data;
 		}
-		
+
 		var envVars = JSON.parse(JSON.stringify(process.env)); // Create copy of environment variables
 		// Remove environment variable if there
 		// This is a hack to prevent some weird Travelling Ruby behaviour with Gems
 		// https://github.com/pact-foundation/pact-mock-service-npm/issues/16
 		delete envVars['RUBYGEMS_GEMDEPS'];
-		
+
 		var file,
 			opts = {
 				cwd: verifierPath.cwd,
@@ -79,9 +79,9 @@ Verifier.prototype.verify = function () {
 				'publishVerificationResult': '--publish-verification-results',
 				'providerVersion': '--provider-app-version'
 			});
-		
+
 		var cmd = [verifierPath.file].concat(args).join(' ');
-		
+
 		if (isWindows) {
 			file = 'cmd.exe';
 			args = ['/s', '/c', cmd];
@@ -91,19 +91,19 @@ Verifier.prototype.verify = function () {
 			file = '/bin/sh';
 			args = ['-c', cmd];
 		}
-		
+
 		this._instance = cp.spawn(file, args, opts);
-		
+
 		this._instance.stdout.setEncoding('utf8');
 		this._instance.stdout.on('data', outputHandler);
 		this._instance.stderr.setEncoding('utf8');
 		this._instance.stderr.on('data', outputHandler);
 		this._instance.on('error', logger.error.bind(logger));
-		
+
 		this._instance.once('close', function (code) {
 			code == 0 ? deferred.resolve(output) : deferred.reject(new Error(output));
 		});
-		
+
 		logger.info('Created Pact Verifier process with PID: ' + this._instance.pid);
 		return deferred.promise.timeout(this._options.timeout, "Timeout waiting for verification process to complete (PID: " + this._instance.pid + ")")
 			.tap(function (data) {
@@ -123,14 +123,14 @@ module.exports = function (options) {
 	options.providerStatesUrl = options.providerStatesUrl || '';
 	options.providerStatesSetupUrl = options.providerStatesSetupUrl || '';
 	options.timeout = options.timeout || 30000;
-	
+
 	options.pactUrls = _.chain(options.pactUrls)
 		.map(function (uri) {
 			// only check local files
 			if (!/https?:/.test(url.parse(uri).protocol)) { // If it's not a URL, check if file is available
 				try {
 					fs.statSync(path.normalize(uri)).isFile();
-					
+
 					// Unixify the paths. Pact in multiple places uses URI and matching and
 					// hasn't really taken Windows into account. This is much easier, albeit
 					// might be a problem on non root-drives
@@ -145,62 +145,59 @@ module.exports = function (options) {
 		})
 		.compact()
 		.value();
-	
+
 	checkTypes.assert.nonEmptyString(options.providerBaseUrl, 'Must provide the --provider-base-url argument');
-	
+
 	if (checkTypes.emptyArray(options.pactUrls) && !options.pactBrokerUrl) {
 		throw new Error('Must provide the --pact-urls argument if no --broker-url provided');
 	}
-	
+
 	if ((!options.pactBrokerUrl || !options.provider) && checkTypes.emptyArray(options.pactUrls)) {
 		throw new Error('Must provide both --provider and --broker-url or if --pact-urls not provided.');
 	}
-	
+
 	if (options.providerStatesSetupUrl) {
 		checkTypes.assert.string(options.providerStatesSetupUrl);
 	}
-	
+
 	if (options.providerStatesUrl) {
+		logger.warn("--provider-states-url is deprecated and no longer required.")
 		checkTypes.assert.string(options.providerStatesUrl);
 	}
-	
+
 	if (options.pactBrokerUsername) {
 		checkTypes.assert.string(options.pactBrokerUsername);
 	}
-	
+
 	if (options.pactBrokerPassword) {
 		checkTypes.assert.string(options.pactBrokerPassword);
 	}
-	
-	if ((options.providerStatesUrl && !options.providerStatesSetupUrl) || (options.providerStatesSetupUrl && !options.providerStatesUrl)) {
-		throw new Error('Must provide both or none of --provider-states-url and --provider-states-setup-url.');
-	}
-	
+
 	if (options.pactUrls) {
 		checkTypes.assert.array.of.string(options.pactUrls);
 	}
-	
+
 	if (options.tags) {
 		checkTypes.assert.array.of.string(options.tags);
 	}
-	
+
 	if (options.providerBaseUrl) {
 		checkTypes.assert.string(options.providerBaseUrl);
 	}
-	
+
 	if (options.publishVerificationResult) {
 		checkTypes.assert.boolean(options.publishVerificationResult);
 	}
-	
+
 	if (options.publishVerificationResult && !options.providerVersion) {
 		throw new Error('Must provide both or none of --publish-verification-results and --provider-app-version.');
 	}
-	
+
 	if (options.providerVersion) {
 		checkTypes.assert.string(options.providerVersion);
 	}
-	
+
 	checkTypes.assert.positive(options.timeout);
-	
+
 	return new Verifier(options.providerBaseUrl, options.pactUrls, options.providerStatesUrl, options.providerStatesSetupUrl, options.pactBrokerUsername, options.pactBrokerPassword, options.publishVerificationResult, options.providerVersion, options.pactBrokerUrl, options.tags, options.provider, options.timeout);
 };

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,5 @@
+--bail
+--reporter spec
+--colors
+--recursive
+--timeout 10000

--- a/test/verifier.integration.spec.js
+++ b/test/verifier.integration.spec.js
@@ -135,7 +135,7 @@ describe("Verifier Integration Spec", function () {
 						return expect(verifier.verify()).to.eventually.be.fulfilled;
 					});
 				});
-				context("and an invalid user/password", function () {
+				context.only("and an invalid user/password", function () {
 					it("should return a rejected promise", function () {
 						var verifier = verifierFactory({
 							providerBaseUrl: providerBaseUrl,
@@ -156,13 +156,7 @@ describe("Verifier Integration Spec", function () {
 							pactBrokerUsername: 'foo',
 							pactBrokerPassword: 'baaoeur'
 						});
-						return verifier.verify()
-							.then(function () {
-								throw new Error("Expected an error but got none");
-							})
-							.catch(function (err) {
-								expect(err.message).to.contain("Unauthorized")
-							})
+						return expect(verifier.verify()).to.eventually.be.rejected
 					});
 				});
 			});

--- a/test/verifier.integration.spec.js
+++ b/test/verifier.integration.spec.js
@@ -135,7 +135,7 @@ describe("Verifier Integration Spec", function () {
 						return expect(verifier.verify()).to.eventually.be.fulfilled;
 					});
 				});
-				context.only("and an invalid user/password", function () {
+				context("and an invalid user/password", function () {
 					it("should return a rejected promise", function () {
 						var verifier = verifierFactory({
 							providerBaseUrl: providerBaseUrl,


### PR DESCRIPTION
Since the verifier `v1.1.3` the states URL is no longer required and is ignored - huzzah!

This PR removes the need for it and adds a deprecation warning.

Also, there was some minor formatting (spaces where there needed be any) in the verifier that my editor has kindly removed.