### PR TITLE
Add can-i-deploy to API and CLI tool

### DIFF
--- a/bin/pact-cli.ts
+++ b/bin/pact-cli.ts
@@ -78,4 +78,19 @@ cli
 	.option("-t, --tags <tags>", "Comma separated list of tags to attach to the Pact Contracts being published", cli.LIST)
 	.action((args: any, options: any) => pact.publishPacts(options));
 
+cli
+	.command("can-i-deploy", "Check if you can deploy based on a Contract")
+	.option("-p, --pacticipant <paths>", "Comma separated list of Pact file or directory paths", cli.LIST, undefined, true)
+	.option("-v, --version <version>", "Version of the consumer, can be any string, but recommended to use a semantic version or git hash.", undefined, undefined, true)
+	.option("-l, --latest <paths>", "Comma separated list of Pact file or directory paths", cli.LIST, undefined, true)
+	.option("-t, --to <paths>", "Comma separated list of Pact file or directory paths", cli.LIST, undefined, true)
+	.option("-b, --pact-broker <URL>", "URL of the Pact Broker to publish pacts to.", undefined, undefined, true)
+	.option("-username, --pact-broker-username <user>", "Pact Broker username.")
+	.option("-password, --pact-broker-password <password>", "Pact Broker password.")
+	.option("-o, --output <output>", "Pact Broker password.")
+	.option("-vv, --verbose", "Pact Broker password.")
+	.option("--retry-while-unknown <times>", "Pact Broker password.")
+	.option("--retry-interval <seconds>", "Pact Broker password.")
+	.action((args: any, options: any) => pact.publishPacts(options));
+
 cli.parse(process.argv);

--- a/bin/pact-cli.ts
+++ b/bin/pact-cli.ts
@@ -79,18 +79,19 @@ cli
 	.action((args: any, options: any) => pact.publishPacts(options));
 
 cli
-	.command("can-i-deploy", "Check if you can deploy based on a Contract")
-	.option("-p, --pacticipant <paths>", "Comma separated list of Pact file or directory paths", cli.LIST, undefined, true)
-	.option("-v, --version <version>", "Version of the consumer, can be any string, but recommended to use a semantic version or git hash.", undefined, undefined, true)
-	.option("-l, --latest <paths>", "Comma separated list of Pact file or directory paths", cli.LIST, undefined, true)
-	.option("-t, --to <paths>", "Comma separated list of Pact file or directory paths", cli.LIST, undefined, true)
+	.command("can-i-deploy", "Check if pacticipants are safe to deploy together")
+	.option("-a, --pacticipants <pacticipants>", "Comma separated list of Pact file or directory paths", cli.LIST, undefined, true)
+	.option("-v, --versions <version>", "Versions of the pacticipants. Must be in the same order as the pacticipants list.", cli.LIST, undefined, true)
+	.option("-l, --latest", "Use the latest pacticipant version", cli.BOOL, undefined)
+	.option("-t, --to <tag>", "Pacticipant tags to check against", cli.LIST)
 	.option("-b, --pact-broker <URL>", "URL of the Pact Broker to publish pacts to.", undefined, undefined, true)
 	.option("-username, --pact-broker-username <user>", "Pact Broker username.")
 	.option("-password, --pact-broker-password <password>", "Pact Broker password.")
-	.option("-o, --output <output>", "Pact Broker password.")
-	.option("-vv, --verbose", "Pact Broker password.")
-	.option("--retry-while-unknown <times>", "Pact Broker password.")
-	.option("--retry-interval <seconds>", "Pact Broker password.")
-	.action((args: any, options: any) => pact.publishPacts(options));
+	.option("-o, --output <output>", "json or table.")
+	.option("-v, --verbose", "Verbose output.")
+	.option("--retry-while-unknown <times>",
+		"The number of times to retry while there is an unknown verification result (ie. the provider verification is likely still running).")
+	.option("--retry-interval <seconds>", "The time between retries in seconds. Use in conjuction with --retry-while-unknown.")
+	.action((args: any, options: any) => pact.canDeploy(options));
 
 cli.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pact-foundation/pact-node",
