### PR TITLE
scripts(package.json): Fix broken npm install command on a fresh checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "typescript": "2.7.2"
   },
   "scripts": {
-    "postinstall": "node postinstall.js",
+    "postinstall": "npm run build && npm run download-checksums && node postinstall.js",
     "install:all": "npm run install:osx && npm run install:win && npm run install:linux32 && npm run install:linux64 && npm run install:current",
     "install:current": "cross-env PACT_DO_NOT_TRACK=true node postinstall.js",
     "install:osx": "cross-env PACT_DO_NOT_TRACK=true node postinstall.js darwin",


### PR DESCRIPTION
This fixes issue #104, by ensuring that the typescript is built and the checksums are downloaded.

The install worked in CI, because the test scripts do this too, and install was run with `--ignore-scripts`. It's possible that we should remove `--ignore-scripts` from CI, to more quickly surface this sort of thing if it happens again? I'm not sure why `--ignore-scripts` is run in CI, so I haven't removed it.
