### PR TITLE
fix(security): bump vulnerable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ia32"
   ],
   "engine": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "repository": {
     "type": "git",
@@ -51,7 +51,7 @@
     "@types/rimraf": "^2.0.2",
     "bunyan": "1.8.12",
     "bunyan-prettystream": "0.1.3",
-    "caporal": "0.10.0",
+    "caporal": "1.1.0",
     "chalk": "2.3.1",
     "check-types": "7.3.0",
     "decompress": "4.2.0",


### PR DESCRIPTION
*Note:* This PR drops support for nodejs versions greater than or equal to 4 and less than 6.

The non-dev dependency, caporal has a known vulnerability in one of its dependencies, lodash.
```
npm audit

                       === npm audit security report ===

# Run  npm install caporal@1.1.0  to resolve 1 vulnerability
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ caporal                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ caporal > cli-table2 > lodash                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/577                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

To update to a secure version, we need to update to caporal 1.0.0 or higher, and [1.0.0 dropped support for node versions lower than 6](https://github.com/mattallty/Caporal.js/blob/master/CHANGELOG.md#100-2018-10-24).

Please help validate - some tests may be failing.