-  "version": "6.19.4",
+  "version": "6.20.0",
   "description": "A wrapper for the Ruby version of Pact to work within Node",
   "main": "src/index.js",
   "homepage": "https://github.com/pact-foundation/pact-node#readme",

--- a/src/can-deploy.spec.ts
+++ b/src/can-deploy.spec.ts
@@ -1,0 +1,136 @@
+// tslint:disable:no-string-literal
+
+import path = require("path");
+import fs = require("fs");
+import chai = require("chai");
+import chaiAsPromised = require("chai-as-promised");
+import canDeployFactory, {CanDeployOptions, CanDeploy} from "./can-deploy";
+import {SpawnArguments} from "./pact-util";
+import logger from "./logger";
+import brokerMock from "../test/integration/broker-mock";
+import * as http from "http";
+
+const rimraf = require("rimraf");
+const mkdirp = require("mkdirp");
+const expect = chai.expect;
+chai.use(chaiAsPromised);
+
+describe("CanDeploy Spec", () => {
+
+	const PORT = Math.floor(Math.random() * 999) + 9000;
+	let server: http.Server;
+	let absolutePath: string;
+	let relativePath: string;
+
+	before(() => brokerMock(PORT).then((s) => {
+		logger.debug(`Pact Broker Mock listening on port: ${PORT}`);
+		server = s;
+	}));
+
+	after(() => server.close());
+
+	beforeEach(() => {
+		relativePath = `.tmp/${Math.floor(Math.random() * 1000)}`;
+		absolutePath = path.resolve(__dirname, "..", relativePath);
+		mkdirp.sync(absolutePath);
+	});
+
+	afterEach(() => {
+		if (fs.existsSync(absolutePath)) {
+			rimraf.sync(absolutePath);
+		}
+	});
+
+	describe("convertForSpawnBinary helper function",() => {
+		let result : SpawnArguments[];
+
+		beforeEach(() => {
+			result = CanDeploy.convertForSpawnBinary(
+				{
+					pacticipants: ["one","two"],
+					versions: ["v1","v2"],
+					pactBroker: "some broker",
+					pactBrokerUsername: "username",
+					pactBrokerPassword: "password",
+			});
+		});
+
+		it("produces an array of SpawnArguments", ()=> {
+			expect(result).to.be.an("array");
+		});
+
+		it("has versions and pacticipants in the right order", ()=> {
+			expect(result).to.eql(
+				[
+					{pacticipant: "one"},
+					{version: "v1"},
+					{pacticipant: "two"},
+					{version:"v2"},
+					{
+						pactBroker: "some broker",
+						pactBrokerUsername: "username",
+						pactBrokerPassword: "password",
+					}
+				]);
+		});
+	});
+
+	context("when invalid options are set", () => {
+		it("should fail with an Error when not given pactBroker", () => {
+			expect(() => {
+				canDeployFactory({
+				} as CanDeployOptions);
+			}).to.throw(Error);
+		});
+
+		it("should fail with an Error when not given pacticipants", () => {
+			expect(() => {
+				canDeployFactory({
+					pactBroker: "http://localhost",
+					versions: ["v1"],
+				} as CanDeployOptions);
+			}).to.throw(Error);
+		});
+
+		it("should fail with an Error when not given versions", () => {
+			expect(() => {
+				canDeployFactory({
+					pactBroker: "http://localhost",
+					pacticipants: ["p1","p2"]
+				} as CanDeployOptions);
+			}).to.throw(Error);
+		});
+
+		it("should fail with an error when not given equal numbers of versions and pacticipants", () => {
+			expect(() => {
+				canDeployFactory({
+					pactBroker: "http://localhost",
+					versions: ["v1"],
+					pacticipants: ["p1","p2"]
+				} as CanDeployOptions);
+			}).to.throw(Error);
+		});
+
+		it("should fail with an error when versions and paticipants are empty", () => {
+			expect(() => {
+				canDeployFactory({
+					pactBroker: "http://localhost",
+					versions: [],
+					pacticipants: []
+				} as CanDeployOptions);
+			}).to.throw(Error);
+		});
+	});
+
+	context("when valid options are set", () => {
+		it("should return a CanDeploy object when given the correct arguments", () => {
+			const c = canDeployFactory({
+				pactBroker: "http://localhost",
+				versions: ["v1","v2"],
+				pacticipants: ["p1","p2"]
+			});
+			expect(c).to.be.ok;
+			expect(c.canDeploy).to.be.a("function");
+		});
+	});
+});

