### PR TITLE
fix(windows-long-path): Checking if Windows has long path enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ An idiomatic Node interface for the [Pact](http://pact.io) mock service (Consume
             -   [Create Message Pacts](#create-message-pacts)
                 -   [Example](#example)
                 -   [Example CLI invocation:](#example-cli-invocation)
+    -   [Windows Issues](#windows-issues)
     -   [Contributing](#contributing)
     -   [Testing](#testing)
     -   [Questions?](#questions)
@@ -361,6 +362,12 @@ node ./bin/pact-cli.js message --pact-file-write-mode update --consumer foo --pr
   }
 }'
 ```
+
+## Windows Issues
+
+### Enable Long Paths
+
+[Windows has a default path length limit of 260](https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation) causing issues with projects that are nested deep inside several directory and with how npm handles node_modules directory structures.  To fix this issue, please enable Windows Long Paths in the registry by running `regedit.exe`, find the key `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled` and change the value from `0` to `1`, then reboot your computer.  Pact should now work as it should, if not, please [raise an issue on github](https://github.com/pact-foundation/pact-node/issues).
 
 ## Contributing
 

--- a/bin/pact-cli.spec.ts
+++ b/bin/pact-cli.spec.ts
@@ -5,6 +5,7 @@ import q = require("q");
 import path = require("path");
 import {ChildProcess} from "child_process";
 import {ServerOptions} from "../src/server";
+import util from "../src/pact-util";
 import providerMock from "../test/integration/provider-mock";
 import brokerMock from "../test/integration/broker-mock";
 import * as http from "http";
@@ -14,7 +15,6 @@ const _ = require("underscore");
 
 const request = q.denodeify(require("request"));
 const pkg = require("../package.json");
-const isWindows = process.platform === "win32";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
@@ -142,11 +142,11 @@ class CLI {
 	public static run(args: string[] = []): q.Promise<CLI> {
 		const opts = {
 			cwd: __dirname,
-			detached: !isWindows,
-			windowsVerbatimArguments: isWindows
+			detached: !util.isWindows(),
+			windowsVerbatimArguments: util.isWindows()
 		};
 		args = [this.__cliPath].concat(args);
-		if(isWindows) {
+		if(util.isWindows()) {
 			args = args.map((v) => `"${v}"`);
 		}
 		const proc = childProcess.spawn("node", args, opts);
@@ -179,7 +179,7 @@ class CLI {
 
 	public static stopAll() {
 		for (let child of this.__children) {
-			isWindows ? childProcess.execSync(`taskkill /f /t /pid ${child.pid}`) : process.kill(-child.pid, "SIGINT");
+			util.isWindows() ? childProcess.execSync(`taskkill /f /t /pid ${child.pid}`) : process.kill(-child.pid, "SIGINT");
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pact-foundation/pact-node",
-  "version": "6.19.6",
+  "version": "6.19.7",
   "description": "A wrapper for the Ruby version of Pact to work within Node",
   "main": "src/index.js",
   "homepage": "https://github.com/pact-foundation/pact-node#readme",
@@ -46,7 +46,9 @@
   },
   "dependencies": {
     "@types/bunyan": "1.8.2",
+    "@types/mkdirp": "^0.5.2",
     "@types/q": "1.0.7",
+    "@types/rimraf": "^2.0.2",
     "bunyan": "1.8.12",
     "bunyan-prettystream": "0.1.3",
     "caporal": "0.10.0",
@@ -56,6 +58,7 @@
     "mkdirp": "0.5.1",
     "q": "1.5.1",
     "request": "2.83.0",
+    "rimraf": "2.6.2",
     "sumchecker": "^2.0.2",
     "tar": "4.4.0",
     "underscore": "1.8.3",
@@ -83,7 +86,6 @@
     "mocha-unfunk-reporter": "0.4.0",
     "nodemon": "1.17.1",
     "rewire": "3.0.2",
-    "rimraf": "2.6.2",
     "sinon": "4.4.2",
     "standard-version": "4.3.0",
     "ts-node": "5.0.0",

--- a/src/pact-standalone.spec.ts
+++ b/src/pact-standalone.spec.ts
@@ -4,10 +4,11 @@ import * as fs from "fs";
 import * as path from "path";
 import * as chai from "chai";
 import install from "../standalone/install";
+import util from "./pact-util";
 import {PactStandalone, standalone} from "./pact-standalone";
 
 const expect = chai.expect;
-const basePath = path.resolve(__dirname, "..");
+const basePath = util.cwd;
 
 // Needs to stay a function and not an arrow function to access mocha 'this' context
 describe("Pact Standalone", function() {

--- a/src/pact-standalone.ts
+++ b/src/pact-standalone.ts
@@ -1,8 +1,6 @@
 import * as path from "path";
 import {getBinaryEntry} from "../standalone/install";
-import util from "../src/pact-util";
-
-const cwd = path.resolve(__dirname, "..");
+import util from "./pact-util";
 
 export interface PactStandalone {
 	cwd: string;
@@ -21,7 +19,7 @@ export interface PactStandalone {
 export const standalone = (platform?: string, arch?: string): PactStandalone => {
 	platform = platform || process.platform;
 	arch = arch || process.arch;
-	const binName = (name: string) => `${name}${util.isWindows(platform) ? ".bat" : ""}`;
+	const binName = (name: string)  => `${name}${util.isWindows(platform) ? ".bat" : ""}`;
 	const mock = binName("pact-mock-service");
 	const message = binName("pact-message");
 	const verify = binName("pact-provider-verifier");
@@ -30,17 +28,17 @@ export const standalone = (platform?: string, arch?: string): PactStandalone => 
 	const basePath = path.join("standalone", getBinaryEntry(platform, arch).folderName, "bin");
 
 	return {
-		cwd: cwd,
+		cwd: util.cwd,
 		brokerPath: path.join(basePath, broker),
-		brokerFullPath: path.resolve(cwd, basePath, broker).trim(),
+		brokerFullPath: path.resolve(util.cwd, basePath, broker).trim(),
 		messagePath: path.join(basePath, message),
-		messageFullPath: path.resolve(cwd, basePath, message).trim(),
+		messageFullPath: path.resolve(util.cwd, basePath, message).trim(),
 		mockServicePath: path.join(basePath, mock),
-		mockServiceFullPath: path.resolve(cwd, basePath, mock).trim(),
+		mockServiceFullPath: path.resolve(util.cwd, basePath, mock).trim(),
 		stubPath: path.join(basePath, stub),
-		stubFullPath: path.resolve(cwd, basePath, stub).trim(),
+		stubFullPath: path.resolve(util.cwd, basePath, stub).trim(),
 		verifierPath: path.join(basePath, verify),
-		verifierFullPath: path.resolve(cwd, basePath, verify).trim()
+		verifierFullPath: path.resolve(util.cwd, basePath, verify).trim()
 	};
 };
 

--- a/src/pact-standalone.ts
+++ b/src/pact-standalone.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import {getBinaryEntry} from "../standalone/install";
+import util from "../src/pact-util";
 
 const cwd = path.resolve(__dirname, "..");
 
@@ -20,7 +21,7 @@ export interface PactStandalone {
 export const standalone = (platform?: string, arch?: string): PactStandalone => {
 	platform = platform || process.platform;
 	arch = arch || process.arch;
-	const binName = (name: string) => `${name}${platform === "win32" ? ".bat" : ""}`;
+	const binName = (name: string) => `${name}${util.isWindows(platform) ? ".bat" : ""}`;
 	const mock = binName("pact-mock-service");
 	const message = binName("pact-message");
 	const verify = binName("pact-provider-verifier");

--- a/src/pact-util.ts
+++ b/src/pact-util.ts
@@ -3,10 +3,9 @@ import cp = require("child_process");
 import logger from "./logger";
 import pactStandalone from "./pact-standalone";
 import {ChildProcess, SpawnOptions} from "child_process";
+
 const _ = require("underscore");
 const checkTypes = require("check-types");
-
-const isWindows = process.platform === "win32";
 
 export const DEFAULT_ARG = "DEFAULT";
 
@@ -40,14 +39,14 @@ export class PactUtil {
 		let file: string;
 		let opts: SpawnOptions = {
 			cwd: pactStandalone.cwd,
-			detached: !isWindows,
+			detached: !this.isWindows(),
 			env: envVars
 		};
 
 		let cmd: string = [command].concat(this.createArguments(args, argMapping)).join(" ");
 
 		let spawnArgs: string[];
-		if (isWindows) {
+		if (this.isWindows()) {
 			file = "cmd.exe";
 			spawnArgs = ["/s", "/c", cmd];
 			(opts as any).windowsVerbatimArguments = true;
@@ -82,12 +81,16 @@ export class PactUtil {
 			binary.removeAllListeners();
 			// Killing instance, since windows can't send signals, must kill process forcefully
 			try {
-				isWindows ? cp.execSync(`taskkill /f /t /pid ${pid}`) : process.kill(-pid, "SIGINT");
+				this.isWindows() ? cp.execSync(`taskkill /f /t /pid ${pid}`) : process.kill(-pid, "SIGINT");
 			} catch (e) {
 				return false;
 			}
 		}
 		return true;
+	}
+
+	public isWindows(platform: string = process.platform): boolean {
+		return platform === "win32";
 	}
 }
 

--- a/src/pact-util.ts
+++ b/src/pact-util.ts
@@ -1,8 +1,8 @@
 // tslint:disable:no-string-literal
 import cp = require("child_process");
 import logger from "./logger";
-import pactStandalone from "./pact-standalone";
 import {ChildProcess, SpawnOptions} from "child_process";
+import * as path from "path";
 
 const _ = require("underscore");
 const checkTypes = require("check-types");
@@ -10,6 +10,10 @@ const checkTypes = require("check-types");
 export const DEFAULT_ARG = "DEFAULT";
 
 export class PactUtil {
+	public get cwd():string {
+		return path.resolve(__dirname, "..");
+	}
+
 	public createArguments(args: SpawnArguments, mappings: { [id: string]: string }): string[] {
 		return _.chain(args)
 			.reduce((acc: any, value: any, key: any) => {
@@ -38,7 +42,7 @@ export class PactUtil {
 
 		let file: string;
 		let opts: SpawnOptions = {
-			cwd: pactStandalone.cwd,
+			cwd: this.cwd,
 			detached: !this.isWindows(),
 			env: envVars
 		};

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -1,9 +1,12 @@
+import * as fs from "fs";
 import * as q from "q";
+import * as path from "path";
 import serverFactory, {Server, ServerOptions} from "./server";
 import stubFactory, {Stub, StubOptions} from "./stub";
 import verifierFactory, {VerifierOptions} from "./verifier";
 import messageFactory, {MessageOptions} from "./message";
 import publisherFactory, {PublisherOptions} from "./publisher";
+import util from "./pact-util";
 import logger, {LogLevels} from "./logger";
 import {AbstractService} from "./service";
 import * as _ from "underscore";
@@ -13,6 +16,23 @@ export class Pact {
 	private __stubs: Stub[] = [];
 
 	constructor() {
+		// Check to see if we hit into Windows Long Path issue
+		if(util.isWindows()) {
+			try {
+				// Trying to trigger windows error by creating path that's over 260 characters long
+				const dir = path.resolve(
+					__dirname,
+					"Jctyo0NXwbPN6Y1o8p2TkicKma2kfqmXwVLw6ypBX47uktBPX9FM9kbPraQXsAUZuT6BvenTbnWczXzuN4js0KB9e7P5cccxvmXPYcFhJnBvPSKGH1FlTqEOsjl8djk3md",
+					"c8T65S510U5v8HCQNjwUprjAYrZNfmBXuRc4Ufc7xaSuZaYEeqQ8Maf5qJpgmWbXJkWKfAUmlwf7h1V4nzLtbrBnhpoZY7xzyoxIvUquRSQWts92218ZPm9k9bfJdfj3ki"
+				);
+				fs.mkdirSync(dir);
+				fs.rmdirSync(dir);
+			} catch {
+				logger.warn(`WARNING: Windows Long Paths is not enabled and might cause Pact to crash. 
+				To fix this issue, please consult https://github.com/pact-foundation/pact-node#enable-long-paths`);
+			}
+		}
+
 		// Listen for Node exiting or someone killing the process
 		// Must remove all the instances of Pact mock service
 		process.once("exit", () => this.removeAll());

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs";
 import * as q from "q";
 import * as path from "path";
 import serverFactory, {Server, ServerOptions} from "./server";
@@ -10,6 +9,8 @@ import util from "./pact-util";
 import logger, {LogLevels} from "./logger";
 import {AbstractService} from "./service";
 import * as _ from "underscore";
+import * as mkdirp from "mkdirp";
+import * as rimraf from "rimraf";
 
 export class Pact {
 	private __servers: Server[] = [];
@@ -20,16 +21,12 @@ export class Pact {
 		if(util.isWindows()) {
 			try {
 				// Trying to trigger windows error by creating path that's over 260 characters long
-				const dir = path.resolve(
-					__dirname,
-					"Jctyo0NXwbPN6Y1o8p2TkicKma2kfqmXwVLw6ypBX47uktBPX9FM9kbPraQXsAUZuT6BvenTbnWczXzuN4js0KB9e7P5cccxvmXPYcFhJnBvPSKGH1FlTqEOsjl8djk3md",
-					"c8T65S510U5v8HCQNjwUprjAYrZNfmBXuRc4Ufc7xaSuZaYEeqQ8Maf5qJpgmWbXJkWKfAUmlwf7h1V4nzLtbrBnhpoZY7xzyoxIvUquRSQWts92218ZPm9k9bfJdfj3ki"
-				);
-				fs.mkdirSync(dir);
-				fs.rmdirSync(dir);
+				const name = "Jctyo0NXwbPN6Y1o8p2TkicKma2kfqmXwVLw6ypBX47uktBPX9FM9kbPraQXsAUZuT6BvenTbnWczXzuN4js0KB9e7P5cccxvmXPYcFhJnBvPSKGH1FlTqEOsjl8djk3md";
+				const dir = mkdirp.sync(path.resolve(__dirname, name, name));
+				dir && rimraf.sync(dir);
 			} catch {
-				logger.warn(`WARNING: Windows Long Paths is not enabled and might cause Pact to crash. 
-				To fix this issue, please consult https://github.com/pact-foundation/pact-node#enable-long-paths`);
+				logger.warn("WARNING: Windows Long Paths is not enabled and might cause Pact to crash if the path is too long. " +
+					"To fix this issue, please consult https://github.com/pact-foundation/pact-node#enable-long-paths`");
 			}
 		}
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -121,14 +121,14 @@ export abstract class AbstractService extends events.EventEmitter {
 				if (match && match[1]) {
 					this.options.port = parseInt(match[1], 10);
 					this.__instance.stdout.removeListener("data", catchPort);
-					this.__instance.stderr.removeListener("data", catchPort);
 					logger.info(`Pact running on port ${this.options.port}`);
 				}
 			};
 
 			this.__instance.stdout.on("data", catchPort);
-			this.__instance.stderr.on("data", catchPort);
 		}
+
+		this.__instance.stderr.on("data", (data:any) => logger.error(`Pact Binary Error: ${data}`));
 
 		// check service is available
 		return this.__waitForServiceUp()

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -1,5 +1,6 @@
 import * as http from "http";
 import * as request from "request";
+import util from "../src/pact-util";
 
 const path = require("path");
 const fs = require("fs");
@@ -10,7 +11,7 @@ const chalk = require("chalk");
 const sumchecker = require("sumchecker");
 
 // Get latest version from https://github.com/pact-foundation/pact-ruby-standalone/releases
-export const PACT_STANDALONE_VERSION = "1.52.1";
+export const PACT_STANDALONE_VERSION = "1.52.2";
 const PACT_DEFAULT_LOCATION = `https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_STANDALONE_VERSION}/`;
 const HTTP_REGEX = /^http(s?):\/\//;
 const CONFIG = createConfig();
@@ -192,7 +193,7 @@ function extract(data: Data): Promise<void> {
 			() => Promise.reject(`Checksum rejected for file '${basename}' with checksum ${path.basename(data.checksumFilepath)}`)
 		)
 		// Extract files into their platform folder
-		.then(() => data.isWindows ?
+		.then(() => util.isWindows() ?
 			decompress(data.filepath, data.platformFolderPath, {strip: 1}) :
 			tar.x({
 				file: data.filepath,
@@ -203,7 +204,7 @@ function extract(data: Data): Promise<void> {
 		)
 		.then(() => {
 			// Remove pact-publish as it's getting deprecated
-			const publishPath = path.resolve(data.platformFolderPath, "bin", `pact-publish${data.isWindows ? ".bat" : ""}`);
+			const publishPath = path.resolve(data.platformFolderPath, "bin", `pact-publish${util.isWindows() ? ".bat" : ""}`);
 			if (fs.existsSync(publishPath)) {
 				fs.unlinkSync(publishPath);
 			}
@@ -233,7 +234,6 @@ function setup(platform?: string, arch?: string): Promise<Data> {
 		checksumFilepath: path.resolve(__dirname, entry.binaryChecksum),
 		platform: entry.platform,
 		arch: entry.arch,
-		isWindows: "win32" === entry.platform,
 		platformFolderPath: path.resolve(__dirname, entry.folderName)
 	});
 }
@@ -326,7 +326,6 @@ export interface Data {
 	checksumFilepath: string;
 	platform: string;
 	arch?: string;
-	isWindows: boolean;
 	platformFolderPath?: string;
 }
 

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -193,7 +193,7 @@ function extract(data: Data): Promise<void> {
 			() => Promise.reject(`Checksum rejected for file '${basename}' with checksum ${path.basename(data.checksumFilepath)}`)
 		)
 		// Extract files into their platform folder
-		.then(() => util.isWindows() ?
+		.then(() => data.isWindows ?
 			decompress(data.filepath, data.platformFolderPath, {strip: 1}) :
 			tar.x({
 				file: data.filepath,
@@ -232,6 +232,7 @@ function setup(platform?: string, arch?: string): Promise<Data> {
 		checksumDownloadPath: join(PACT_DEFAULT_LOCATION, entry.binaryChecksum),
 		filepath: path.resolve(__dirname, entry.binary),
 		checksumFilepath: path.resolve(__dirname, entry.binaryChecksum),
+		isWindows: util.isWindows(platform),
 		platform: entry.platform,
 		arch: entry.arch,
 		platformFolderPath: path.resolve(__dirname, entry.folderName)
@@ -325,6 +326,7 @@ export interface Data {
 	filepath: string;
 	checksumFilepath: string;
 	platform: string;
+	isWindows: boolean;
 	arch?: string;
 	platformFolderPath?: string;
 }


### PR DESCRIPTION
Showing a warning with a way to fix the situation if not.  The check involves creating a directory path that's longer than 260 characters to see if that crashes, if it does, show a warning to the user, if not, Windows is good to go.