### PR TITLE
Improve type checking across codebase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ trim_trailing_whitespace = false
 [*.js]
 indent_style = tab
 indent_size = 4
+
+[package.json]
+indent_style = space
+indent_size = 2

--- a/bin/pact-cli.spec.ts
+++ b/bin/pact-cli.spec.ts
@@ -3,11 +3,11 @@ import chaiAsPromised = require("chai-as-promised");
 import childProcess = require("child_process");
 import q = require("q");
 import path = require("path");
-import _ = require("underscore");
 import {ChildProcess} from "child_process";
 import {ServerOptions} from "../src/server";
-import decamelize = require("decamelize");
 import providerMock from "../test/integration/provider-mock";
+const decamelize = require("decamelize");
+const _ = require("underscore");
 
 const request = q.denodeify(require("request"));
 const pkg = require("../package.json");
@@ -64,7 +64,7 @@ describe("Pact CLI Spec", () => {
 		});
 
 		context("with mock broker", () => {
-			let server;
+			let server: any;
 			const PORT = 9123;
 			const providerBaseUrl = `http://localhost:${PORT}`;
 
@@ -83,7 +83,7 @@ class CLI {
 	public static runMock(options: ServerOptions = {}): q.Promise<CLI> {
 		const args = _.chain(options)
 			.pairs()
-			.map((arr) => [`--${decamelize(arr[0], "-")}`, `${arr[1]}`])
+			.map((arr: any[]) => [`--${decamelize(arr[0], "-")}`, `${arr[1]}`])
 			.flatten()
 			.value();
 
@@ -113,6 +113,7 @@ class CLI {
 					cp.process.once("exit", () => deferred.resolve());
 					return deferred.promise;
 				}
+				return null;
 			});
 	}
 

--- a/bin/pact-cli.ts
+++ b/bin/pact-cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import pact from "../src/pact";
-import cli = require("caporal");
+const cli = require("caporal");
 
 const pkg = require("../package.json");
 
@@ -23,7 +23,7 @@ cli
 	.option("-i, --pact-version [n]", "The Pact specification version to use when writing the Pact files. Default is 1.", cli.INT)
 	.option("--consumer [consumerName]", "Specify consumer name for written Pact files.")
 	.option("--provider [providerName]", "Specify provider name for written Pact files.")
-	.action((args, options) => pact.createServer(options).start());
+	.action((args: any, options: any) => pact.createServer(options).start());
 
 cli
 	.command("verify")
@@ -38,6 +38,6 @@ cli
 	.option("-v, --provider-version [version]", "Provider version, required to publish verification result to Broker.")
 	.option("-t, --timeout [milliseconds]", "The duration in ms we should wait to confirm verification process was successful. Defaults to 30000.", cli.INT)
 	.option("-pub, --publish-verification-result", "Publish verification result to Broker.")
-	.action((args, options) => pact.verifyPacts(options));
+	.action((args: any, options: any) => pact.verifyPacts(options));
 
 cli.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/node": "8.0.26",
     "@types/q": "1.0.5",
     "@types/request": "2.0.3",
+    "@types/underscore": "^1.8.5",
     "basic-auth": "1.1.0",
     "body-parser": "1.17.2",
     "caporal": "0.7.0",
@@ -92,7 +93,7 @@
     "clean": "rimraf '{src,test,bin}/**/*.{js,map,d.ts}' 'package.zip' '.tmp'",
     "lint": "tslint -p tsconfig.json",
     "pretest": "npm run build",
-    "test": "mocha -r ts-node/register -R mocha-unfunk-reporter --timeout 10000 \"{src,test,bin}/**/*.spec.ts\"",
+    "test": "mocha -r ts-node/register -R mocha-unfunk-reporter --timeout 15000 \"{src,test,bin}/**/*.spec.ts\"",
     "dev": "npm run lint --force && npm test && node .",
     "build": "npm run clean && tsc",
     "start": "npm run watch"

--- a/src/broker.ts
+++ b/src/broker.ts
@@ -1,5 +1,6 @@
 import q = require("q");
 import logger from "./logger";
+import { IWhenable } from "q";
 const _ = require("underscore");
 const checkTypes = require("check-types");
 const request = q.denodeify(require("request"));
@@ -50,7 +51,7 @@ export class Broker {
 			} : null
 		};
 		return request(requestOptions)