--- a/src/can-deploy.ts
+++ b/src/can-deploy.ts
@@ -1,0 +1,105 @@
+import q = require("q");
+import logger from "./logger";
+import pactUtil, {SpawnArguments} from "./pact-util";
+import {deprecate} from "util";
+import pactStandalone from "./pact-standalone";
+const _ = require("underscore");
+const checkTypes = require("check-types");
+
+export class CanDeploy {
+	public static create = deprecate(
+		(options: CanDeployOptions) => new CanDeploy(options),
+		"Create function will be removed in future release, please use the default export function or use `new CanDeploy()`");
+
+	public static convertForSpawnBinary(options: CanDeployOptions) {
+			return _.flatten(_.zip(
+				_.map(options.pacticipants, (x: string) => ({pacticipant: x})),
+				_.map(options.versions, (x: string) => ({version: x}))
+			)).concat(
+				[_.omit(options,"pacticipants","versions")]);
+	}
+
+	public readonly options: CanDeployOptions;
+	private readonly __argMapping = {
+		"pacticipant": "--pacticipant",
+		"version": "--version",
+		"latest": "--latest",
+		"to": "--to",
+		"pactBroker": "--broker-base-url",
+		"pactBrokerUsername": "--broker-username",
+		"pactBrokerPassword": "--broker-password",
+		"output": "--output",
+		"verbose": "--verbose",
+		"retryWhileUnknown": "--retry-while-unknown",
+		"retryInterval": "--retry-interval",
+	};
+
+	constructor(options: CanDeployOptions) {
+		options = options || {};
+		// Setting defaults
+		options.timeout = options.timeout || 60000;
+		options.pacticipants = options.pacticipants || [];
+		options.versions = options.versions || [];
+
+		checkTypes.assert.nonEmptyString(options.pactBroker, "Must provide the pactBroker argument");
+		checkTypes.assert.arrayLike(options.pacticipants, "Must provide the pacticipants argument");
+		checkTypes.assert.arrayLike(options.versions, "Must provide the versions argument");
+		checkTypes.assert.equal(options.pacticipants.length, options.versions.length, "Must provide the same number of pacticipants and versions");
+		checkTypes.assert.nonEmptyArray(options.pacticipants, "Pacticipants array must not be empty");
+		checkTypes.assert.nonEmptyArray(options.versions, "Versions array must not be empty");
+
+		if (options.pactBroker) {
+			checkTypes.assert.string(options.pactBroker);
+		}
+
+		if (options.pactBrokerUsername) {
+			checkTypes.assert.string(options.pactBrokerUsername);
+		}
+
+		if (options.pactBrokerPassword) {
+			checkTypes.assert.string(options.pactBrokerPassword);
+		}
+
+		if ((options.pactBrokerUsername && !options.pactBrokerPassword) || (options.pactBrokerPassword && !options.pactBrokerUsername)) {
+			throw new Error("Must provide both Pact Broker username and password. None needed if authentication on Broker is disabled.");
+		}
+
+		this.options = options;
+	}
+
+	public canDeploy(): q.Promise<string[]> {
+		logger.info(`Asking broker at ${this.options.pactBroker} if it is possible to deploy`);
+		const deferred = q.defer<string[]>();
+		const instance = pactUtil.spawnBinary(`${pactStandalone.brokerPath} can-i-deploy`, CanDeploy.convertForSpawnBinary(this.options), this.__argMapping);
+		const output: any[] = [];
+		instance.stdout.on("data", (l) => output.push(l));
+		instance.stderr.on("data", (l) => output.push(l));
+		instance.once("close", (code) => {
+			const o = output.join("\n");
+			const success = /All verification results are published and successful/igm.exec(o);
+			if (code !== 0 || !success) {
+				logger.error(`can-i-deploy did not return success message:\n${o}`);
+				return deferred.reject(new Error(o));
+			}
+
+			logger.info(o);
+			return deferred.resolve();
+		});
+
+		return deferred.promise
+			.timeout(this.options.timeout as number, `Timeout waiting for verification process to complete (PID: ${instance.pid})`);
+	}
+}
+
+export default (options: CanDeployOptions) => new CanDeploy(options);
+
+export interface CanDeployOptions extends SpawnArguments {
+	pacticipants: string[];
+	versions: string[];
+	pactBroker: string;
+	pactBrokerUsername?: string;
+	pactBrokerPassword?: string;
+	tags?: string[];
+	verbose?: boolean;
+	timeout?: number;
+}

