### PR TITLE
Declares @types/bunyan as a package dependency as it's publically exposed

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@types/bunyan": "1.8.2",
     "@pact-foundation/pact-standalone": "~3.4.0",
     "bunyan": "1.8.12",
     "bunyan-prettystream": "0.1.3",
@@ -60,7 +61,6 @@
     "url-join": "2.0.2"
   },
   "devDependencies": {
-    "@types/bunyan": "1.8.2",
     "@types/chai": "4.0.4",
     "@types/chai-as-promised": "0.0.31",
     "@types/express": "4.0.37",


### PR DESCRIPTION
bunyan is publically exposed to consumers of this library (via logger.ts) thus consumers need
type definitions for TypeScript compilation to pass.

This fixes #69