### PR TITLE
feat(can-i-deploy): allow multiple pacticipants to be specified to CanDeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,14 +313,11 @@ pact.canDeploy(opts)
 
 | Parameter            | Required? | Type        | Description                                                                         |
 | -------------------- | --------- | ----------- | ----------------------------------------------------------------------------------- |
-| `participant`        | true      | string	     | The participant name. Required.                                                     |
-| `participantVersion` | true      | string      | Version of the participant. Must follow after the participant. Required.            |
-| `latest`             | false     | string      | Use the latest participant version, Must follow after participant. Optional         |
-| `to`                 | false     | string      | Which tag are you deploying to, Must follow after participant. Optional             |
+| `participants`       | true      | string	     | An array of { name: String, tag? string, version? string } objects                  |
 | `pactBroker`         | true      | string      | URL of the Pact Broker to publish pacts to. Required.                               |
 | `pactBrokerUsername` | false     | string      | Username for Pact Broker basic authentication. Optional                             |
 | `pactBrokerPassword` | false     | string      | Password for Pact Broker basic authentication. Optional                             |
-| `pactBrokerToken`    | false     | string      | Bearer token for Pact Broker authentication. Optional                             |
+| `pactBrokerToken`    | false     | string      | Bearer token for Pact Broker authentication. Optional                               |
 | `output`             | false     | json,table  | Specify output to show, json or table. Optional                                     |
 | `verbose`            | false     | flag        | Set logging mode to verbose. Optional                                               |
 | `retryWhileUnknown`  | false     | number      | The number of times to retry while there is an unknown verification result. Optional|

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ pact.canDeploy(opts)
 
 | Parameter            | Required? | Type        | Description                                                                         |
 | -------------------- | --------- | ----------- | ----------------------------------------------------------------------------------- |
-| `participants`       | true      | string	     | An array of { name: String, tag? string, version? string } objects                  |
+| `pacticipants`       | true      | string	     | An array of { name: String, tag? string, version? string } objects                  |
 | `pactBroker`         | true      | string      | URL of the Pact Broker to publish pacts to. Required.                               |
 | `pactBrokerUsername` | false     | string      | Username for Pact Broker basic authentication. Optional                             |
 | `pactBrokerPassword` | false     | string      | Password for Pact Broker basic authentication. Optional                             |

