### PR TITLE
fix(windows-path): spaces in paths on windows would error our the pact binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ deploy:
   on:
     branch: master
     tags: true
-    node: 6
+    node: 8

--- a/bin/pact-cli.spec.ts
+++ b/bin/pact-cli.spec.ts
@@ -17,7 +17,7 @@ const isWindows = process.platform === "win32";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe.skip("Pact CLI Spec", () => {
+describe("Pact CLI Spec", () => {
 	afterEach(() => CLI.stopAll());
 
 	it("should show the proper version", () => {

--- a/bin/pact-cli.spec.ts
+++ b/bin/pact-cli.spec.ts
@@ -17,7 +17,7 @@ const isWindows = process.platform === "win32";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe("Pact CLI Spec", () => {
+describe.skip("Pact CLI Spec", () => {
 	afterEach(() => CLI.stopAll());
 
 	it("should show the proper version", () => {

--- a/bin/pact-cli.spec.ts
+++ b/bin/pact-cli.spec.ts
@@ -145,7 +145,7 @@ class CLI {
 			detached: !isWindows,
 			windowsVerbatimArguments: isWindows
 		};
-		args = [this.__cliPath].concat(args);
+		args = [this.__cliPath].concat(args).map((v) => `"${v}"`);
 		const proc = childProcess.spawn("node", args, opts);
 		this.__children.push(proc);
 		return q(new CLI(proc))

--- a/bin/pact-cli.spec.ts
+++ b/bin/pact-cli.spec.ts
@@ -8,6 +8,7 @@ import {ServerOptions} from "../src/server";
 import providerMock from "../test/integration/provider-mock";
 import brokerMock from "../test/integration/broker-mock";
 import * as http from "http";
+
 const decamelize = require("decamelize");
 const _ = require("underscore");
 
@@ -73,11 +74,25 @@ describe("Pact CLI Spec", () => {
 			before(() => providerMock(PORT).then((s) => server = s));
 			after(() => server.close());
 
-			it("should work pointing to fake broker", () => {
-				const p = CLI.runSync(["verify", "--provider-base-url", providerBaseUrl, "--pact-urls", path.resolve(__dirname, "integration/me-they-success.json")])
-					.then((cp) => cp.stdout);
-				return expect(p).to.eventually.be.fulfilled;
-			});
+			it("should work pointing to fake broker", () =>
+				expect(
+					CLI.runSync([
+						"verify",
+						"--provider-base-url", providerBaseUrl,
+						"--pact-urls", path.resolve(__dirname, "integration/me-they-success.json")
+					]).then((cp) => cp.stdout)
+				).to.eventually.be.fulfilled
+			);
+
+			it("should work with a weird path to a file", () =>
+				expect(
+					CLI.runSync([
+						"verify",
+						"--provider-base-url", providerBaseUrl,
+						"--pact-urls", path.resolve(__dirname, "integration/me-they-weird path-success.json")
+					]).then((cp) => cp.stdout)
+				).to.eventually.be.fulfilled
+			);
 		});
 	});
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "caporal": "0.10.0",
     "chalk": "2.3.1",
     "check-types": "7.3.0",
+    "cross-spawn": "6.0.5",
     "decompress": "4.2.0",
     "mkdirp": "0.5.1",
     "q": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pact-foundation/pact-node",
-  "version": "6.18.1",
+  "version": "6.18.3",
   "description": "A wrapper for the Ruby version of Pact to work within Node",
   "main": "src/index.js",
   "homepage": "https://github.com/pact-foundation/pact-node#readme",
@@ -101,7 +101,7 @@
     "clean": "rimraf '{src,test,bin,standalone}/**/*.{js,map,d.ts}' 'package.zip' '.tmp' 'tmp'",
     "lint": "tslint -p tsconfig.json",
     "pretest": "npm run build && npm run download-checksums && npm run install:current",
-    "test": "cross-env PACT_DO_NOT_TRACK=true mocha -r ts-node/register -R mocha-unfunk-reporter -t 15000 -s 5000 -b --check-leaks --exit \"{src,test,bin}/**/*.spec.ts\"",
+    "test": "cross-env LOGLEVEL=debug PACT_DO_NOT_TRACK=true mocha -r ts-node/register -R mocha-unfunk-reporter -t 15000 -s 5000 -b --check-leaks --exit \"{src,test,bin}/**/*.spec.ts\"",
     "dev": "npm run lint --force && npm test && node .",
     "build": "npm run clean && tsc",
     "start": "npm run watch",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "caporal": "0.10.0",
     "chalk": "2.3.1",
     "check-types": "7.3.0",
-    "cross-spawn": "6.0.5",
     "decompress": "4.2.0",
     "mkdirp": "0.5.1",
     "q": "1.5.1",

--- a/src/pact-util.ts
+++ b/src/pact-util.ts
@@ -1,11 +1,11 @@
 // tslint:disable:no-string-literal
 import cp = require("child_process");
-import path = require("path");
 import logger from "./logger";
 import pactStandalone from "./pact-standalone";
 import {ChildProcess, SpawnOptions} from "child_process";
 const _ = require("underscore");
 const checkTypes = require("check-types");
+
 const isWindows = process.platform === "win32";
 
 export const DEFAULT_ARG = "DEFAULT";
@@ -44,17 +44,18 @@ export class PactUtil {
 			env: envVars
 		};
 
+		let cmd: string = [command].concat(this.createArguments(args, argMapping)).join(" ");
+
 		let spawnArgs: string[];
 		if (isWindows) {
 			file = "cmd.exe";
-			spawnArgs = ["/s", "/c", command];
+			spawnArgs = ["/s", "/c", cmd];
 			(opts as any).windowsVerbatimArguments = true;
 		} else {
+			cmd = `./${cmd}`;
 			file = "/bin/sh";
-			spawnArgs = ["-c", `./${command}`];
+			spawnArgs = ["-c", cmd];
 		}
-
-		spawnArgs = spawnArgs.concat(this.createArguments(args, argMapping));
 
 		logger.debug(`Starting pact binary with '${_.flatten([file, args, JSON.stringify(opts)])}'`);
 		const instance = cp.spawn(file, spawnArgs, opts);
@@ -70,7 +71,7 @@ export class PactUtil {
 			}
 		});
 
-		logger.info(`Created '${command.split(path.sep).pop()}' process with PID: ${instance.pid}`);
+		logger.info(`Created '${cmd}' process with PID: ${instance.pid}`);
 		return instance;
 	}
 

--- a/src/pact-util.ts
+++ b/src/pact-util.ts
@@ -1,13 +1,11 @@
 // tslint:disable:no-string-literal
 import cp = require("child_process");
+import path = require("path");
 import logger from "./logger";
-import path from "path";
 import pactStandalone from "./pact-standalone";
 import {ChildProcess, SpawnOptions} from "child_process";
 const _ = require("underscore");
 const checkTypes = require("check-types");
-const spawn = require("cross-spawn");
-
 const isWindows = process.platform === "win32";
 
 export const DEFAULT_ARG = "DEFAULT";
@@ -59,20 +57,20 @@ export class PactUtil {
 		spawnArgs = spawnArgs.concat(this.createArguments(args, argMapping));
 
 		logger.debug(`Starting pact binary with '${_.flatten([file, args, JSON.stringify(opts)])}'`);
-		const instance = spawn(file, spawnArgs, opts);
+		const instance = cp.spawn(file, spawnArgs, opts);
 
 		instance.stdout.setEncoding("utf8");
 		instance.stderr.setEncoding("utf8");
 		instance.stdout.on("data", logger.debug.bind(logger));
 		instance.stderr.on("data", logger.debug.bind(logger));
 		instance.on("error", logger.error.bind(logger));
-		instance.once("close", (code: number) => {
+		instance.once("close", (code) => {
 			if (code !== 0) {
 				logger.warn(`Pact exited with code ${code}.`);
 			}
 		});
 
-		logger.info(`Created '${command.split(path.sep).pop()}' with PID: ${instance.pid}`);
+		logger.info(`Created '${command.split(path.sep).pop()}' process with PID: ${instance.pid}`);
 		return instance;
 	}
 

--- a/src/stub.spec.ts
+++ b/src/stub.spec.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-string-literal
 
-import stubFactory from "./stub";
+import stubFactory, {Stub} from "./stub";
 import chai = require("chai");
 import chaiAsPromised = require("chai-as-promised");
 import fs = require("fs");
@@ -17,7 +17,7 @@ describe("Stub Spec", () => {
 		pactUrls: [path.resolve(__dirname, "../test/integration/me-they-success.json")]
 	};
 
-	afterEach(() => stub ? stub.delete() : null);
+	afterEach(() => stub ? stub.delete().then(() => stub = null) : null);
 
 	describe("Start stub", () => {
 		context("when invalid options are set", () => {
@@ -78,6 +78,13 @@ describe("Stub Spec", () => {
 
 			it("should start correctly with valid pact URLs", () => {
 				stub = stubFactory(validDefaults);
+				return expect(stub.start()).to.eventually.be.fulfilled;
+			});
+
+			it("should start correctly with valid pact URLs with spaces in it", () => {
+				stub = stubFactory({
+					pactUrls: [path.resolve(__dirname, "../test/integration/me-they-weird path-success.json")]
+				});
 				return expect(stub.start()).to.eventually.be.fulfilled;
 			});
 

--- a/src/stub.spec.ts
+++ b/src/stub.spec.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-string-literal
 
-import stubFactory, {Stub} from "./stub";
+import stubFactory from "./stub";
 import chai = require("chai");
 import chaiAsPromised = require("chai-as-promised");
 import fs = require("fs");

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -9,7 +9,7 @@ const tar = require("tar");
 const chalk = require("chalk");
 const sumchecker = require("sumchecker");
 
-export const PACT_STANDALONE_VERSION = "1.44.1";
+export const PACT_STANDALONE_VERSION = "1.44.2";
 const HTTP_REGEX = /^http(s?):\/\//;
 const PACT_DEFAULT_LOCATION = `https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_STANDALONE_VERSION}/`;
 let PACT_BINARY_LOCATION = PACT_DEFAULT_LOCATION;

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -9,7 +9,7 @@ const tar = require("tar");
 const chalk = require("chalk");
 const sumchecker = require("sumchecker");
 
-export const PACT_STANDALONE_VERSION = "1.44.2";
+export const PACT_STANDALONE_VERSION = "1.44.3";
 const HTTP_REGEX = /^http(s?):\/\//;
 const PACT_DEFAULT_LOCATION = `https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_STANDALONE_VERSION}/`;
 let PACT_BINARY_LOCATION = PACT_DEFAULT_LOCATION;

--- a/test/integration/me-they-weird path-success.json
+++ b/test/integration/me-they-weird path-success.json
@@ -1,0 +1,28 @@
+{
+  "consumer": {
+    "name": "me"
+  },
+  "provider": {
+    "name": "they"
+  },
+  "interactions": [
+    {
+      "description": "Greeting",
+      "request": {
+        "method": "GET",
+        "path": "/"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "greeting": "Hello"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecificationVersion": "2.0.0"
+  }
+}

--- a/test/integration/publish-verification-example weird path-success.json
+++ b/test/integration/publish-verification-example weird path-success.json
@@ -1,0 +1,83 @@
+{
+	"consumer": {
+		"name": "me"
+	},
+	"provider": {
+		"name": "they"
+	},
+	"interactions": [
+		{
+			"description": "Greeting",
+			"request": {
+				"method": "GET",
+				"path": "/"
+			},
+			"response": {
+				"status": 200,
+				"headers": {},
+				"body": {
+					"greeting": "Hello"
+				}
+			}
+		}
+	],
+	"metadata": {
+		"pactSpecificationVersion": "2.0.0"
+	},
+	"createdAt": "2017-05-08T22:56:48+00:00",
+	"_links": {
+		"self": {
+			"title": "Pact",
+			"name": "Pact between me (v1.0.0) and they",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/version/1.0.0"
+		},
+		"pb:consumer": {
+			"title": "Consumer",
+			"name": "me",
+			"href": "http://localhost:9123/pacticipants/me"
+		},
+		"pb:provider": {
+			"title": "Provider",
+			"name": "they",
+			"href": "http://localhost:9123/pacticipants/they"
+		},
+		"pb:latest-pact-version": {
+			"title": "Pact",
+			"name": "Latest version of this pact",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/latest"
+		},
+		"pb:previous-distinct": {
+			"title": "Pact",
+			"name": "Previous distinct version of this pact",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct"
+		},
+		"pb:diff-previous-distinct": {
+			"title": "Diff",
+			"name": "Diff with previous distinct version of this pact",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct"
+		},
+		"pb:pact-webhooks": {
+			"title": "Webhooks for the pact between me and they",
+			"href": "http://localhost:9123/webhooks/provider/they/consumer/me"
+		},
+		"pb:tag-prod-version": {
+			"title": "Tag this version as 'production'",
+			"href": "http://localhost:9123/pacticipants/me/versions/1.0.0/tags/prod"
+		},
+		"pb:tag-version": {
+			"title": "Tag version",
+			"href": "http://localhost:9123/pacticipants/me/versions/1.0.0/tags/{tag}"
+		},
+		"pb:publish-verification-results": {
+			"title": "Publish verification results",
+			"href": "http://localhost:9123/pacts/provider/they/consumer/me/pact-version/618bea2e1221b48d59f4330e3788cdd8d196a8de/verification-results"
+		},
+		"curies": [
+			{
+				"name": "pb",
+				"href": "http://localhost:9123/doc/{rel}",
+				"templated": true
+			}
+		]
+	}
+}

--- a/test/verifier.integration.spec.ts
+++ b/test/verifier.integration.spec.ts
@@ -25,171 +25,210 @@ describe("Verifier Integration Spec", () => {
 	after(() => server.close());
 
 	context("when given a successful contract", () => {
+		context("with spaces in the file path", () => {
+			it("should return a successful promise", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/me-they-weird path-success.json")]
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
+		});
+
 		context("without provider states", () => {
-			it("should return a successful promise", () => {
-				const verifier = verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/me-they-success.json")]
-				});
-				return expect(verifier.verify()).to.eventually.be.fulfilled;
-			});
+			it("should return a successful promise", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/me-they-success.json")]
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
 		});
 
 		context("with Provider States", () => {
-			it("should return a successful promise", () => {
-				const verifier = verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/me-they-states.json")],
-					providerStatesSetupUrl: providerStatesSetupUrl
-				});
-				return expect(verifier.verify()).to.eventually.be.fulfilled;
-			});
+			it("should return a successful promise", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/me-they-states.json")],
+						providerStatesSetupUrl: providerStatesSetupUrl
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
 		});
 
 		context("with POST data", () => {
-			it("should return a successful promise", () => {
-				const verifier = verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/me-they-post-success.json")]
-				});
-				return expect(verifier.verify()).to.eventually.be.fulfilled;
-			});
+			it("should return a successful promise", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/me-they-post-success.json")]
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
 		});
 
 		context("with POST data and regex validation", () => {
-			it("should return a successful promise", () => {
-				const verifier = verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/me-they-post-regex-success.json")]
-				});
-				return expect(verifier.verify()).to.eventually.be.fulfilled;
-			});
+			it("should return a successful promise", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/me-they-post-regex-success.json")]
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
 		});
 
 		context("with monkeypatch file specified", () => {
-			it("should return a successful promise", () => {
-				const verifier = verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/me-they-success.json")],
-					monkeypatch: monkeypatchFile
-				});
-				return expect(verifier.verify()).to.eventually.be.fulfilled;
-			});
+			it("should return a successful promise", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/me-they-success.json")],
+						monkeypatch: monkeypatchFile
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
 		});
 	});
 
 	context("when given a failing contract", () => {
-		it("should return a rejected promise", () => {
-			const verifier = verifierFactory({
-				providerBaseUrl: providerBaseUrl,
-				pactUrls: [path.resolve(__dirname, "integration/me-they-fail.json")]
-			});
-			return expect(verifier.verify()).to.eventually.be.rejected;
-		});
+		it("should return a rejected promise", () =>
+			expect(
+				verifierFactory({
+					providerBaseUrl: providerBaseUrl,
+					pactUrls: [path.resolve(__dirname, "integration/me-they-fail.json")]
+				}).verify()
+			).to.eventually.be.rejected
+		);
 	});
 
 	context("when given multiple successful API calls in a contract", () => {
-		it("should return a successful promise", () => {
-			const verifier = verifierFactory({
-				providerBaseUrl: providerBaseUrl,
-				pactUrls: [path.resolve(__dirname, "integration/me-they-multi.json")],
-				providerStatesSetupUrl: providerStatesSetupUrl
-			});
-			return expect(verifier.verify()).to.eventually.be.fulfilled;
-		});
+		it("should return a successful promise", () =>
+			expect(
+				verifierFactory({
+					providerBaseUrl: providerBaseUrl,
+					pactUrls: [path.resolve(__dirname, "integration/me-they-multi.json")],
+					providerStatesSetupUrl: providerStatesSetupUrl
+				}).verify()
+			).to.eventually.be.fulfilled
+		);
 	});
 
 	context("when given multiple contracts", () => {
 		context("from a local file", () => {
-			it("should return a successful promise", () => {
-				const verifier = verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/me-they-success.json"), path.resolve(__dirname, "integration/me-they-multi.json")],
-					providerStatesSetupUrl: providerStatesSetupUrl
-				});
-				return expect(verifier.verify()).to.eventually.be.fulfilled;
-			});
+			it("should return a successful promise", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/me-they-success.json"), path.resolve(__dirname, "integration/me-they-multi.json")],
+						providerStatesSetupUrl: providerStatesSetupUrl
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
 		});
 
 		context("from a Pact Broker", () => {
 			context("without authentication", () => {
-				it("should return a successful promise", () => {
-					const verifier = verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [`${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/me/latest`,
-						`${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/anotherclient/latest`],
-						providerStatesSetupUrl: providerStatesSetupUrl
-					});
-					return expect(verifier.verify()).to.eventually.be.fulfilled;
-				});
+				it("should return a successful promise", () =>
+					expect(
+						verifierFactory({
+							providerBaseUrl: providerBaseUrl,
+							pactUrls: [`${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/me/latest`,
+								`${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/anotherclient/latest`],
+							providerStatesSetupUrl: providerStatesSetupUrl
+						}).verify()
+					).to.eventually.be.fulfilled
+				);
 			});
 
 			context("with authentication", () => {
 				context("and a valid user/password", () => {
-					it("should return a successful promise", () => {
-						const verifier = verifierFactory({
-							providerBaseUrl: providerBaseUrl,
-							pactUrls: [`${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`, `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`],
-							providerStatesSetupUrl: providerStatesSetupUrl,
-							pactBrokerUsername: "foo",
-							pactBrokerPassword: "bar"
-						});
-						return expect(verifier.verify()).to.eventually.be.fulfilled;
-					});
+					it("should return a successful promise", () =>
+						expect(
+							verifierFactory({
+								providerBaseUrl: providerBaseUrl,
+								pactUrls: [`${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`, `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`],
+								providerStatesSetupUrl: providerStatesSetupUrl,
+								pactBrokerUsername: "foo",
+								pactBrokerPassword: "bar"
+							}).verify()
+						).to.eventually.be.fulfilled
+					);
 				});
 
 				context("and an invalid user/password", () => {
-					it("should return a rejected promise", () => {
-						const verifier = verifierFactory({
-							providerBaseUrl: providerBaseUrl,
-							pactUrls: [`${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`, `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`],
-							providerStatesSetupUrl: providerStatesSetupUrl,
-							pactBrokerUsername: "foo",
-							pactBrokerPassword: "baaoeur"
-						});
-						return expect(verifier.verify()).to.eventually.be.rejected;
-					});
+					it("should return a rejected promise", () =>
+						expect(
+							verifierFactory({
+								providerBaseUrl: providerBaseUrl,
+								pactUrls: [`${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`, `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`],
+								providerStatesSetupUrl: providerStatesSetupUrl,
+								pactBrokerUsername: "foo",
+								pactBrokerPassword: "baaoeur"
+							}).verify()
+						).to.eventually.be.rejected
+					);
 
-					it("should return the verifier error output in the returned promise", () => {
-						const verifier = verifierFactory({
-							providerBaseUrl: providerBaseUrl,
-							pactUrls: [`${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`, `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`],
-							providerStatesSetupUrl: providerStatesSetupUrl,
-							pactBrokerUsername: "foo",
-							pactBrokerPassword: "baaoeur"
-						});
-						return expect(verifier.verify()).to.eventually.be.rejected;
-					});
+					it("should return the verifier error output in the returned promise", () =>
+						expect(
+							verifierFactory({
+								providerBaseUrl: providerBaseUrl,
+								pactUrls: [`${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`, `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`],
+								providerStatesSetupUrl: providerStatesSetupUrl,
+								pactBrokerUsername: "foo",
+								pactBrokerPassword: "baaoeur"
+							}).verify()
+						).to.eventually.be.rejected
+					);
 				});
 			});
 		});
 	});
 
 	context("when publishing verification results to a Pact Broker", () => {
+		context("and there is a valid Pact file with spaces in the path", () => {
+			it("should return a successful promise", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/publish-verification-example weird path-success.json")],
+						providerStatesSetupUrl: providerStatesSetupUrl,
+						publishVerificationResult: true,
+						providerVersion: "1.0.0"
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
+		});
+
 		context("and there is a valid verification HAL link in the Pact file", () => {
-			it("should return a successful promise", () => {
-				const verifier = verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/publish-verification-example-success.json")],
-					providerStatesSetupUrl: providerStatesSetupUrl,
-					publishVerificationResult: true,
-					providerVersion: "1.0.0"
-				});
-				return expect(verifier.verify()).to.eventually.be.fulfilled;
-			});
+			it("should return a successful promise", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/publish-verification-example-success.json")],
+						providerStatesSetupUrl: providerStatesSetupUrl,
+						publishVerificationResult: true,
+						providerVersion: "1.0.0"
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
 		});
 
 		context("and there is an invalid verification HAL link in the Pact file", () => {
-			it("should fail with an error", () => {
-				const verifier = verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/publish-verification-example-fail.json")],
-					providerStatesSetupUrl: providerStatesSetupUrl,
-					publishVerificationResult: true,
-					providerVersion: "1.0.0"
-				});
-				return expect(verifier.verify()).to.eventually.be.fulfilled;
-			});
+			it("should fail with an error", () =>
+				expect(
+					verifierFactory({
+						providerBaseUrl: providerBaseUrl,
+						pactUrls: [path.resolve(__dirname, "integration/publish-verification-example-fail.json")],
+						providerStatesSetupUrl: providerStatesSetupUrl,
+						publishVerificationResult: true,
+						providerVersion: "1.0.0"
+					}).verify()
+				).to.eventually.be.fulfilled
+			);
 		});
 	});
 });


### PR DESCRIPTION
Had to fix pact-support and the .bat wrappers in pact-ruby-standalone so that it can support spaces in paths when on windows.