### PR TITLE
Avoids packaging TypeScript sources to avoid .d.ts conflicts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -44,3 +44,8 @@ package.zip
 # ts-node cache
 ts-node-*
 
+# ignore the TypeScript sources as compiled JS is published
+*.ts
+
+# include TypeScript definitions to go with compiled JS
+!*.d.ts


### PR DESCRIPTION
This is part of fixing #69.

Per https://github.com/Microsoft/TypeScript/issues/7432 the TypeScript compiler will attempt to
compile the TypeScript sources if they're found. This is because definitions (.d.ts) do not take
precedence over source files.

New package contents:
```
$ npm pack
$ tar -tf pact-foundation-pact-node-6.7.2.tgz --wildcards 'package/src/*.ts'
package/src/publisher.d.ts
package/src/index.d.ts
package/src/pact.d.ts
package/src/pact.spec.d.ts
package/src/index.spec.d.ts
package/src/broker.spec.d.ts
package/src/publisher.spec.d.ts
package/src/server.d.ts
package/src/logger.d.ts
package/src/server.spec.d.ts
package/src/broker.d.ts
package/src/service.d.ts
package/src/stub.d.ts
package/src/pact-util.d.ts
package/src/stub.spec.d.ts
package/src/verifier.d.ts
package/src/verifier.spec.d.ts
package/src/pact-util.spec.d.ts
```