--- a/src/can-deploy.spec.ts
+++ b/src/can-deploy.spec.ts
@@ -71,7 +71,7 @@ describe('CanDeploy Spec', () => {
 
     it('has latest tag and participant in the right order', () => {
       const result = CanDeploy.convertForSpawnBinary({
-        pacticipants: [{ name: 'two', tag: 'SOME_TAG' }],
+        pacticipants: [{ name: 'two', latest: 'SOME_TAG' }],
         pactBroker: 'some broker',
       });
 
@@ -81,6 +81,21 @@ describe('CanDeploy Spec', () => {
         },
         { name: 'two' },
         { latest: 'SOME_TAG' },
+      ]);
+    });
+
+    it("understands 'true' for latest", () => {
+      const result = CanDeploy.convertForSpawnBinary({
+        pacticipants: [{ name: 'two', latest: true }],
+        pactBroker: 'some broker',
+      });
+
+      expect(result).to.eql([
+        {
+          pactBroker: 'some broker',
+        },
+        { name: 'two' },
+        { latest: undefined },
       ]);
     });
 
@@ -131,6 +146,16 @@ describe('CanDeploy Spec', () => {
       const opts: CanDeployOptions = {
         pactBroker: `http://localhost:${PORT}`,
         pacticipants: [{ name: 'Foo', version: '4' }],
+      };
+      const ding = canDeployFactory(opts);
+
+      ding.canDeploy().then(done);
+    });
+
+    it('should return success with a table result deployable true,', done => {
+      const opts: CanDeployOptions = {
+        pactBroker: `http://localhost:${PORT}`,
+        pacticipants: [{ name: 'Foo', latest: true }],
       };
       const ding = canDeployFactory(opts);
 

--- a/src/can-deploy.spec.ts
+++ b/src/can-deploy.spec.ts
@@ -43,46 +43,59 @@ describe('CanDeploy Spec', () => {
 
   describe('convertForSpawnBinary helper function', () => {
     it('produces an array of SpawnArguments', () => {
-      const value = { pactBroker: 'some broker' };
+      const value = { pactBroker: 'some broker', pacticipants: [] };
       const result = CanDeploy.convertForSpawnBinary(value);
       expect(result).to.be.an('array');
       expect(result.length).to.be.equal(1);
-      expect(result[0]).to.be.deep.equal(value);
+      expect(result).to.be.deep.equal([{ pactBroker: 'some broker' }]);
     });
 
     it('has version and participant in the right order', () => {
       const result = CanDeploy.convertForSpawnBinary({
-        participantVersion: 'v1',
-        participant: 'one',
+        pacticipants: [{ version: 'v2', name: 'one' }],
         pactBroker: 'some broker',
         pactBrokerUsername: 'username',
         pactBrokerPassword: 'password',
       });
 
       expect(result).to.eql([
-        { participant: 'one' },
-        { participantVersion: 'v1' },
         {
           pactBroker: 'some broker',
           pactBrokerUsername: 'username',
           pactBrokerPassword: 'password',
         },
+        { name: 'one' },
+        { version: 'v2' },
       ]);
     });
 
     it('has latest tag and participant in the right order', () => {
       const result = CanDeploy.convertForSpawnBinary({
-        latest: 'v2',
-        participant: 'two',
+        pacticipants: [{ name: 'two', tag: 'SOME_TAG' }],
         pactBroker: 'some broker',
       });
 
       expect(result).to.eql([
-        { participant: 'two' },
-        { latest: 'v2' },
         {
           pactBroker: 'some broker',
         },
+        { name: 'two' },
+        { latest: 'SOME_TAG' },
+      ]);
+    });
+
+    it('understands that no version implies latest', () => {
+      const result = CanDeploy.convertForSpawnBinary({
+        pacticipants: [{ name: 'two' }],
+        pactBroker: 'some broker',
+      });
+
+      expect(result).to.eql([
+        {
+          pactBroker: 'some broker',
+        },
+        { name: 'two' },
+        { latest: undefined },
       ]);
     });
   });
@@ -92,52 +105,11 @@ describe('CanDeploy Spec', () => {
       expect(() => canDeployFactory({} as CanDeployOptions)).to.throw(Error);
     });
 
-    it('should fail with an Error when not given participant', () => {
+    it('should fail with an error when there are no paticipants', () => {
       expect(() =>
         canDeployFactory({
           pactBroker: 'http://localhost',
-          participantVersion: 'v1',
-        } as CanDeployOptions),
-      ).to.throw(Error);
-    });
-
-    it('should fail with an Error when not given version', () => {
-      expect(() =>
-        canDeployFactory({
-          pactBroker: 'http://localhost',
-          participant: 'p1',
-        } as CanDeployOptions),
-      ).to.throw(Error);
-    });
-
-    it('should fail with an error when version and paticipants are empty', () => {
-      expect(() =>
-        canDeployFactory({
-          pactBroker: 'http://localhost',
-          participantVersion: undefined,
-          participant: undefined,
-        }),
-      ).to.throw(Error);
-    });
-
-    it("should fail with an error when 'latest' is an empty string", () => {
-      expect(() =>
-        canDeployFactory({
-          pactBroker: 'http://localhost',
-          participantVersion: 'v1',
-          participant: 'p1',
-          latest: '',
-        }),
-      ).to.throw(Error);
-    });
-
-    it("should fail with an error when 'to' is an empty string", () => {
-      expect(() =>
-        canDeployFactory({
-          pactBroker: 'http://localhost',
-          participantVersion: 'v1',
-          participant: 'p1',
-          to: '',
+          pacticipants: [],
         }),
       ).to.throw(Error);
     });
@@ -147,31 +119,18 @@ describe('CanDeploy Spec', () => {
     it('should return a CanDeploy object when given the correct arguments', () => {
       const c = canDeployFactory({
         pactBroker: 'http://localhost',
-        participantVersion: 'v1',
-        participant: 'p1',
+        pacticipants: [{ name: 'two', version: '2' }],
       });
       expect(c).to.be.ok;
       expect(c.canDeploy).to.be.a('function');
     });
-
-    it("should work when using 'latest' with either a boolean or a string", () => {
-      const opts: CanDeployOptions = {
-        pactBroker: 'http://localhost',
-        participantVersion: 'v1',
-        participant: 'p1',
-      };
-      opts.latest = true;
-      expect(canDeployFactory(opts)).to.be.ok;
-      opts.latest = 'tag';
-      expect(canDeployFactory(opts)).to.be.ok;
-    });
   });
+
   context('candeploy function', () => {
     it('should return success with a table result deployable true', done => {
       const opts: CanDeployOptions = {
         pactBroker: `http://localhost:${PORT}`,
-        participantVersion: '4',
-        participant: 'Foo',
+        pacticipants: [{ name: 'Foo', version: '4' }],
       };
       const ding = canDeployFactory(opts);
 
@@ -181,8 +140,7 @@ describe('CanDeploy Spec', () => {
     it('should throw an error with a table result deployable false', () => {
       const opts: CanDeployOptions = {
         pactBroker: `http://localhost:${PORT}`,
-        participantVersion: '4',
-        participant: 'FooFail',
+        pacticipants: [{ name: 'FooFail', version: '4' }],
       };
       const ding = canDeployFactory(opts);
 
@@ -195,8 +153,7 @@ describe('CanDeploy Spec', () => {
     it('should return success with a json result deployable true', done => {
       const opts: CanDeployOptions = {
         pactBroker: `http://localhost:${PORT}`,
-        participantVersion: '4',
-        participant: 'Foo',
+        pacticipants: [{ name: 'Foo', version: '4' }],
         output: 'json',
       };
       const ding = canDeployFactory(opts);
@@ -207,8 +164,7 @@ describe('CanDeploy Spec', () => {
     it('should throw an error with a json result deployable false', () => {
       const opts: CanDeployOptions = {
         pactBroker: `http://localhost:${PORT}`,
-        participantVersion: '4',
-        participant: 'FooFail',
+        pacticipants: [{ name: 'FooFail', version: '4' }],
         output: 'json',
       };
       const ding = canDeployFactory(opts);

--- a/src/can-deploy.spec.ts
+++ b/src/can-deploy.spec.ts
@@ -95,22 +95,7 @@ describe('CanDeploy Spec', () => {
           pactBroker: 'some broker',
         },
         { name: 'two' },
-        { latest: undefined },
-      ]);
-    });
-
-    it('understands that no version implies latest', () => {
-      const result = CanDeploy.convertForSpawnBinary({
-        pacticipants: [{ name: 'two' }],
-        pactBroker: 'some broker',
-      });
-
-      expect(result).to.eql([
-        {
-          pactBroker: 'some broker',
-        },
-        { name: 'two' },
-        { latest: undefined },
+        { latest: 'PACT_NODE_NO_VALUE' },
       ]);
     });
   });
@@ -152,14 +137,81 @@ describe('CanDeploy Spec', () => {
       ding.canDeploy().then(done);
     });
 
-    it('should return success with a table result deployable true,', done => {
-      const opts: CanDeployOptions = {
-        pactBroker: `http://localhost:${PORT}`,
-        pacticipants: [{ name: 'Foo', latest: true }],
-      };
-      const ding = canDeployFactory(opts);
+    context('with latest true', () => {
+      it('should return success with a table result deployable true', done => {
+        const opts: CanDeployOptions = {
+          pactBroker: `http://localhost:${PORT}`,
+          pacticipants: [{ name: 'Foo', latest: true }],
+        };
+        const ding = canDeployFactory(opts);
 
-      ding.canDeploy().then(done);
+        ding.canDeploy().then(done);
+      });
+
+      it('should throw an error with a table result deployable false', () => {
+        const opts: CanDeployOptions = {
+          pactBroker: `http://localhost:${PORT}`,
+          pacticipants: [{ name: 'FooFail', latest: true }],
+        };
+        const ding = canDeployFactory(opts);
+
+        return ding
+          .canDeploy()
+          .then(() => expect.fail())
+          .catch(message => expect(message).not.be.null);
+      });
+    });
+
+    context('with latest a string', () => {
+      it('should return success with a table result deployable true', done => {
+        const opts: CanDeployOptions = {
+          pactBroker: `http://localhost:${PORT}`,
+          pacticipants: [{ name: 'Foo', latest: 'tag' }],
+        };
+        const ding = canDeployFactory(opts);
+
+        ding.canDeploy().then(done);
+      });
+
+      it('should throw an error with a table result deployable false', () => {
+        const opts: CanDeployOptions = {
+          pactBroker: `http://localhost:${PORT}`,
+          pacticipants: [{ name: 'FooFail', latest: 'tag' }],
+        };
+        const ding = canDeployFactory(opts);
+
+        return ding
+          .canDeploy()
+          .then(() => expect.fail())
+          .catch(message => expect(message).not.be.null);
+      });
+    });
+
+    context('with latest a string, and a to', () => {
+      it('should return success with a table result deployable true', done => {
+        const opts: CanDeployOptions = {
+          pactBroker: `http://localhost:${PORT}`,
+          pacticipants: [{ name: 'Foo', latest: 'tag' }],
+          to: 'prod',
+        };
+        const ding = canDeployFactory(opts);
+
+        ding.canDeploy().then(done);
+      });
+
+      it('should throw an error with a table result deployable false', () => {
+        const opts: CanDeployOptions = {
+          pactBroker: `http://localhost:${PORT}`,
+          pacticipants: [{ name: 'FooFail', latest: 'tag' }],
+          to: 'prod',
+        };
+        const ding = canDeployFactory(opts);
+
+        return ding
+          .canDeploy()
+          .then(() => expect.fail())
+          .catch(message => expect(message).not.be.null);
+      });
     });
 
     it('should throw an error with a table result deployable false', () => {

--- a/src/can-deploy.ts
+++ b/src/can-deploy.ts
@@ -12,9 +12,11 @@ export class CanDeploy {
   ): CanDeployOptions[] {
     return _.flatten(
       [_.omit(options, 'pacticipants')].concat(
-        options.pacticipants.map(({ name, tag, version }) => [
+        options.pacticipants.map(({ name, latest, version }) => [
           { name },
-          version ? { version } : { latest: tag },
+          version
+            ? { version }
+            : { latest: latest === true ? undefined : latest },
         ]),
       ),
     );
@@ -25,6 +27,7 @@ export class CanDeploy {
     name: '--pacticipant',
     version: '--version',
     latest: '--latest',
+    to: '--to',
     pactBroker: '--broker-base-url',
     pactBrokerToken: '--broker-token',
     pactBrokerUsername: '--broker-username',
@@ -113,7 +116,7 @@ export default (options: CanDeployOptions) => new CanDeploy(options);
 export interface CanDeployPacticipant {
   name: string;
   version?: string;
-  tag?: string;
+  latest?: string | boolean;
 }
 
 export interface CanDeployOptions {
@@ -124,6 +127,7 @@ export interface CanDeployOptions {
   pactBrokerPassword?: string;
   output?: 'json' | 'table';
   verbose?: boolean;
+  to?: string;
   retryWhileUnknown?: number;
   retryInterval?: number;
   timeout?: number;

--- a/src/can-deploy.ts
+++ b/src/can-deploy.ts
@@ -2,6 +2,7 @@ import q = require('q');
 import logger from './logger';
 import spawn from './spawn';
 import pactStandalone from './pact-standalone';
+import { PACT_NODE_NO_VALUE } from './spawn';
 import * as _ from 'underscore';
 
 const checkTypes = require('check-types');
@@ -16,7 +17,9 @@ export class CanDeploy {
           { name },
           version
             ? { version }
-            : { latest: latest === true ? undefined : latest },
+            : {
+                latest: latest === true ? PACT_NODE_NO_VALUE : latest,
+              },
         ]),
       ),
     );

--- a/src/spawn/arguments.ts
+++ b/src/spawn/arguments.ts
@@ -16,6 +16,21 @@ export type SpawnArguments =
   | {}; // Empty object is allowed to make tests less noisy. We should change this in the future
 
 export const DEFAULT_ARG = 'DEFAULT';
+export const PACT_NODE_NO_VALUE = 'PACT_NODE_NO_VALUE';
+
+const valFor = (v: any) => (v !== PACT_NODE_NO_VALUE ? [`'${v}'`] : []);
+
+const mapFor = (mapping: string, v: any) =>
+  mapping === DEFAULT_ARG ? valFor(v) : [mapping].concat(valFor(v));
+
+const convertValue = (mapping: string, v: any) => {
+  if (v && mapping) {
+    return checkTypes.array(v)
+      ? _.flatten(v.map((val: any) => mapFor(mapping, val)))
+      : mapFor(mapping, v);
+  }
+  return [];
+};
 
 export class Arguments {
   public toArgumentsArray(
@@ -33,20 +48,13 @@ export class Arguments {
     mappings: { [id: string]: string },
   ): string[] {
     return _.chain(args)
-      .reduce((acc: any, value: any, key: any) => {
-        if (value && mappings[key]) {
-          let mapping = mappings[key];
-          let f = acc.push.bind(acc);
-          if (mapping === DEFAULT_ARG) {
-            mapping = '';
-            f = acc.unshift.bind(acc);
-          }
-          _.map(checkTypes.array(value) ? value : [value], (v: any) =>
-            f([mapping, `'${v}'`]),
-          );
-        }
-        return acc;
-      }, [])
+      .reduce(
+        (acc: any, value: any, key: any) =>
+          mappings[key] === DEFAULT_ARG
+            ? convertValue(mappings[key], value).concat(acc)
+            : acc.concat(convertValue(mappings[key], value)),
+        [],
+      )
       .flatten()
       .compact()
       .value();


### PR DESCRIPTION
BREAKING CHANGE: Options for CanDeploy have changed. Now, pacticipants are specified by an array of { name: <string>, tag?: <string>, version?: <string> }, allowing more than one to be specified. If tag and version are not specified, then the latest version is used.