### PR TITLE
fix: prevent archive extracting as the wrong user when installing as root

### DIFF
--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -201,7 +201,8 @@ function extract(data: Data): Promise<void> {
 			tar.x({
 				file: data.filepath,
 				strip: 1,
-				cwd: data.platformFolderPath,
+                cwd: data.platformFolderPath,
+                preserveOwner: false,
 				Z: true
 			})
 		)


### PR DESCRIPTION
Fixes #166 