### PR TITLE
chore(scripts): put watch script back

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "pretest": "npm run build && npm run download-checksums && npm run install:current",
     "test": "cross-env LOGLEVEL=debug PACT_DO_NOT_TRACK=true mocha -r ts-node/register -R mocha-unfunk-reporter -t 15000 -s 5000 -b --check-leaks --exit \"{src,test,bin,standalone}/**/*.spec.ts\"",
     "dev": "npm run lint --force && npm test && node .",
+    "watch": "nodemon -e ts,json --ignore '**/*.d.ts' -x npm run dev",
     "build": "npm run clean && tsc",
     "start": "npm run watch",
     "download-checksums": "node download-checksums.js",


### PR DESCRIPTION
The readme says that `npm run watch` is the right way to start autorefreshing lint and test for development, but the script doesn't exist at the moment.

The `watch` script was removed a year ago in f304c5c261cfef58042cbf38ef25c4fb0a76c59f - but I can't see why, and it seems to still work. 

This PR puts it back, but if it were intentionally removed, we should reject this PR and instead update the documentation. I'm putting this PR up for review, because I'm not familiar with the history here.