-			.then((data) => data[0])
+			.then((data: any) => data[0])
 			.then((response) => {
 				if (response.statusCode < 200 && response.statusCode >= 300) {
 					return q.reject(response);
@@ -58,7 +59,7 @@ export class Broker {
 				const body = JSON.parse(response.body);
 				return request(_.extend({}, requestOptions, {uri: body._links[`pb:latest-provider-pacts${tag ? "-with-tag" : ""}`].href.replace("{tag}", tag).replace("{provider}", this.options.provider)}));
 			})
-			.then((data) => data[0])
+			.then((data: any) => data[0])
 			.then((response) => response.statusCode < 200 && response.statusCode >= 300 ? q.reject(response) : JSON.parse(response.body));
 	}
 
@@ -75,7 +76,7 @@ export class Broker {
 				}
 				return array;
 			}, []))
-			.catch(() => q.reject(`Unable to find pacts for given provider '${this.options.provider}' and tags '${this.options.tags}'`));
+			.catch(() => q.reject(`Unable to find pacts for given provider '${this.options.provider}' and tags '${this.options.tags}'`) as IWhenable<any>);
 	}
 }
 

--- a/src/broker.ts
+++ b/src/broker.ts
@@ -76,7 +76,7 @@ export class Broker {
 				}
 				return array;
 			}, []))
-			.catch(() => q.reject(`Unable to find pacts for given provider '${this.options.provider}' and tags '${this.options.tags}'`) as IWhenable<any>);
+			.catch(() => q.reject<IWhenable<any>>(`Unable to find pacts for given provider '${this.options.provider}' and tags '${this.options.tags}'`));
 	}
 }
 

--- a/src/broker.ts
+++ b/src/broker.ts
@@ -1,8 +1,7 @@
-import checkTypes = require("check-types");
 import q = require("q");
-import _ = require("underscore");
 import logger from "./logger";
