### PR TITLE
feat(can-deploy): add broker token to can-deploy task

### DIFF
--- a/bin/pact-cli.ts
+++ b/bin/pact-cli.ts
@@ -80,6 +80,7 @@ cli
 	.option("-l, --latest [TAG]", "Use the latest version of the participant, or the latest based on the tag. Must follow after participant.", undefined, undefined)
 	.option("-t, --to <tag>", "participant tags to check against", undefined, undefined)
 	.option("-b, --pact-broker <URL>", "URL of the Pact Broker to publish pacts to.", undefined, undefined, true)
+	.option("-token, --pact-broker-token <token>", "Pact Broker API token.")
 	.option("-username, --pact-broker-username <user>", "Pact Broker username.")
 	.option("-password, --pact-broker-password <password>", "Pact Broker password.")
 	.option("-o, --output <output>", "json or table.")

--- a/src/can-deploy.ts
+++ b/src/can-deploy.ts
@@ -34,6 +34,7 @@ export class CanDeploy {
 		"latest": "--latest",
 		"to": "--to",
 		"pactBroker": "--broker-base-url",
+		"pactBrokerToken": "--broker-token",
 		"pactBrokerUsername": "--broker-username",
 		"pactBrokerPassword": "--broker-password",
 		"output": "--output",
@@ -51,7 +52,8 @@ export class CanDeploy {
 		checkTypes.assert.nonEmptyString(options.participantVersion, "Must provide the participant version argument");
 		checkTypes.assert.nonEmptyString(options.pactBroker, "Must provide the pactBroker argument");
 		options.latest !== undefined && checkTypes.assert.nonEmptyString(options.latest.toString());
-		options.to  !== undefined && checkTypes.assert.nonEmptyString(options.to);
+		options.to !== undefined && checkTypes.assert.nonEmptyString(options.to);
+		options.pactBrokerToken !== undefined && checkTypes.assert.nonEmptyString(options.pactBrokerToken);
 		options.pactBrokerUsername !== undefined && checkTypes.assert.string(options.pactBrokerUsername);
 		options.pactBrokerPassword !== undefined && checkTypes.assert.string(options.pactBrokerPassword);
 
@@ -94,6 +96,7 @@ export interface CanDeployOptions extends SpawnArguments {
 	to?: string;
 	latest?: boolean | string;
 	pactBroker: string;
+	pactBrokerToken?: string;
 	pactBrokerUsername?: string;
 	pactBrokerPassword?: string;
 	output?: "json" | "table";


### PR DESCRIPTION
It was raised in Slack that this flag was missing - adding in now.

<img width="665" alt="screenshot" src="https://user-images.githubusercontent.com/53900/57618256-44d07f80-75c6-11e9-9776-cf3adb7f9eda.png">
