### PR TITLE
fix(verifier): consumerVersionTag should support multiple tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,7 @@ pact.verifyPacts({
 | `providerBaseUrl`           | true      | string  | Running API provider host endpoint.                                                                        |
 | `pactBrokerUrl`         | false     | string  | Base URL of the Pact Broker from which to retrieve the pacts. Required if `pactUrls` not given.                                                                        |
 | `provider`                  | false     | string  | Name of the provider if fetching from a Broker                                                             |
-| `tags`                      | false     | array   | Array of tags, used to filter pacts from the Broker                                                        |
-| `consumerVersionTag`        | false     | string  | Retrieve the latest pacts with this consumer version tag                                                        |
+| `consumerVersionTag`        | false     | string | array  | Retrieve the latest pacts with this consumer version tag(s)                                                        |
 | `pactUrls`                  | false     | array   | Array of local pact file paths or HTTP-based URLs. Required if _not_ using a Pact Broker.                  |
 | `providerStatesSetupUrl`    | false     | string  | URL to send PUT requests to setup a given provider state                                                   |
 | `pactBrokerUsername`        | false     | string  | Username for Pact Broker basic authentication                                                              |

--- a/src/verifier.spec.ts
+++ b/src/verifier.spec.ts
@@ -209,12 +209,22 @@ describe("Verifier Spec", () => {
 		});
 	});
 
-	context("when consumerVersionTag is provided", () => {
+	context("when consumerVersionTag is provided as a string", () => {
 		it("should not fail", () => {
 			expect(() => verifierFactory({
 				providerBaseUrl: "http://localhost",
 				pactUrls: [path.dirname(currentDir)],
 				consumerVersionTag: "tag-1"
+			})).to.not.throw(Error);
+		});
+	});
+
+	context("when consumerVersionTag is provided as an array", () => {
+		it("should not fail", () => {
+			expect(() => verifierFactory({
+				providerBaseUrl: "http://localhost",
+				pactUrls: [path.dirname(currentDir)],
+				consumerVersionTag: ["tag-1"]
 			})).to.not.throw(Error);
 		});
 	});

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -37,8 +37,7 @@ export class Verifier {
 	constructor(options: VerifierOptions) {
 		options = options || {};
 		options.pactBrokerUrl = options.pactBrokerUrl || "";
-		options.consumerVersionTag = options.consumerVersionTag || "";
-		options.tags = options.tags || [];
+		options.consumerVersionTag = _.toArray(options.consumerVersionTag);
 		options.pactUrls = options.pactUrls || [];
 		options.provider = options.provider || "";
 		options.providerStatesSetupUrl = options.providerStatesSetupUrl || "";
@@ -93,15 +92,11 @@ export class Verifier {
 		}
 
 		if (options.consumerVersionTag) {
-			checkTypes.assert.string(options.consumerVersionTag);
+			checkTypes.assert.array.of.string(options.consumerVersionTag);
 		}
 
 		if (options.pactUrls) {
 			checkTypes.assert.array.of.string(options.pactUrls);
-		}
-
-		if (options.tags) {
-			checkTypes.assert.array.of.string(options.tags);
 		}
 
 		if (options.providerBaseUrl) {
@@ -174,11 +169,10 @@ export interface VerifierOptions extends SpawnArguments {
 	pactBrokerUsername?: string;
 	pactBrokerPassword?: string;
 	pactBrokerToken?: string;
-	consumerVersionTag?: string;
+	consumerVersionTag?: string | string[];
 	customProviderHeaders?: string[];
 	publishVerificationResult?: boolean;
 	providerVersion?: string;
-	tags?: string[];
 	timeout?: number;
 	monkeypatch?: string;
 	format?: "json" | "RspecJunitFormatter";


### PR DESCRIPTION
1. `VerifierOptions.tags` is removed, as it is unused and it is not passed to `pact-provider-verifier`
2. `VerifierOptions.consumerVersionTag` supports multiple tags (as per https://github.com/pact-foundation/pact-provider-verifier/blob/master/lib/pact/provider_verifier/cli/verify.rb#L21), so extended `pact-node` to support this (for backward-compatibility, both `string` and `string[]` are supported).