### PR TITLE
feat(standalone): implement standalone pact service

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
 		"url": "https://github.com/pact-foundation/pact-node/issues"
 	},
 	"dependencies": {
-		"@pact-foundation/pact-mock-service": "~2.1.0",
-		"@pact-foundation/pact-provider-verifier": "^1.4.3",
+		"@pact-foundation/pact-standalone": "~1.0.0",
 		"bunyan": "^1.8.12",
 		"bunyan-prettystream": "^0.1.3",
 		"check-types": "~7.1.5",

--- a/src/server.js
+++ b/src/server.js
@@ -10,7 +10,7 @@ var checkTypes = require('check-types'),
 	http = require('request'),
 	q = require('q'),
 	util = require('util'),
-	pactPath = require('@pact-foundation/pact-mock-service'),
+	pactPath = require('@pact-foundation/pact-standalone'),
 	mkdirp = require('mkdirp'),
 	pactUtil = require('./pact-util'),
 	isWindows = process.platform === 'win32';
@@ -73,7 +73,7 @@ Server.prototype.start = function () {
 			'provider': '--provider'
 		});
 
-	var cmd = [pactPath.file].concat(args).join(' ');
+	var cmd = [pactPath.mockServicePath].concat(args).join(' ');
 
 	if (isWindows) {
 		file = 'cmd.exe';

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -7,7 +7,7 @@ var checkTypes = require('check-types'),
 	q = require('q'),
 	unixify = require('unixify'),
 	url = require('url'),
-	verifierPath = require('@pact-foundation/pact-provider-verifier'),
+	standalonePath = require('@pact-foundation/pact-standalone'),
 	pactUtil = require('./pact-util'),
 	isWindows = process.platform === 'win32';
 
@@ -65,7 +65,7 @@ Verifier.prototype.verify = function () {
 
 		var file,
 			opts = {
-				cwd: verifierPath.cwd,
+				cwd: standalonePath.cwd,
 				detached: !isWindows,
 				env: envVars
 			},
@@ -80,7 +80,7 @@ Verifier.prototype.verify = function () {
 				'providerVersion': '--provider-app-version'
 			});
 
-		var cmd = [verifierPath.file].concat(args).join(' ');
+		var cmd = [standalonePath.verifierPath].concat(args).join(' ');
 
 		if (isWindows) {
 			file = 'cmd.exe';
@@ -91,7 +91,6 @@ Verifier.prototype.verify = function () {
 			file = '/bin/sh';
 			args = ['-c', cmd];
 		}
-
 		this._instance = cp.spawn(file, args, opts);
 
 		this._instance.stdout.setEncoding('utf8');


### PR DESCRIPTION
Removes the two npm packages in favour of a single standalone package.

1. Means faster time-to-market (the rest of the languages are using this single package, so it will save us from having to publish all of the gems, then the two packages etc. etc.)
2. Means smaller distribution, as there is only a single Ruby runtime for both the mock service and verifier.

See https://travis-ci.org/pact-foundation/pact-node/jobs/278567944 for a passing build (it's currently red, but that's because I pushed this branch before I published the standalone module).

