### PR TITLE
Guard against `setTimeout` mocking in consumer tests

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -11,6 +11,9 @@ import {ChildProcess} from "child_process";
 const mkdirp = require("mkdirp");
 const checkTypes = require("check-types");
 
+// Get a reference to the global setTimeout object in case it is mocked by a testing library later
+const setTimeout = global.setTimeout;
+
 const CHECKTIME = 500;
 const RETRY_AMOUNT = 60;
 const PROCESS_TIMEOUT = 30000;


### PR DESCRIPTION
This is the simplest fix to the problem. But maybe it would be useful to have a separate "timer" module that gets used anywhere in this project where we need to use `setTimeout`, `setInterval`, `clearTimeout`, or `clearInterval`.

Also, I don't know if there is a lot of value in testing this. But I'm happy to write a test if you disagree.