-
+const _ = require("underscore");
+const checkTypes = require("check-types");
 const request = q.denodeify(require("request"));
 
 export class Broker {
@@ -67,10 +66,10 @@ export class Broker {
 	// and removes duplicates (e.g. where multiple tags on the same pact)
 	public findConsumers(): q.Promise<string[]> {
 		logger.debug("Finding consumers");
-		const promises = _.isEmpty(this.options.tags) ? [this.findPacts()] : _.map(this.options.tags, (t) => this.findPacts(t));
+		const promises = _.isEmpty(this.options.tags) ? [this.findPacts()] : _.map(this.options.tags, (t: string) => this.findPacts(t));
 
 		return q.all(promises)
-			.then((values) => _.reduce(values, (array, v) => {
+			.then((values) => _.reduce(values, (array: string[], v: any) => {
 				if (v && v._links && v._links.pacts) {
 					array.push(..._.pluck(v._links.pacts, "href"));
 				}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import bunyan = require("bunyan");
-import PrettyStream = require("bunyan-prettystream");
+const PrettyStream = require("bunyan-prettystream");
 
 const pkg = require("../package.json");
 const prettyStdOut = new PrettyStream();

--- a/src/pact-util.ts
+++ b/src/pact-util.ts
@@ -19,7 +19,7 @@ export class PactUtil {
 					let mapping = mappings[key];
 					let f = acc.push.bind(acc);
 					if (mapping === DEFAULT_ARG) {
-						mapping = null;
+						mapping = "";
 						f = acc.unshift.bind(acc);
 					}
 					_.map(checkTypes.array(value) ? value : [value], (v: any) => f([mapping, `'${v}'`]));
@@ -93,7 +93,7 @@ export class PactUtil {
 }
 
 export interface SpawnArguments {
-	[id: string]: string | string[] | boolean | number;
+	[id: string]: string | string[] | boolean | number | undefined;
 }
 
 export default new PactUtil();

--- a/src/pact-util.ts
+++ b/src/pact-util.ts
@@ -1,10 +1,11 @@
 // tslint:disable:no-string-literal
-import _ = require("underscore");
-import checkTypes = require("check-types");
-import pactStandalone = require("@pact-foundation/pact-standalone");
 import cp = require("child_process");
 import logger from "./logger";
 import {ChildProcess, SpawnOptions} from "child_process";
+import { Dictionary } from "underscore";
+const _ = require("underscore");
+const checkTypes = require("check-types");
+const pactStandalone = require("@pact-foundation/pact-standalone");
 
 const isWindows = process.platform === "win32";
 
@@ -13,7 +14,7 @@ export const DEFAULT_ARG = "DEFAULT";
 export class PactUtil {
 	public createArguments(args: SpawnArguments, mappings: { [id: string]: string }): string[] {
 		return _.chain(args)
-			.reduce((acc, value, key) => {
+			.reduce((acc: any, value: any, key: any) => {
 				if (value && mappings[key]) {
 					let mapping = mappings[key];
 					let f = acc.push.bind(acc);
@@ -21,7 +22,7 @@ export class PactUtil {
 						mapping = null;
 						f = acc.unshift.bind(acc);
 					}
-					_.map(checkTypes.array(value) ? value : [value], (v) => f([mapping, `'${v}'`]));
+					_.map(checkTypes.array(value) ? value : [value], (v: any) => f([mapping, `'${v}'`]));
 				}
 				return acc;
 			}, [])

--- a/src/pact.spec.ts
+++ b/src/pact.spec.ts
@@ -51,7 +51,7 @@ describe("Pact Spec", () => {
 	});
 
 	describe("Create serverFactory", () => {
-		let dirPath: any;
+		let dirPath: string;
 
 		beforeEach(() => dirPath = path.resolve(__dirname, `../.tmp/${Math.floor(Math.random() * 1000)}`));
 

--- a/src/pact.spec.ts
+++ b/src/pact.spec.ts
@@ -12,7 +12,7 @@ describe("Pact Spec", () => {
 	afterEach(() => pact.removeAllServers());
 
 	describe("Set Log Level", () => {
-		let originalLogLevel;
+		let originalLogLevel: any;
 		// Reset lot level after the tests
 		before(() => originalLogLevel = pact.logLevel());
 		after(() => pact.logLevel(originalLogLevel));
@@ -51,7 +51,7 @@ describe("Pact Spec", () => {
 	});
 
 	describe("Create serverFactory", () => {
-		let dirPath;
+		let dirPath: any;
 
 		beforeEach(() => dirPath = path.resolve(__dirname, `../.tmp/${Math.floor(Math.random() * 1000)}`));
 

--- a/src/pact.spec.ts
+++ b/src/pact.spec.ts
@@ -5,8 +5,8 @@ import fs = require("fs");
 import pact from "./pact";
 
 const expect = chai.expect;
-
 chai.use(chaiAsPromised);
+const currentDir = (process && process.mainModule) ? process.mainModule.filename : "";
 
 describe("Pact Spec", () => {
 	afterEach(() => pact.removeAllServers());
@@ -242,7 +242,7 @@ describe("Pact Spec", () => {
 			it("should start the pact-provider-verifier service and verify pacts", () => {
 				let opts = {
 					providerBaseUrl: "http://localhost",
-					pactUrls: [path.dirname(process.mainModule.filename)]
+					pactUrls: [path.dirname(currentDir)]
 				};
 				return expect(pact.verifyPacts(opts)).to.eventually.be.fulfilled;
 			});
@@ -253,7 +253,7 @@ describe("Pact Spec", () => {
 		it("should start running the Pact publishing process", () => {
 			let opts = {
 				pactBroker: "http://localhost",
-				pactUrls: [path.dirname(process.mainModule.filename)],
+				pactUrls: [path.dirname(currentDir)],
 				consumerVersion: "1.0.0"
 			};
 			return expect(pact.publishPacts(opts)).to.eventually.be.fulfilled;

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -21,7 +21,7 @@ export class Pact {
 
 	// Creates server with specified options
 	public createServer(options: ServerOptions = {}): Server {
-		if (options && options.port && _.some(this.__servers, (s) => s.options.port === options.port)) {
+		if (options && options.port && _.some(this.__servers, (s: Server) => s.options.port === options.port)) {
 			let msg = `Port '${options.port}' is already in use by another process.`;
 			logger.error(msg);
 			throw new Error(msg);
@@ -32,7 +32,7 @@ export class Pact {
 		logger.info(`Creating Pact Server with options: \n${this.__stringifyOptions(server.options)}`);
 
 		// Listen to server delete events, to remove from server list
-		server.once("delete", (s: any) => {
+		server.once("delete", (s: Server) => {
 			logger.info(`Deleting Pact Server with options: \n${this.__stringifyOptions(s.options)}`);
 			this.__servers = _.without(this.__servers, s);
 		});
@@ -71,7 +71,7 @@ export class Pact {
 	private __stringifyOptions(obj: ServerOptions): string {
 		return _.chain(obj)
 			.pairs()
-			.map((v) => v.join(" = "))
+			.map((v: string[]) => v.join(" = "))
 			.value()
 			.join(",\n");
 	}

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -32,7 +32,7 @@ export class Pact {
 		logger.info(`Creating Pact Server with options: \n${this.__stringifyOptions(server.options)}`);
 
 		// Listen to server delete events, to remove from server list
-		server.once("delete", (s) => {
+		server.once("delete", (s: any) => {
 			logger.info(`Deleting Pact Server with options: \n${this.__stringifyOptions(s.options)}`);
 			this.__servers = _.without(this.__servers, s);
 		});

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -1,9 +1,9 @@
-import _ = require("underscore");
 import q = require("q");
 import serverFactory, {Server, ServerOptions} from "./server";
 import verifierFactory, {VerifierOptions} from "./verifier";
 import publisherFactory, {PublisherOptions} from "./publisher";
 import logger, {LogLevels} from "./logger";
+import _ = require("underscore");
 
 export class Pact {
 	private __servers: Server[] = [];
@@ -53,7 +53,7 @@ export class Pact {
 		}
 
 		logger.info("Removing all Pact servers.");
-		return q.all<Server>(_.map(this.__servers, (server:Server) => server.delete()));
+		return q.all<Server>(_.map(this.__servers, (server:Server) => server.delete() as PromiseLike<Server>));
 	}
 
 	// Run the Pact Verification process

--- a/src/publisher.spec.ts
+++ b/src/publisher.spec.ts
@@ -10,6 +10,7 @@ import * as http from "http";
 
 const expect = chai.expect;
 chai.use(chaiAsPromised);
+const currentDir = (process && process.mainModule) ? process.mainModule.filename : "";
 
 describe("Publish Spec", () => {
 
@@ -39,7 +40,7 @@ describe("Publish Spec", () => {
 			it("should fail with an error", () => {
 				expect(() => {
 					publisherFactory({
-						pactFilesOrDirs: [path.dirname(process.mainModule.filename)],
+						pactFilesOrDirs: [path.dirname(currentDir)],
 						consumerVersion: "1.0.0"
 					});
 				}).to.throw(Error);
@@ -51,7 +52,7 @@ describe("Publish Spec", () => {
 				expect(() => {
 					publisherFactory({
 						pactBroker: "http://localhost",
-						pactFilesOrDirs: [path.dirname(process.mainModule.filename)]
+						pactFilesOrDirs: [path.dirname(currentDir)]
 					});
 				}).to.throw(Error);
 			});
@@ -73,7 +74,7 @@ describe("Publish Spec", () => {
 				expect(() => {
 					publisherFactory({
 						pactBroker: "http://localhost",
-						pactFilesOrDirs: [path.dirname(process.mainModule.filename)],
+						pactFilesOrDirs: [path.dirname(currentDir)],
 						consumerVersion: "1.0.0"
 					});
 				}).to.not.throw(Error);

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -76,7 +76,7 @@ export class Publisher {
 		});
 
 		return deferred.promise
-			.timeout(this.options.timeout, `Timeout waiting for verification process to complete (PID: ${instance.pid})`);
+			.timeout(this.options.timeout as number, `Timeout waiting for verification process to complete (PID: ${instance.pid})`);
 	}
 }
 

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -1,8 +1,8 @@
-import checkTypes = require("check-types");
 import q = require("q");
 import logger from "./logger";
-import pactStandalone = require("@pact-foundation/pact-standalone");
 import pactUtil, {DEFAULT_ARG, SpawnArguments} from "./pact-util";
+const pactStandalone = require("@pact-foundation/pact-standalone");
+const checkTypes = require("check-types");
 
 export class Publisher {
 
@@ -60,7 +60,7 @@ export class Publisher {
 		logger.info(`Publishing pacts to broker at: ${this.options.pactBroker}`);
 		const deferred = q.defer<string[]>();
 		const instance = pactUtil.spawnBinary(`${pactStandalone.brokerPath} publish`, this.options, this.__argMapping);
-		const output = [];
+		const output: any[] = [];
 		instance.stdout.on("data", (l) => output.push(l));
 		instance.stderr.on("data", (l) => output.push(l));
 		instance.once("close", (code) => {

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -57,7 +57,7 @@ describe("Server Spec", () => {
 		});
 
 		context("when valid options are set", () => {
-			let dirPath: any;
+			let dirPath: string;
 
 			beforeEach(() => dirPath = path.resolve(__dirname, `../.tmp/${Math.floor(Math.random() * 1000)}`));
 

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -12,7 +12,7 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 describe("Server Spec", () => {
-	let server;
+	let server: any;
 
 	afterEach(() => server ? server.delete() : null);
 
@@ -57,7 +57,7 @@ describe("Server Spec", () => {
 		});
 
 		context("when valid options are set", () => {
-			let dirPath;
+			let dirPath: any;
 
 			beforeEach(() => dirPath = path.resolve(__dirname, `../.tmp/${Math.floor(Math.random() * 1000)}`));
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -149,7 +149,7 @@ export class Server extends events.EventEmitter {
 	public start(): q.Promise<Server> {
 		if (this.__instance && this.__instance.connected) {
 			logger.warn(`You already have a process running with PID: ${this.__instance.pid}`);
-			return;
+			return null;
 		}
 		this.__instance = pactUtil.spawnBinary(`${pact.mockServicePath} service`, this.options, this.__argMapping);
 		this.__instance.once("close", () => this.stop());

--- a/src/server.ts
+++ b/src/server.ts
@@ -149,7 +149,7 @@ export class Server extends events.EventEmitter {
 	public start(): q.Promise<Server> {
 		if (this.__instance && this.__instance.connected) {
 			logger.warn(`You already have a process running with PID: ${this.__instance.pid}`);
-			return null;
+			return q.resolve(this);
 		}
 		this.__instance = pactUtil.spawnBinary(`${pact.mockServicePath} service`, this.options, this.__argMapping);
 		this.__instance.once("close", () => this.stop());
@@ -188,7 +188,6 @@ export class Server extends events.EventEmitter {
 			.timeout(PROCESS_TIMEOUT, `Couldn't stop Pact with PID '${pid}'`)
 			.then(() => {
 				this.__running = false;
-				this.__instance = undefined;
 				this.emit(Server.Events.STOP_EVENT, this);
 				return this;
 			});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,16 @@
 // tslint:disable:no-string-literal
 
-import checkTypes = require("check-types");
 import path = require("path");
 import fs = require("fs");
 import events = require("events");
 import http = require("request");
 import q = require("q");
-import pact = require("@pact-foundation/pact-standalone");
-import mkdirp = require("mkdirp");
 import logger from "./logger";
 import pactUtil, {SpawnArguments} from "./pact-util";
 import {ChildProcess} from "child_process";
+const mkdirp = require("mkdirp");
+const pact = require("@pact-foundation/pact-standalone");
+const checkTypes = require("check-types");
 
 const CHECKTIME = 500;
 const RETRY_AMOUNT = 60;
@@ -156,7 +156,7 @@ export class Server extends events.EventEmitter {
 
 		if (!this.options.port) {
 			// if port isn't specified, listen for it when pact runs
-			const catchPort = (data) => {
+			const catchPort = (data: any) => {
 				const match = data.match(/port=([0-9]+)/);
 				if (match && match[1]) {
 					this.options.port = parseInt(match[1], 10);
@@ -266,7 +266,7 @@ export class Server extends events.EventEmitter {
 			config.agentOptions.agent = false;
 		}
 
-		http(config, (err, res) => (!err && res.statusCode === 200) ? deferred.resolve() : deferred.reject(`HTTP Error: '${JSON.stringify(err ? err : res)}'`));
+		http(config, (err: any, res: any) => (!err && res.statusCode === 200) ? deferred.resolve() : deferred.reject(`HTTP Error: '${JSON.stringify(err ? err : res)}'`));
 
 		return deferred.promise;
 	}

--- a/src/verifier.spec.ts
+++ b/src/verifier.spec.ts
@@ -5,6 +5,7 @@ import verifierFactory from "./verifier";
 
 const expect = chai.expect;
 chai.use(chaiAsPromised);
+const currentDir = (process && process.mainModule) ? process.mainModule.filename : "";
 
 describe("Verifier Spec", () => {
 	describe("Verifier", () => {
@@ -86,7 +87,7 @@ describe("Verifier Spec", () => {
 			it("should not fail", () => {
 				expect(() => verifierFactory({
 					providerBaseUrl: "http://localhost",
-					pactUrls: [path.dirname(process.mainModule.filename)]
+					pactUrls: [path.dirname(currentDir)]
 				})).to.not.throw(Error);
 			});
 		});

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -1,13 +1,13 @@
-import checkTypes = require("check-types");
 import path = require("path");
 import q = require("q");
 import _ = require("underscore");
-import unixify = require("unixify");
 import url = require("url");
-import pactStandalone = require("@pact-foundation/pact-standalone");
 import Broker from "./broker";
 import logger from "./logger";
 import pactUtil, {DEFAULT_ARG, SpawnArguments} from "./pact-util";
+const pactStandalone = require("@pact-foundation/pact-standalone");
+const checkTypes = require("check-types");
+const unixify = require("unixify");
 
 import fs = require("fs");
 
@@ -127,7 +127,7 @@ export class Verifier {
 				const deferred = q.defer<string>();
 				this.options.pactUrls = data;
 				const instance = pactUtil.spawnBinary(pactStandalone.verifierPath, this.options, this.__argMapping);
-				const output = [];
+				const output: any[] = [];
 				instance.stdout.on("data", (l) => output.push(l));
 				instance.stderr.on("data", (l) => output.push(l));
 				instance.once("close", (code) => {

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -1,10 +1,10 @@
 import path = require("path");
-import q = require("q");
-import _ = require("underscore");
 import url = require("url");
 import Broker from "./broker";
 import logger from "./logger";
 import pactUtil, {DEFAULT_ARG, SpawnArguments} from "./pact-util";
+import q = require("q");
+const _ = require("underscore");
 const pactStandalone = require("@pact-foundation/pact-standalone");
 const checkTypes = require("check-types");
 const unixify = require("unixify");
@@ -21,9 +21,9 @@ export class Verifier {
 		options.timeout = options.timeout || 30000;
 
 		options.pactUrls = _.chain(options.pactUrls)
-			.map((uri) => {
+			.map((uri: string) => {
 				// only check local files
-				if (!/https?:/.test(url.parse(uri).protocol)) { // If it"s not a URL, check if file is available
+				if (!/https?:/.test(url.parse(uri).protocol || "")) { // If it's not a URL, check if file is available
 					try {
 						fs.statSync(path.normalize(uri)).isFile();
 
@@ -111,7 +111,7 @@ export class Verifier {
 	public verify(): q.Promise<string> {
 		logger.info("Verifying Pact Files");
 		return q(this.options.pactUrls)
-			.then((uris) => {
+		.then((uris) => {
 				if (!uris || uris.length === 0) {
 					return new Broker({
 						brokerUrl: this.options.pactBrokerUrl,
@@ -123,7 +123,7 @@ export class Verifier {
 				}
 				return uris;
 			})
-			.then((data: string[]): q.Promise<string> => {
+			.then((data: string[]): PromiseLike<string> => {
 				const deferred = q.defer<string>();
 				this.options.pactUrls = data;
 				const instance = pactUtil.spawnBinary(pactStandalone.verifierPath, this.options, this.__argMapping);
@@ -136,8 +136,8 @@ export class Verifier {
 				});
 
 				return deferred.promise
-					.timeout(this.options.timeout, `Timeout waiting for verification process to complete (PID: ${instance.pid})`)
-					.tap(() => logger.info("Pact Verification succeeded."));
+					.timeout(this.options.timeout as number, `Timeout waiting for verification process to complete (PID: ${instance.pid})`)
+					.tap(() => logger.info("Pact Verification succeeded.")) as PromiseLike<string>;
 			});
 	}
 }

--- a/test/integration/broker-mock.ts
+++ b/test/integration/broker-mock.ts
@@ -1,10 +1,10 @@
-import cors = require("cors");
-import _ = require("underscore");
 import q = require("q");
 import express = require("express");
-import bodyParser = require("body-parser");
 import * as http from "http";
 import {auth, returnJson} from "./data-utils";
+const cors = require("cors");
+const _ = require("underscore");
+const bodyParser = require("body-parser");
 
 export default (port: number): q.Promise<http.Server> => {
 	const BROKER_HOST = `http://localhost:${port}`;

--- a/test/integration/data-utils.ts
+++ b/test/integration/data-utils.ts
@@ -1,5 +1,5 @@
 import express = require("express");
-import basicAuth = require("basic-auth");
+const basicAuth = require("basic-auth");
 
 export function returnJsonFile(filename: string): (req: express.Request, res: express.Response) => express.Response {
 	return returnJson(require(filename));

--- a/test/integration/data-utils.ts
+++ b/test/integration/data-utils.ts
@@ -13,7 +13,7 @@ export function auth(req: express.Request, res: express.Response, next: express.
 	const user = basicAuth(req);
 	if (user && user.name === "foo" && user.pass === "bar") {
 		next();
-		return;
+		return null;
 	}
 
 	res.set("WWW-Authenticate", "Basic realm=Authorization Required");

--- a/test/integration/data-utils.ts
+++ b/test/integration/data-utils.ts
@@ -13,7 +13,6 @@ export function auth(req: express.Request, res: express.Response, next: express.
 	const user = basicAuth(req);
 	if (user && user.name === "foo" && user.pass === "bar") {
 		next();
-		return null;
 	}
 
 	res.set("WWW-Authenticate", "Basic realm=Authorization Required");

--- a/test/integration/provider-mock.ts
+++ b/test/integration/provider-mock.ts
@@ -1,9 +1,9 @@
-import cors = require("cors");
 import express = require("express");
 import q = require("q");
-import bodyParser = require("body-parser");
 import * as http from "http";
 import {returnJson, returnJsonFile, auth} from "./data-utils";
+const cors = require("cors");
+const bodyParser = require("body-parser");
 
 export default (port: number): q.Promise<http.Server> => {
 	const server: express.Express = express();

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,4 +2,4 @@
 --reporter spec
 --colors
 --recursive
---timeout 10000
+--timeout 15000

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"target": "es5",
-		"noImplicitAny": false,
 		"removeComments": true,
 		"noLib": false,
 		"emitDecoratorMetadata": true,
@@ -12,7 +11,8 @@
 		"isolatedModules": false,
 		"moduleResolution": "node",
 		"suppressImplicitAnyIndexErrors": true,
-		"declaration": true
+		"declaration": true,
+		"noImplicitReturns": true
 	},
 	"include": [
 		"**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		"suppressImplicitAnyIndexErrors": true,
 		"declaration": true,
 		"noImplicitReturns": true,
+		"noImplicitAny": true,
 		"noImplicitThis": true
 	},
 	"include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
 		"moduleResolution": "node",
 		"suppressImplicitAnyIndexErrors": true,
 		"declaration": true,
-		"noImplicitReturns": true
+		"noImplicitReturns": true,
+		"noImplicitThis": true
 	},
 	"include": [
 		"**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
 		"declaration": true,
 		"noImplicitReturns": true,
 		"noImplicitAny": true,
-		"noImplicitThis": true
+		"noImplicitThis": true,
+		"strictNullChecks": true
 	},
 	"include": [
 		"**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
 	],
 	"exclude": [
 		"node_modules",
-		"**/*.spec.ts",
 		"**/*.d.ts"
 	],
 	"compileOnSave": false


### PR DESCRIPTION
Adds the following TS configuration, in order to improve the libraries portability into other TS projects:

* --noImplicitAny: Raise error on expressions and declarations with an implied any type.
* --noImplicitReturns: Report error when not all code paths in function return a value.
* --noImplicitThis: Raise error on this expressions with an implied any type.
* --strictNullChecks: In strict null checking mode, the nulland undefined values are not in the domain of every type and are only assignable to themselves and any (the one exception being that undefined is also assignable to void).

NOTE: in a few q-related cases, explicit type casting was necessary. I haven't been able to dig far enough into why the code works but types are incorrect - either there is an issue with the code, or the types aren't quite correct (in particular, a `q.Resolve(...)` is not compatible with the `PromiseLike` interface).

Fixes #55.