### PR TITLE
build(deps): Fix GitHub warning by updating request from 2.83.0 to 2.87.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "decompress": "4.2.0",
     "mkdirp": "0.5.1",
     "q": "1.5.1",
-    "request": "2.83.0",
+    "request": "2.87.0",
     "rimraf": "2.6.2",
     "sumchecker": "^2.0.2",
     "tar": "4.4.0",


### PR DESCRIPTION
# The problem

Currently a repository including `pact-node` gets the following warnings in the GitHub gui:

![screen shot 2018-10-23 at 12 27 12 pm](https://user-images.githubusercontent.com/914369/47329077-18ebbc00-d6bf-11e8-9761-da1622c478db.png)

![screen shot 2018-10-23 at 12 26 50 pm](https://user-images.githubusercontent.com/914369/47329043-f35eb280-d6be-11e8-9ca9-ab07b15df0b5.png)

For `request@2.83.0`,  the problem library `cryptiles` was brought in by `hawk`:

```
$ npm ls cryptiles
@pact-foundation/pact-node@6.19.11 /Users/work/office/pact/pact-node
└─┬ request@2.83.0
  └─┬ hawk@6.0.2
    └── cryptiles@3.1.2
```

# The solution

This PR upgrades `request`. Since later versions of request no longer depend on `hawk` or `cryptiles`, this will remove the warning in future releases.

```
$ npm ls cryptiles
@pact-foundation/pact-node@6.19.11 /Users/work/office/pact/pact-node
└── (empty)
```

*Aside:* The latest version of `request` is actually `2.88.0` (as suggested by [this dependabot PR](https://github.com/pact-foundation/pact-node/pull/130)). However, the [travis build for 2.88.0](https://travis-ci.org/request/request/jobs/414594405) fails with lots of test errors, so I don't think we should use it. This is also further evidence that dependabot isn't very useful for us (at least in this configuration).