### PR TITLE
fix(boundaries): don't add a global handler for unhandled promise rejections

### DIFF
--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -305,11 +305,6 @@ export default (platform?: string, arch?: string) =>
 		.then(() => console.log(chalk.green("Pact Standalone Binary is ready.")))
 		.catch((e: string) => Promise.reject(`Postinstalled Failed Unexpectedly: ${e}`));
 
-// Handle all unhandled promise rejection
-process.on("unhandledRejection", (e: any) => {
-	throw new Error(chalk.red(`Unhandled Promise Rejection: ${e}`));
-});
-
 export interface PackageConfig {
 	binaryLocation?: string;
 	doNotTrack?: boolean;


### PR DESCRIPTION
This fixes #132.

However, it might not be the right change, as I have just removed the handler (there was probably a reason it was added that I am missing).