--- a/src/pact-util.spec.ts
+++ b/src/pact-util.spec.ts
@@ -53,7 +53,15 @@ describe("Pact Util Spec", () => {
 			});
 			describe("with multiple elements",() => {
 				it("should wrap its argument values in quotes", () => {
-					const result = pactUtil.createArguments([{pacticipant: "one",},{version: "v1",},{pacticipant: "two",},{version: "v2",}], {version: "--version" ,pacticipant: "--pacticipant",});
+					const result = pactUtil.createArguments(
+						[
+							{pacticipant: "one"},
+							{version: "v1"},
+							{pacticipant: "two"},
+							{version: "v2"}
+						],
+						{version: "--version" ,pacticipant: "--pacticipant",}
+					);
 
 					expect(result).to.be.an("array");
 					expect(result).to.eql(
@@ -64,9 +72,9 @@ describe("Pact Util Spec", () => {
 						"--pacticipant",
 						"'two'",
 						"--version",
-						"'v2'"])
+						"'v2'"]);
 				});
-			})
+			});
 		});
 
 		it("should make DEFAULT values first, everything else after", () => {

--- a/src/pact-util.spec.ts
+++ b/src/pact-util.spec.ts
@@ -8,24 +8,65 @@ chai.use(chaiAsPromised);
 
 describe("Pact Util Spec", () => {
 	describe("createArguments", () => {
-		it("should return an array of all arguments", () => {
-			const result = pactUtil.createArguments({providerBaseUrl: "http://localhost",}, {providerBaseUrl: "--provider-base-url",});
-			expect(result).to.be.an("array").that.includes("--provider-base-url");
-			expect(result.length).to.be.equal(2);
-		});
-
-		it("should wrap its argument values in quotes", () => {
-			const result = pactUtil.createArguments({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["http://idontexist"]
-			}, {
-				providerBaseUrl: "--provider-base-url",
-				pactUrls: "--pact-urls"
+		describe("when called with an object", () => {
+			it("should return an array of all arguments", () => {
+				const result = pactUtil.createArguments({providerBaseUrl: "http://localhost",}, {providerBaseUrl: "--provider-base-url",});
+				expect(result).to.be.an("array").that.includes("--provider-base-url");
+				expect(result.length).to.be.equal(2);
 			});
-			expect(result).to.include("--provider-base-url");
-			expect(result).to.include("'http://localhost'");
-			expect(result).to.include("--pact-urls");
-			expect(result).to.include("'http://idontexist'");
+
+			it("should wrap its argument values in quotes", () => {
+				const result = pactUtil.createArguments({
+					providerBaseUrl: "http://localhost",
+					pactUrls: ["http://idontexist"]
+				}, {
+					providerBaseUrl: "--provider-base-url",
+					pactUrls: "--pact-urls"
+				});
+				expect(result).to.include("--provider-base-url");
+				expect(result).to.include("'http://localhost'");
+				expect(result).to.include("--pact-urls");
+				expect(result).to.include("'http://idontexist'");
+			});
+		});
+		describe("when called with an array", () => {
+			describe("with one element",() => {
+				it("should return an array of all arguments", () => {
+					const result = pactUtil.createArguments([{providerBaseUrl: "http://localhost",}], {providerBaseUrl: "--provider-base-url",});
+					expect(result).to.be.an("array").that.includes("--provider-base-url");
+					expect(result.length).to.be.equal(2);
+				});
+
+				it("should wrap its argument values in quotes", () => {
+					const result = pactUtil.createArguments([{
+						providerBaseUrl: "http://localhost",
+						pactUrls: ["http://idontexist"]
+					}], {
+						providerBaseUrl: "--provider-base-url",
+						pactUrls: "--pact-urls"
+					});
+					expect(result).to.include("--provider-base-url");
+					expect(result).to.include("'http://localhost'");
+					expect(result).to.include("--pact-urls");
+					expect(result).to.include("'http://idontexist'");
+				});
+			});
+			describe("with multiple elements",() => {
+				it("should wrap its argument values in quotes", () => {
+					const result = pactUtil.createArguments([{pacticipant: "one",},{version: "v1",},{pacticipant: "two",},{version: "v2",}], {version: "--version" ,pacticipant: "--pacticipant",});
+
+					expect(result).to.be.an("array");
+					expect(result).to.eql(
+						["--pacticipant",
+						"'one'",
+						"--version",
+						"'v1'",
+						"--pacticipant",
+						"'two'",
+						"--version",
+						"'v2'"])
+				});
+			})
 		});
 
 		it("should make DEFAULT values first, everything else after", () => {

--- a/src/pact-util.ts
+++ b/src/pact-util.ts
@@ -11,26 +11,32 @@ const isWindows = process.platform === "win32";
 export const DEFAULT_ARG = "DEFAULT";
 
 export class PactUtil {
-	public createArguments(args: SpawnArguments, mappings: { [id: string]: string }): string[] {
+	private static createArgumentsFromObject(args: SpawnArguments, mappings: { [id: string]: string }): string[] {
 		return _.chain(args)
-			.reduce((acc: any, value: any, key: any) => {
-				if (value && mappings[key]) {
-					let mapping = mappings[key];
-					let f = acc.push.bind(acc);
-					if (mapping === DEFAULT_ARG) {
-						mapping = "";
-						f = acc.unshift.bind(acc);
-					}
-					_.map(checkTypes.array(value) ? value : [value], (v: any) => f([mapping, `'${v}'`]));
-				}
-				return acc;
-			}, [])
-			.flatten()
-			.compact()
-			.value();
+		 .reduce((acc: any, value: any, key: any) => {
+			 if (value && mappings[key]) {
+				 let mapping = mappings[key];
+				 let f = acc.push.bind(acc);
+				 if (mapping === DEFAULT_ARG) {
+					 mapping = "";
+					 f = acc.unshift.bind(acc);
+				 }
+				 _.map(checkTypes.array(value) ? value : [value], (v: any) => f([mapping, `'${v}'`]));
+			 }
+			 return acc;
+		 }, [])
+		 .flatten()
+		 .compact()
+		 .value();
 	}
 
-	public spawnBinary(command: string, args: SpawnArguments = {}, argMapping: { [id: string]: string } = {}): ChildProcess {
+	public createArguments(args: SpawnArguments | SpawnArguments[], mappings: { [id: string]: string }): string[] {
+				return args instanceof Array ?
+					_.chain(args).map((x: SpawnArguments) => PactUtil.createArgumentsFromObject(x,mappings)).flatten().value() :
+					PactUtil.createArgumentsFromObject(args,mappings);
+	}
+
+	public spawnBinary(command: string, args: SpawnArguments | SpawnArguments[] = {}, argMapping: { [id: string]: string } = {}): ChildProcess {
 		const envVars = JSON.parse(JSON.stringify(process.env)); // Create copy of environment variables
 		// Remove environment variable if there
 		// This is a hack to prevent some weird Travelling Ruby behaviour with Gems

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -4,6 +4,7 @@ import stubFactory, {Stub, StubOptions} from "./stub";
 import verifierFactory, {VerifierOptions} from "./verifier";
 import messageFactory, {MessageOptions} from "./message";
 import publisherFactory, {PublisherOptions} from "./publisher";
+import canDeployFactory, {CanDeployOptions} from "./can-deploy";
 import logger, {LogLevels} from "./logger";
 import {AbstractService} from "./service";
 import * as _ from "underscore";
@@ -119,10 +120,11 @@ export class Pact {
 		logger.info("Publishing Pacts to Broker");
 		return publisherFactory(options).publish();
 	}
-	// Publish Pacts to a Pact Broker
-	public canDeploy(options: PublisherOptions): q.Promise<any[]> {
-		logger.info("Publishing Pacts to Broker");
-		return publisherFactory(options).canDeploy();
+
+	// Use can-i-deploy to determine if it is safe to deploy
+	public canDeploy(options: CanDeployOptions): q.Promise<any[]> {
+		logger.info("Checking if it it possible to deploy");
+		return canDeployFactory(options).canDeploy();
 	}
 
 	private __stringifyOptions(obj: ServerOptions): string {

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -119,6 +119,11 @@ export class Pact {
 		logger.info("Publishing Pacts to Broker");
 		return publisherFactory(options).publish();
 	}
+	// Publish Pacts to a Pact Broker
+	public canDeploy(options: PublisherOptions): q.Promise<any[]> {
+		logger.info("Publishing Pacts to Broker");
+		return publisherFactory(options).canDeploy();
+	}
 
 	private __stringifyOptions(obj: ServerOptions): string {
 		return _.chain(obj)

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -10,7 +10,7 @@ const chalk = require("chalk");
 const sumchecker = require("sumchecker");
 
 // Get latest version from https://github.com/pact-foundation/pact-ruby-standalone/releases
-export const PACT_STANDALONE_VERSION = "1.47.2";
+export const PACT_STANDALONE_VERSION = "1.48.0";
 const PACT_DEFAULT_LOCATION = `https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_STANDALONE_VERSION}/`;
 const HTTP_REGEX = /^http(s?):\/\//;
 const CONFIG = createConfig();


### PR DESCRIPTION
This PR adds the `can-i-deploy` to the API and CLI tools.

Since it's my first substantial change to pact-node, I'd like to highlight some discussion points:

* Because the order of arguments to `can-i-deploy` matters, but the previous way of handing options off to `PactUtil` doesn't let you specify order of arguments (or even the same argument more than once), I've added a helper in `CanDeploy` to take the options object and convert it into an array of options. Possibly this helper should be in `PactUtil` instead? I'm torn - it's specific to `can-i-deploy`, but it's not really the responsibility of the `CanDeploy` object.

* All the functions / classes here are named `CanDeploy`. I'm not sure if I should have used `CanIDeploy` instead?

* The first commit on this branch also bumped the version number - but I wasn't sure if I should have removed the bump before making the PR?

*  We have a small challenge with the arguments to the CLI -  the broker binary CLI accepts `can-i-deploy --pacticipant <p1> --pacticipant <p2> --version <v2>` - ie, specifying pacticipants without a given version. However, because of the way the CLI library we're using for node works, we can't specify the same argument multiple times. I've changed the format to `--pacticipants "<p1>,<p2>" --versions "<v1>,<v2>"`.  At the moment, I'm rejecting arguments where the lengths of the lists don't match - which enforces that all pacticipants must have a version supplied. Although this is recommended as good practice anyway, we may not want to enforce it. I don't like having a difference between what is possible to specify using the node cli and the binary cli, but also I want the node cli arguments to be easy to use correctly.

* This PR doesn't add the documentation yet - I figured I'd write it after we discuss the above.

Comments and review very welcome!