### PR TITLE
chore: move @types/request to a dependency rather than a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@types/request": "2.47.0",
     "@types/q": "1.0.7",
     "bunyan": "1.8.12",
     "bunyan-prettystream": "0.1.3",
@@ -73,7 +74,6 @@
     "@types/express": "4.11.1",
     "@types/mocha": "2.2.48",
     "@types/node": "9.4.6",
-    "@types/request": "2.47.0",
     "@types/underscore": "1.8.7",
     "basic-auth": "2.0.0",
     "body-parser": "1.18.2",


### PR DESCRIPTION
I believe this fixes the broken builds that we're experiencing.