### PR TITLE
fix(verification): fail verification if empty [] found

### DIFF
--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -148,6 +148,11 @@ export class Verifier {
 				}
 				return uris;
 			})
+			.tap((pacts) => {
+				if (_.isEmpty(pacts)) {
+					throw new Error (`Unable to find pacts for given provider '${this.options.provider}' and tags '${this.options.tags}'`);
+				}
+			})
 			.then((data: string[]): PromiseLike<string> => {
 				const deferred = q.defer<string>();
 				this.options.pactUrls = data;


### PR DESCRIPTION
In some edge cases when following links in the broker, there are no links
to pact files in the leaf nodes. The classic case is for the 'latest' tag (not a real tag).

This change ensures the verification process fails (instead of misleadingly continues/passes):

Fixes #134