### PR TITLE
chore: anonymise IP in tracking call to GA. See https://github.com/pa…

### DIFF
--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -140,7 +140,8 @@ function download(data: Data): Promise<Data> {
 					av: require("../package.json").version, // App version.
 					aid: "pact-node", // App Id.
 					aiid: `standalone-${PACT_STANDALONE_VERSION}`, // App Installer Id.
-					cd: `download-node-${data.platform}-${isCI ? "ci" : "user"}`
+					cd: `download-node-${data.platform}-${isCI ? "ci" : "user"}`,
+					aip: true, // Anonymise IP address
 				}
 			}).on("error", () => {
 			}); // Ignore all errors


### PR DESCRIPTION
See #142 for background and the following doc: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#anonymizeIp

See https://www.blastam.com/blog/5-actionable-steps-gdpr-compliance-google-analytics for some info on GDPR, specifically:

> The definition of personal data is expanded and clarified to include IP addresses, cookie identifiers, and GPS locations.

We don't need the IP address specifically, so I suggest we remove it.
