### PR TITLE
chore(format + ts): Add prettier, upgrade typescript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,14 +6,18 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = tab
-indent_size = 4
+indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
 
 [*.js]
 indent_style = tab
-indent_size = 4
+indent_size = 2
+
+[*.ts]
+indent_style = tab
+indent_size = 2
 
 [package.json]
 indent_style = space

--- a/bin/pact-broker.ts
+++ b/bin/pact-broker.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-import standalone from "../src/pact-standalone";
-const spawnSync = require("child_process").spawnSync;
+import standalone from '../src/pact-standalone';
+const spawnSync = require('child_process').spawnSync;
 
-const status = spawnSync(standalone.brokerFullPath, process.argv.slice(2), {stdio: "inherit"}).status;
+const status = spawnSync(standalone.brokerFullPath, process.argv.slice(2), {
+  stdio: 'inherit',
+}).status;
 process.exit(status);

--- a/bin/pact-message.ts
+++ b/bin/pact-message.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-import standalone from "../src/pact-standalone";
-const spawnSync = require("child_process").spawnSync;
+import standalone from '../src/pact-standalone';
+const spawnSync = require('child_process').spawnSync;
 
-const status = spawnSync(standalone.messageFullPath, process.argv.slice(2), {stdio: "inherit"}).status;
+const status = spawnSync(standalone.messageFullPath, process.argv.slice(2), {
+  stdio: 'inherit',
+}).status;
 process.exit(status);

--- a/bin/pact-mock-service.ts
+++ b/bin/pact-mock-service.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
-import standalone from "../src/pact-standalone";
-const spawnSync = require("child_process").spawnSync;
+import standalone from '../src/pact-standalone';
+const spawnSync = require('child_process').spawnSync;
 
-const status = spawnSync(standalone.mockServiceFullPath, process.argv.slice(2), {stdio: "inherit"}).status;
+const status = spawnSync(
+  standalone.mockServiceFullPath,
+  process.argv.slice(2),
+  { stdio: 'inherit' },
+).status;
 process.exit(status);

--- a/bin/pact-provider-verifier.ts
+++ b/bin/pact-provider-verifier.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-import standalone from "../src/pact-standalone";
-const spawnSync = require("child_process").spawnSync;
+import standalone from '../src/pact-standalone';
+const spawnSync = require('child_process').spawnSync;
 
-const status = spawnSync(standalone.verifierFullPath, process.argv.slice(2), {stdio: "inherit"}).status;
+const status = spawnSync(standalone.verifierFullPath, process.argv.slice(2), {
+  stdio: 'inherit',
+}).status;
 process.exit(status);

--- a/bin/pact-stub-service.ts
+++ b/bin/pact-stub-service.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-import standalone from "../src/pact-standalone";
-const spawnSync = require("child_process").spawnSync;
+import standalone from '../src/pact-standalone';
+const spawnSync = require('child_process').spawnSync;
 
-const status = spawnSync(standalone.stubFullPath, process.argv.slice(2), {stdio: "inherit"}).status;
+const status = spawnSync(standalone.stubFullPath, process.argv.slice(2), {
+  stdio: 'inherit',
+}).status;
 process.exit(status);

--- a/bin/pact.ts
+++ b/bin/pact.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-import standalone from "../src/pact-standalone";
-const spawnSync = require("child_process").spawnSync;
+import standalone from '../src/pact-standalone';
+const spawnSync = require('child_process').spawnSync;
 
-const status = spawnSync(standalone.pactFullPath, process.argv.slice(2), {stdio: "inherit"}).status;
+const status = spawnSync(standalone.pactFullPath, process.argv.slice(2), {
+  stdio: 'inherit',
+}).status;
 process.exit(status);

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,15 @@
         "@types/node": "*"
       }
     },
+    "@types/bunyan": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.6.tgz",
+      "integrity": "sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
@@ -8071,9 +8080,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5742,6 +5742,12 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -8000,6 +8006,12 @@
           }
         }
       }
+    },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
     },
     "tsutils": {
       "version": "2.22.2",

--- a/package.json
+++ b/package.json
@@ -86,11 +86,13 @@
     "mocha": "5.0.1",
     "mocha-unfunk-reporter": "0.4.0",
     "nodemon": "^1.18.10",
+    "prettier": "^1.18.2",
     "rewire": "^4.0.1",
     "sinon": "4.4.2",
     "standard-version": "^5.0.1",
     "ts-node": "5.0.0",
     "tslint": "5.9.1",
+    "tslint-config-prettier": "^1.18.0",
     "typescript": "2.7.2"
   },
   "scripts": {
@@ -113,7 +115,15 @@
     "prerelease": "npm i && npm t && rm package-lock.json",
     "release": "standard-version",
     "snyk-protect": "snyk protect",
+    "prettier:base": "prettier --parser typescript --no-editorconfig",
+    "prettier:check": "npm run prettier:base -- --list-different \"src/**/*.{ts,tsx}\"",
+    "prettier:write": "npm run prettier:base -- --write \"src/**/*.{ts,tsx}\"",
     "prepare": "npm run snyk-protect"
+  },
+  "prettier": {
+    "semi": true,
+    "trailingComma": "all",
+    "singleQuote": true
   },
   "snyk": true
 }

--- a/package.json
+++ b/package.json
@@ -116,8 +116,8 @@
     "release": "standard-version",
     "snyk-protect": "snyk protect",
     "prettier:base": "prettier --parser typescript --no-editorconfig",
-    "prettier:check": "npm run prettier:base -- --list-different \"src/**/*.{ts,tsx}\"",
-    "prettier:write": "npm run prettier:base -- --write \"src/**/*.{ts,tsx}\"",
+    "prettier:check": "npm run prettier:base -- --list-different \"{src,standalone,bin,test}/**/*.{ts,tsx}\"",
+    "prettier:write": "npm run prettier:base -- --write \"{src,standalone,bin,test}/**/*.{ts,tsx}\"",
     "prepare": "npm run snyk-protect"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "snyk": "^1.193.2"
   },
   "devDependencies": {
+    "@types/bunyan": "^1.8.6",
     "@types/chai": "4.1.2",
     "@types/chai-as-promised": "7.1.0",
     "@types/express": "4.11.1",
@@ -90,10 +91,10 @@
     "rewire": "^4.0.1",
     "sinon": "4.4.2",
     "standard-version": "^5.0.1",
-    "ts-node": "5.0.0",
+    "ts-node": "8.3.0",
     "tslint": "5.9.1",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "2.7.2"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "postinstall": "node postinstall.js",

--- a/src/can-deploy.spec.ts
+++ b/src/can-deploy.spec.ts
@@ -1,212 +1,222 @@
 // tslint:disable:no-string-literal
 
-import path = require("path");
-import fs = require("fs");
-import chai = require("chai");
-import chaiAsPromised = require("chai-as-promised");
-import canDeployFactory, {CanDeploy, CanDeployOptions} from "./can-deploy";
-import logger from "./logger";
-import brokerMock from "../test/integration/broker-mock";
-import * as http from "http";
+import path = require('path');
+import fs = require('fs');
+import chai = require('chai');
+import chaiAsPromised = require('chai-as-promised');
+import canDeployFactory, { CanDeploy, CanDeployOptions } from './can-deploy';
+import logger from './logger';
+import brokerMock from '../test/integration/broker-mock';
+import * as http from 'http';
 
-const rimraf = require("rimraf");
-const mkdirp = require("mkdirp");
+const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
-describe("CanDeploy Spec", () => {
+describe('CanDeploy Spec', () => {
+  const PORT = Math.floor(Math.random() * 999) + 9000;
+  let server: http.Server;
+  let absolutePath: string;
+  let relativePath: string;
 
-	const PORT = Math.floor(Math.random() * 999) + 9000;
-	let server: http.Server;
-	let absolutePath: string;
-	let relativePath: string;
+  before(() =>
+    brokerMock(PORT).then(s => {
+      logger.debug(`Pact Broker Mock listening on port: ${PORT}`);
+      server = s;
+    }),
+  );
 
-	before(() => brokerMock(PORT).then((s) => {
-		logger.debug(`Pact Broker Mock listening on port: ${PORT}`);
-		server = s;
-	}));
+  after(() => server.close());
 
-	after(() => server.close());
+  beforeEach(() => {
+    relativePath = `.tmp/${Math.floor(Math.random() * 1000)}`;
+    absolutePath = path.resolve(__dirname, '..', relativePath);
+    mkdirp.sync(absolutePath);
+  });
 
-	beforeEach(() => {
-		relativePath = `.tmp/${Math.floor(Math.random() * 1000)}`;
-		absolutePath = path.resolve(__dirname, "..", relativePath);
-		mkdirp.sync(absolutePath);
-	});
+  afterEach(() => {
+    if (fs.existsSync(absolutePath)) {
+      rimraf.sync(absolutePath);
+    }
+  });
 
-	afterEach(() => {
-		if (fs.existsSync(absolutePath)) {
-			rimraf.sync(absolutePath);
-		}
-	});
+  describe('convertForSpawnBinary helper function', () => {
+    it('produces an array of SpawnArguments', () => {
+      const value = { pactBroker: 'some broker' };
+      const result = CanDeploy.convertForSpawnBinary(value);
+      expect(result).to.be.an('array');
+      expect(result.length).to.be.equal(1);
+      expect(result[0]).to.be.deep.equal(value);
+    });
 
-	describe("convertForSpawnBinary helper function", () => {
+    it('has version and participant in the right order', () => {
+      const result = CanDeploy.convertForSpawnBinary({
+        participantVersion: 'v1',
+        participant: 'one',
+        pactBroker: 'some broker',
+        pactBrokerUsername: 'username',
+        pactBrokerPassword: 'password',
+      });
 
-		it("produces an array of SpawnArguments", () => {
-			const value = {pactBroker: "some broker"};
-			const result = CanDeploy.convertForSpawnBinary(value);
-			expect(result).to.be.an("array");
-			expect(result.length).to.be.equal(1);
-			expect(result[0]).to.be.deep.equal(value);
-		});
+      expect(result).to.eql([
+        { participant: 'one' },
+        { participantVersion: 'v1' },
+        {
+          pactBroker: 'some broker',
+          pactBrokerUsername: 'username',
+          pactBrokerPassword: 'password',
+        },
+      ]);
+    });
 
-		it("has version and participant in the right order", () => {
-			const result = CanDeploy.convertForSpawnBinary({
-				participantVersion: "v1",
-				participant: "one",
-				pactBroker: "some broker",
-				pactBrokerUsername: "username",
-				pactBrokerPassword: "password",
-			});
+    it('has latest tag and participant in the right order', () => {
+      const result = CanDeploy.convertForSpawnBinary({
+        latest: 'v2',
+        participant: 'two',
+        pactBroker: 'some broker',
+      });
 
-			expect(result).to.eql([
-				{participant: "one"},
-				{participantVersion: "v1"},
-				{
-					pactBroker: "some broker",
-					pactBrokerUsername: "username",
-					pactBrokerPassword: "password"
-				}
-			]);
-		});
+      expect(result).to.eql([
+        { participant: 'two' },
+        { latest: 'v2' },
+        {
+          pactBroker: 'some broker',
+        },
+      ]);
+    });
+  });
 
-		it("has latest tag and participant in the right order", () => {
-			const result = CanDeploy.convertForSpawnBinary({
-				latest: "v2",
-				participant: "two",
-				pactBroker: "some broker",
-			});
+  context('when invalid options are set', () => {
+    it('should fail with an Error when not given pactBroker', () => {
+      expect(() => canDeployFactory({} as CanDeployOptions)).to.throw(Error);
+    });
 
-			expect(result).to.eql([
-				{participant: "two"},
-				{latest: "v2"},
-				{
-					pactBroker: "some broker"
-				}
-			]);
-		});
-	});
+    it('should fail with an Error when not given participant', () => {
+      expect(() =>
+        canDeployFactory({
+          pactBroker: 'http://localhost',
+          participantVersion: 'v1',
+        } as CanDeployOptions),
+      ).to.throw(Error);
+    });
 
-	context("when invalid options are set", () => {
-		it("should fail with an Error when not given pactBroker", () => {
-			expect(() => canDeployFactory({} as CanDeployOptions)).to.throw(Error);
-		});
+    it('should fail with an Error when not given version', () => {
+      expect(() =>
+        canDeployFactory({
+          pactBroker: 'http://localhost',
+          participant: 'p1',
+        } as CanDeployOptions),
+      ).to.throw(Error);
+    });
 
-		it("should fail with an Error when not given participant", () => {
-			expect(() => canDeployFactory({
-				pactBroker: "http://localhost",
-				participantVersion: "v1",
-			} as CanDeployOptions)).to.throw(Error);
-		});
+    it('should fail with an error when version and paticipants are empty', () => {
+      expect(() =>
+        canDeployFactory({
+          pactBroker: 'http://localhost',
+          participantVersion: undefined,
+          participant: undefined,
+        }),
+      ).to.throw(Error);
+    });
 
-		it("should fail with an Error when not given version", () => {
-			expect(() => canDeployFactory({
-				pactBroker: "http://localhost",
-				participant: "p1"
-			} as CanDeployOptions)).to.throw(Error);
-		});
+    it("should fail with an error when 'latest' is an empty string", () => {
+      expect(() =>
+        canDeployFactory({
+          pactBroker: 'http://localhost',
+          participantVersion: 'v1',
+          participant: 'p1',
+          latest: '',
+        }),
+      ).to.throw(Error);
+    });
 
-		it("should fail with an error when version and paticipants are empty", () => {
-			expect(() => canDeployFactory({
-				pactBroker: "http://localhost",
-				participantVersion: undefined,
-				participant: undefined
-			})).to.throw(Error);
-		});
+    it("should fail with an error when 'to' is an empty string", () => {
+      expect(() =>
+        canDeployFactory({
+          pactBroker: 'http://localhost',
+          participantVersion: 'v1',
+          participant: 'p1',
+          to: '',
+        }),
+      ).to.throw(Error);
+    });
+  });
 
-		it("should fail with an error when 'latest' is an empty string", () => {
-			expect(() => canDeployFactory({
-				pactBroker: "http://localhost",
-				participantVersion: "v1",
-				participant: "p1",
-				latest: ""
-			})).to.throw(Error);
-		});
+  context('when valid options are set', () => {
+    it('should return a CanDeploy object when given the correct arguments', () => {
+      const c = canDeployFactory({
+        pactBroker: 'http://localhost',
+        participantVersion: 'v1',
+        participant: 'p1',
+      });
+      expect(c).to.be.ok;
+      expect(c.canDeploy).to.be.a('function');
+    });
 
-		it("should fail with an error when 'to' is an empty string", () => {
-			expect(() => canDeployFactory({
-				pactBroker: "http://localhost",
-				participantVersion: "v1",
-				participant: "p1",
-				to: ""
-			})).to.throw(Error);
-		});
-	});
+    it("should work when using 'latest' with either a boolean or a string", () => {
+      const opts: CanDeployOptions = {
+        pactBroker: 'http://localhost',
+        participantVersion: 'v1',
+        participant: 'p1',
+      };
+      opts.latest = true;
+      expect(canDeployFactory(opts)).to.be.ok;
+      opts.latest = 'tag';
+      expect(canDeployFactory(opts)).to.be.ok;
+    });
+  });
+  context('candeploy function', () => {
+    it('should return success with a table result deployable true', done => {
+      const opts: CanDeployOptions = {
+        pactBroker: `http://localhost:${PORT}`,
+        participantVersion: '4',
+        participant: 'Foo',
+      };
+      const ding = canDeployFactory(opts);
 
-	context("when valid options are set", () => {
-		it("should return a CanDeploy object when given the correct arguments", () => {
-			const c = canDeployFactory({
-				pactBroker: "http://localhost",
-				participantVersion: "v1",
-				participant: "p1"
-			});
-			expect(c).to.be.ok;
-			expect(c.canDeploy).to.be.a("function");
-		});
+      ding.canDeploy().then(done);
+    });
 
-		it("should work when using 'latest' with either a boolean or a string", () => {
-			const opts: CanDeployOptions = {
-				pactBroker: "http://localhost",
-				participantVersion: "v1",
-				participant: "p1"
-			};
-			opts.latest = true;
-			expect(canDeployFactory(opts)).to.be.ok;
-			opts.latest = "tag";
-			expect(canDeployFactory(opts)).to.be.ok;
-		});
+    it('should throw an error with a table result deployable false', () => {
+      const opts: CanDeployOptions = {
+        pactBroker: `http://localhost:${PORT}`,
+        participantVersion: '4',
+        participant: 'FooFail',
+      };
+      const ding = canDeployFactory(opts);
 
-	});
-	context("candeploy function", () => {
-		it("should return success with a table result deployable true", (done)=> {
-			const opts: CanDeployOptions = {
-				pactBroker: `http://localhost:${PORT}`,
-				participantVersion: "4",
-				participant: "Foo"
-			};
-			const ding = canDeployFactory(opts);
+      return ding
+        .canDeploy()
+        .then(() => expect.fail())
+        .catch(message => expect(message).not.be.null);
+    });
 
-			ding.canDeploy().then(done);
-		});
+    it('should return success with a json result deployable true', done => {
+      const opts: CanDeployOptions = {
+        pactBroker: `http://localhost:${PORT}`,
+        participantVersion: '4',
+        participant: 'Foo',
+        output: 'json',
+      };
+      const ding = canDeployFactory(opts);
 
-		it("should throw an error with a table result deployable false", ()=> {
-			const opts: CanDeployOptions = {
-				pactBroker: `http://localhost:${PORT}`,
-				participantVersion: "4",
-				participant: "FooFail"
-			};
-			const ding = canDeployFactory(opts);
+      ding.canDeploy().then(done);
+    });
 
-			return ding.canDeploy()
-			.then(() => expect.fail())
-			.catch((message)=> expect(message).not.be.null);
-		});
+    it('should throw an error with a json result deployable false', () => {
+      const opts: CanDeployOptions = {
+        pactBroker: `http://localhost:${PORT}`,
+        participantVersion: '4',
+        participant: 'FooFail',
+        output: 'json',
+      };
+      const ding = canDeployFactory(opts);
 
-		it("should return success with a json result deployable true", (done)=> {
-			const opts: CanDeployOptions = {
-				pactBroker: `http://localhost:${PORT}`,
-				participantVersion: "4",
-				participant: "Foo",
-				output: "json"
-			};
-			const ding = canDeployFactory(opts);
-
-			ding.canDeploy().then(done);
-		});
-
-		it("should throw an error with a json result deployable false", ()=> {
-			const opts: CanDeployOptions = {
-				pactBroker: `http://localhost:${PORT}`,
-				participantVersion: "4",
-				participant: "FooFail",
-				output: "json"
-			};
-			const ding = canDeployFactory(opts);
-
-			return ding.canDeploy()
-			.then(() => expect.fail())
-			.catch((message)=> expect(message).not.be.null);
-		});
-	});
-
+      return ding
+        .canDeploy()
+        .then(() => expect.fail())
+        .catch(message => expect(message).not.be.null);
+    });
+  });
 });

--- a/src/can-deploy.ts
+++ b/src/can-deploy.ts
@@ -1,114 +1,140 @@
-import q = require("q");
-import logger from "./logger";
-import pactUtil, {SpawnArguments} from "./pact-util";
-import pactStandalone from "./pact-standalone";
-import * as _ from "underscore";
+import q = require('q');
+import logger from './logger';
+import pactUtil, { SpawnArguments } from './pact-util';
+import pactStandalone from './pact-standalone';
+import * as _ from 'underscore';
 
-const checkTypes = require("check-types");
+const checkTypes = require('check-types');
 
 export class CanDeploy {
+  public static convertForSpawnBinary(
+    options: CanDeployOptions,
+  ): SpawnArguments[] {
+    // This is the order that the arguments must be in, everything else is afterwards
+    const keys = ['participant', 'participantVersion', 'latest', 'to'];
+    // Create copy of options, while omitting the arguments specified above
+    const args: SpawnArguments[] = [_.omit(options, keys)];
 
-	public static convertForSpawnBinary(options: CanDeployOptions):SpawnArguments[] {
-		// This is the order that the arguments must be in, everything else is afterwards
-		const keys = ["participant", "participantVersion", "latest", "to"];
-		// Create copy of options, while omitting the arguments specified above
-		const args:SpawnArguments[] = [_.omit(options, keys)];
+    // Go backwards in the keys as we are going to unshift them into the array
+    keys.reverse().forEach(key => {
+      const val: any = options[key];
+      if (options[key] !== undefined) {
+        const obj: any = {};
+        obj[key] = val;
+        args.unshift(obj);
+      }
+    });
 
-		// Go backwards in the keys as we are going to unshift them into the array
-		keys.reverse().forEach((key) => {
-			const val: any = options[key];
-			if(options[key] !== undefined) {
-				const obj: any = {};
-				obj[key] = val;
-				args.unshift(obj);
-			}
-		});
+    return args;
+  }
 
-		return args;
-	}
+  public readonly options: CanDeployOptions;
+  private readonly __argMapping = {
+    participant: '--pacticipant',
+    participantVersion: '--version',
+    latest: '--latest',
+    to: '--to',
+    pactBroker: '--broker-base-url',
+    pactBrokerToken: '--broker-token',
+    pactBrokerUsername: '--broker-username',
+    pactBrokerPassword: '--broker-password',
+    output: '--output',
+    verbose: '--verbose',
+    retryWhileUnknown: '--retry-while-unknown',
+    retryInterval: '--retry-interval',
+  };
 
-	public readonly options: CanDeployOptions;
-	private readonly __argMapping = {
-		"participant": "--pacticipant",
-		"participantVersion": "--version",
-		"latest": "--latest",
-		"to": "--to",
-		"pactBroker": "--broker-base-url",
-		"pactBrokerToken": "--broker-token",
-		"pactBrokerUsername": "--broker-username",
-		"pactBrokerPassword": "--broker-password",
-		"output": "--output",
-		"verbose": "--verbose",
-		"retryWhileUnknown": "--retry-while-unknown",
-		"retryInterval": "--retry-interval",
-	};
+  constructor(options: CanDeployOptions) {
+    options = options || {};
+    // Setting defaults
+    options.timeout = options.timeout || 60000;
 
-	constructor(options: CanDeployOptions) {
-		options = options || {};
-		// Setting defaults
-		options.timeout = options.timeout || 60000;
+    checkTypes.assert.nonEmptyString(
+      options.participant,
+      'Must provide the participant argument',
+    );
+    checkTypes.assert.nonEmptyString(
+      options.participantVersion,
+      'Must provide the participant version argument',
+    );
+    checkTypes.assert.nonEmptyString(
+      options.pactBroker,
+      'Must provide the pactBroker argument',
+    );
+    options.latest !== undefined &&
+      checkTypes.assert.nonEmptyString(options.latest.toString());
+    options.to !== undefined && checkTypes.assert.nonEmptyString(options.to);
+    options.pactBrokerToken !== undefined &&
+      checkTypes.assert.nonEmptyString(options.pactBrokerToken);
+    options.pactBrokerUsername !== undefined &&
+      checkTypes.assert.string(options.pactBrokerUsername);
+    options.pactBrokerPassword !== undefined &&
+      checkTypes.assert.string(options.pactBrokerPassword);
 
-		checkTypes.assert.nonEmptyString(options.participant, "Must provide the participant argument");
-		checkTypes.assert.nonEmptyString(options.participantVersion, "Must provide the participant version argument");
-		checkTypes.assert.nonEmptyString(options.pactBroker, "Must provide the pactBroker argument");
-		options.latest !== undefined && checkTypes.assert.nonEmptyString(options.latest.toString());
-		options.to !== undefined && checkTypes.assert.nonEmptyString(options.to);
-		options.pactBrokerToken !== undefined && checkTypes.assert.nonEmptyString(options.pactBrokerToken);
-		options.pactBrokerUsername !== undefined && checkTypes.assert.string(options.pactBrokerUsername);
-		options.pactBrokerPassword !== undefined && checkTypes.assert.string(options.pactBrokerPassword);
+    if (
+      (options.pactBrokerUsername && !options.pactBrokerPassword) ||
+      (options.pactBrokerPassword && !options.pactBrokerUsername)
+    ) {
+      throw new Error(
+        'Must provide both Pact Broker username and password. None needed if authentication on Broker is disabled.',
+      );
+    }
 
-		if ((options.pactBrokerUsername && !options.pactBrokerPassword) || (options.pactBrokerPassword && !options.pactBrokerUsername)) {
-			throw new Error("Must provide both Pact Broker username and password. None needed if authentication on Broker is disabled.");
-		}
+    this.options = options;
+  }
 
-		this.options = options;
-	}
+  public canDeploy(): q.Promise<any> {
+    logger.info(
+      `Asking broker at ${this.options.pactBroker} if it is possible to deploy`,
+    );
+    const deferred = q.defer<string[]>();
+    const instance = pactUtil.spawnBinary(
+      `${pactStandalone.brokerPath} can-i-deploy`,
+      CanDeploy.convertForSpawnBinary(this.options),
+      this.__argMapping,
+    );
+    const output: any[] = [];
+    instance.stdout.on('data', l => output.push(l));
+    instance.stderr.on('data', l => output.push(l));
+    instance.once('close', code => {
+      const o = output.join('\n');
 
-	public canDeploy(): q.Promise<any> {
-		logger.info(`Asking broker at ${this.options.pactBroker} if it is possible to deploy`);
-		const deferred = q.defer<string[]>();
-		const instance = pactUtil.spawnBinary(`${pactStandalone.brokerPath} can-i-deploy`, CanDeploy.convertForSpawnBinary(this.options), this.__argMapping);
-		const output: any[] = [];
-		instance.stdout.on("data", (l) => output.push(l));
-		instance.stderr.on("data", (l) => output.push(l));
-		instance.once("close", (code) => {
-			const o = output.join("\n");
+      let success = false;
+      if (this.options.output === 'json') {
+        success = JSON.parse(o).summary.deployable;
+      } else {
+        success = /Computer says yes/gim.exec(o) !== null;
+      }
 
-			let success = false;
-			if (this.options.output === "json") {
-				success = JSON.parse(o).summary.deployable;
-			} else {
-				success = /Computer says yes/igm.exec(o) !== null;
-			}
+      if (code === 0 || success) {
+        logger.info(o);
+        return deferred.resolve();
+      }
 
-			if (code === 0 || success) {
-				logger.info(o);
-				return deferred.resolve();
-			}
+      logger.error(`can-i-deploy did not return success message:\n${o}`);
+      return deferred.reject(new Error(o));
+    });
 
-			logger.error(`can-i-deploy did not return success message:\n${o}`);
-			return deferred.reject(new Error(o));
-
-		});
-
-		return deferred.promise
-			.timeout(this.options.timeout as number, `Timeout waiting for verification process to complete (PID: ${instance.pid})`);
-	}
+    return deferred.promise.timeout(
+      this.options.timeout as number,
+      `Timeout waiting for verification process to complete (PID: ${instance.pid})`,
+    );
+  }
 }
 
 export default (options: CanDeployOptions) => new CanDeploy(options);
 
 export interface CanDeployOptions extends SpawnArguments {
-	participant?: string;
-	participantVersion?: string;
-	to?: string;
-	latest?: boolean | string;
-	pactBroker: string;
-	pactBrokerToken?: string;
-	pactBrokerUsername?: string;
-	pactBrokerPassword?: string;
-	output?: "json" | "table";
-	verbose?: boolean;
-	retryWhileUnknown?: number;
-	retryInterval?: number;
+  participant?: string;
+  participantVersion?: string;
+  to?: string;
+  latest?: boolean | string;
+  pactBroker: string;
+  pactBrokerToken?: string;
+  pactBrokerUsername?: string;
+  pactBrokerPassword?: string;
+  output?: 'json' | 'table';
+  verbose?: boolean;
+  retryWhileUnknown?: number;
+  retryInterval?: number;
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,19 +1,18 @@
-import chai = require("chai");
-import index from "./index";
+import chai = require('chai');
+import index from './index';
 const expect = chai.expect;
 
-describe("Index Spec", () => {
+describe('Index Spec', () => {
+  it('Typescript import should work', () => {
+    expect(index).to.be.ok;
+    expect(index.createServer).to.be.ok;
+    expect(index.createServer).to.be.a('function');
+  });
 
-	it("Typescript import should work", () => {
-		expect(index).to.be.ok;
-		expect(index.createServer).to.be.ok;
-		expect(index.createServer).to.be.a("function");
-	});
-
-	it("Node Require import should work", () => {
-		const entrypoint = require("./index");
-		expect(entrypoint).to.be.ok;
-		expect(entrypoint.createServer).to.be.ok;
-		expect(entrypoint.createServer).to.be.a("function");
-	});
+  it('Node Require import should work', () => {
+    const entrypoint = require('./index');
+    expect(entrypoint).to.be.ok;
+    expect(entrypoint.createServer).to.be.ok;
+    expect(entrypoint.createServer).to.be.a('function');
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-import pact from "./pact";
+import pact from './pact';
 module.exports = exports = pact;
 export default pact;
 
-export * from "./verifier";
+export * from './verifier';
 
-export * from "./server";
+export * from './server';
 
-export * from "./publisher";
+export * from './publisher';
 
-export * from "./stub";
+export * from './stub';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -20,10 +20,6 @@ bunyan.prototype.time = (action: string, startTime: number) => {
   );
 };
 
-// @ts-ignore
-bunyan.prototype.logLevelName = (): string =>
-  bunyan.nameFromLevel[this.level()];
-
 export type LogLevels = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 const Logger = new bunyan({

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,34 +1,40 @@
-const bunyan = require("bunyan");
-const PrettyStream = require("bunyan-prettystream");
+const bunyan = require('bunyan');
+const PrettyStream = require('bunyan-prettystream');
 
-const pkg = require("../package.json");
+const pkg = require('../package.json');
 const prettyStdOut = new PrettyStream();
 prettyStdOut.pipe(process.stdout);
 
 // TODO: replace bunyan with something that actually works with typescript
 // Extend bunyan
 bunyan.prototype.time = (action: string, startTime: number) => {
-	let time = Date.now() - startTime;
-	// @ts-ignore
-	this.info({
-		duration: time,
-		action: action,
-		type: "TIMER"
-	}, `TIMER: ${action} completed in ${time} milliseconds`);
+  let time = Date.now() - startTime;
+  // @ts-ignore
+  this.info(
+    {
+      duration: time,
+      action: action,
+      type: 'TIMER',
+    },
+    `TIMER: ${action} completed in ${time} milliseconds`,
+  );
 };
 
 // @ts-ignore
-bunyan.prototype.logLevelName = ():string => bunyan.nameFromLevel[this.level()];
+bunyan.prototype.logLevelName = (): string =>
+  bunyan.nameFromLevel[this.level()];
 
-export type LogLevels = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+export type LogLevels = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 const Logger = new bunyan({
-	name: `pact-node@${pkg.version}`,
-	streams: [{
-		level: (process.env.LOGLEVEL || "info") as LogLevels,
-		stream: prettyStdOut,
-		type: "raw"
-	}]
+  name: `pact-node@${pkg.version}`,
+  streams: [
+    {
+      level: (process.env.LOGLEVEL || 'info') as LogLevels,
+      stream: prettyStdOut,
+      type: 'raw',
+    },
+  ],
 });
 
 export default Logger;

--- a/src/message.spec.ts
+++ b/src/message.spec.ts
@@ -1,127 +1,143 @@
-import chai = require("chai");
-import path = require("path");
-import chaiAsPromised = require("chai-as-promised");
-import fs = require("fs");
-import messageFactory from "./message";
+import chai = require('chai');
+import path = require('path');
+import chaiAsPromised = require('chai-as-promised');
+import fs = require('fs');
+import messageFactory from './message';
 
-const mkdirp = require("mkdirp");
-const rimraf = require("rimraf");
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
-describe("Message Spec", () => {
-	const validJSON = `{ "description": "a test mesage", "content": { "name": "Mary" } }`;
+describe('Message Spec', () => {
+  const validJSON = `{ "description": "a test mesage", "content": { "name": "Mary" } }`;
 
-	let absolutePath: string;
-	let relativePath: string;
-	beforeEach(() => {
-		relativePath = `.tmp/${Math.floor(Math.random() * 1000)}`;
-		absolutePath = path.resolve(__dirname, "..", relativePath);
-		mkdirp.sync(absolutePath);
-	});
+  let absolutePath: string;
+  let relativePath: string;
+  beforeEach(() => {
+    relativePath = `.tmp/${Math.floor(Math.random() * 1000)}`;
+    absolutePath = path.resolve(__dirname, '..', relativePath);
+    mkdirp.sync(absolutePath);
+  });
 
-	afterEach(() => {
-		if (fs.existsSync(absolutePath)) {
-			rimraf.sync(absolutePath);
-		}
-	});
+  afterEach(() => {
+    if (fs.existsSync(absolutePath)) {
+      rimraf.sync(absolutePath);
+    }
+  });
 
-	context("when invalid options are set", () => {
-		it("should throw an Error when not given any message content", () => {
-			expect(() => messageFactory({
-				consumer: "a-consumer",
-				dir: absolutePath
-			})).to.throw(Error);
-		});
+  context('when invalid options are set', () => {
+    it('should throw an Error when not given any message content', () => {
+      expect(() =>
+        messageFactory({
+          consumer: 'a-consumer',
+          dir: absolutePath,
+        }),
+      ).to.throw(Error);
+    });
 
-		it("should throw an Error when not given a consumer", () => {
-			expect(() => messageFactory({
-				provider: "a-provider",
-				dir: absolutePath,
-				content: validJSON
-			})).to.throw(Error);
-		});
+    it('should throw an Error when not given a consumer', () => {
+      expect(() =>
+        messageFactory({
+          provider: 'a-provider',
+          dir: absolutePath,
+          content: validJSON,
+        }),
+      ).to.throw(Error);
+    });
 
-		it("should throw an Error when not given a provider", () => {
-			expect(() => messageFactory({
-				consumer: "a-provider",
-				dir: absolutePath,
-				content: validJSON
-			})).to.throw(Error);
-		});
+    it('should throw an Error when not given a provider', () => {
+      expect(() =>
+        messageFactory({
+          consumer: 'a-provider',
+          dir: absolutePath,
+          content: validJSON,
+        }),
+      ).to.throw(Error);
+    });
 
-		it("should throw an Error when given an invalid JSON document", () => {
-			expect(() => messageFactory({
-				consumer: "some-consumer",
-				provider: "a-provider",
-				dir: absolutePath,
-				content: `{ "unparseable" }`
-			})).to.throw(Error);
-		});
+    it('should throw an Error when given an invalid JSON document', () => {
+      expect(() =>
+        messageFactory({
+          consumer: 'some-consumer',
+          provider: 'a-provider',
+          dir: absolutePath,
+          content: `{ "unparseable" }`,
+        }),
+      ).to.throw(Error);
+    });
 
-		it("should throw an Error when not given a pact dir", () => {
-			expect(() => messageFactory({
-				consumer: "a-consumer",
-				content: validJSON
-			})).to.throw(Error);
-		});
-	});
+    it('should throw an Error when not given a pact dir', () => {
+      expect(() =>
+        messageFactory({
+          consumer: 'a-consumer',
+          content: validJSON,
+        }),
+      ).to.throw(Error);
+    });
+  });
 
-	context("when valid options are set", () => {
-		it("should return a message object when given the correct arguments", () => {
-			const message = messageFactory({
-				consumer: "some-consumer",
-				provider: "a-provider",
-				dir: absolutePath,
-				content: validJSON
-			});
-			expect(message).to.be.a("object");
-			expect(message).to.respondTo("createMessage");
-		});
+  context('when valid options are set', () => {
+    it('should return a message object when given the correct arguments', () => {
+      const message = messageFactory({
+        consumer: 'some-consumer',
+        provider: 'a-provider',
+        dir: absolutePath,
+        content: validJSON,
+      });
+      expect(message).to.be.a('object');
+      expect(message).to.respondTo('createMessage');
+    });
 
-		it("should return a promise when calling createMessage", () => {
-			const promise = messageFactory({
-				consumer: "some-consumer",
-				provider: "a-provider",
-				dir: absolutePath,
-				content: validJSON
-			}).createMessage();
-			expect(promise).to.ok;
-			return expect(promise).to.eventually.be.fulfilled;
-		});
+    it('should return a promise when calling createMessage', () => {
+      const promise = messageFactory({
+        consumer: 'some-consumer',
+        provider: 'a-provider',
+        dir: absolutePath,
+        content: validJSON,
+      }).createMessage();
+      expect(promise).to.ok;
+      return expect(promise).to.eventually.be.fulfilled;
+    });
 
-		it("should create a new directory if the directory specified doesn't exist yet", () => {
-			const dir = path.resolve(absolutePath, "create");
-			return messageFactory({
-				consumer: "some-consumer",
-				provider: "a-provider",
-				dir: dir,
-				content: validJSON
-			})
-				.createMessage()
-				.then(() => expect(fs.existsSync(dir)).to.be.true);
-		});
+    it("should create a new directory if the directory specified doesn't exist yet", () => {
+      const dir = path.resolve(absolutePath, 'create');
+      return messageFactory({
+        consumer: 'some-consumer',
+        provider: 'a-provider',
+        dir: dir,
+        content: validJSON,
+      })
+        .createMessage()
+        .then(() => expect(fs.existsSync(dir)).to.be.true);
+    });
 
-		it("should return an absolute path when a relative one is given", () => {
-			const dir = path.join(relativePath, "create");
-			expect(messageFactory({
-				consumer: "some-consumer",
-				provider: "a-provider",
-				dir: dir,
-				content: validJSON
-			}).options.dir).to.equal(path.resolve(__dirname, "..", dir));
-		});
+    it('should return an absolute path when a relative one is given', () => {
+      const dir = path.join(relativePath, 'create');
+      expect(
+        messageFactory({
+          consumer: 'some-consumer',
+          provider: 'a-provider',
+          dir: dir,
+          content: validJSON,
+        }).options.dir,
+      ).to.equal(path.resolve(__dirname, '..', dir));
+    });
 
-		it("should create a new directory with a relative path", () => {
-			const dir = path.join(relativePath, "create");
-			return messageFactory({
-				consumer: "some-consumer",
-				provider: "a-provider",
-				dir: dir,
-				content: validJSON
-			})
-				.createMessage()
-				.then(() => expect(fs.existsSync(path.resolve(__dirname, "..", dir))).to.be.true);
-		});
-	});
+    it('should create a new directory with a relative path', () => {
+      const dir = path.join(relativePath, 'create');
+      return messageFactory({
+        consumer: 'some-consumer',
+        provider: 'a-provider',
+        dir: dir,
+        content: validJSON,
+      })
+        .createMessage()
+        .then(
+          () =>
+            expect(fs.existsSync(path.resolve(__dirname, '..', dir))).to.be
+              .true,
+        );
+    });
+  });
 });

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,103 +1,128 @@
-import fs = require("fs");
-import q = require("q");
-import logger from "./logger";
-import pactUtil, {DEFAULT_ARG, SpawnArguments} from "./pact-util";
-import pactStandalone from "./pact-standalone";
-import path = require("path");
-const mkdirp = require("mkdirp");
-const checkTypes = require("check-types");
+import fs = require('fs');
+import q = require('q');
+import logger from './logger';
+import pactUtil, { DEFAULT_ARG, SpawnArguments } from './pact-util';
+import pactStandalone from './pact-standalone';
+import path = require('path');
+const mkdirp = require('mkdirp');
+const checkTypes = require('check-types');
 
 export class Message {
-	public readonly options: MessageOptions;
-	private readonly __argMapping = {
-		"content": DEFAULT_ARG,
-		"pactFileWriteMode": DEFAULT_ARG,
-		"dir": "--pact_dir",
-		"consumer": "--consumer",
-		"provider": "--provider",
-		"spec": "--pact_specification_version",
-	};
+  public readonly options: MessageOptions;
+  private readonly __argMapping = {
+    content: DEFAULT_ARG,
+    pactFileWriteMode: DEFAULT_ARG,
+    dir: '--pact_dir',
+    consumer: '--consumer',
+    provider: '--provider',
+    spec: '--pact_specification_version',
+  };
 
-	constructor(options: MessageOptions) {
-		options = options || {};
-		options.pactFileWriteMode = options.pactFileWriteMode || "update";
-		options.spec = options.spec || 3;
+  constructor(options: MessageOptions) {
+    options = options || {};
+    options.pactFileWriteMode = options.pactFileWriteMode || 'update';
+    options.spec = options.spec || 3;
 
-		checkTypes.assert.nonEmptyString(options.consumer, "Must provide the consumer name");
-		checkTypes.assert.nonEmptyString(options.provider, "Must provide the provider name");
-		checkTypes.assert.nonEmptyString(options.content, "Must provide message content");
-		checkTypes.assert.nonEmptyString(options.dir, "Must provide pact output dir");
+    checkTypes.assert.nonEmptyString(
+      options.consumer,
+      'Must provide the consumer name',
+    );
+    checkTypes.assert.nonEmptyString(
+      options.provider,
+      'Must provide the provider name',
+    );
+    checkTypes.assert.nonEmptyString(
+      options.content,
+      'Must provide message content',
+    );
+    checkTypes.assert.nonEmptyString(
+      options.dir,
+      'Must provide pact output dir',
+    );
 
-		if (options.spec) {
-			checkTypes.assert.number(options.spec);
-			checkTypes.assert.integer(options.spec);
-			checkTypes.assert.positive(options.spec);
-		}
+    if (options.spec) {
+      checkTypes.assert.number(options.spec);
+      checkTypes.assert.integer(options.spec);
+      checkTypes.assert.positive(options.spec);
+    }
 
-		if (options.dir) {
-			options.dir = path.resolve(options.dir);
-			try {
-				fs.statSync(options.dir).isDirectory();
-			} catch (e) {
-				mkdirp.sync(options.dir);
-			}
-		}
+    if (options.dir) {
+      options.dir = path.resolve(options.dir);
+      try {
+        fs.statSync(options.dir).isDirectory();
+      } catch (e) {
+        mkdirp.sync(options.dir);
+      }
+    }
 
-		if (options.content) {
-			try {
-				JSON.parse(options.content);
-			} catch (e) {
-				throw new Error("Unable to parse message content to JSON, invalid json supplied");
-			}
-		}
+    if (options.content) {
+      try {
+        JSON.parse(options.content);
+      } catch (e) {
+        throw new Error(
+          'Unable to parse message content to JSON, invalid json supplied',
+        );
+      }
+    }
 
-		if (options.consumer) {
-			checkTypes.assert.string(options.consumer);
-		}
+    if (options.consumer) {
+      checkTypes.assert.string(options.consumer);
+    }
 
-		if (options.provider) {
-			checkTypes.assert.string(options.provider);
-		}
+    if (options.provider) {
+      checkTypes.assert.string(options.provider);
+    }
 
-		checkTypes.assert.includes(["overwrite", "update", "merge"], options.pactFileWriteMode);
+    checkTypes.assert.includes(
+      ['overwrite', 'update', 'merge'],
+      options.pactFileWriteMode,
+    );
 
-		if ((options.pactBrokerUsername && !options.pactBrokerPassword) || (options.pactBrokerPassword && !options.pactBrokerUsername)) {
-			throw new Error("Must provide both Pact Broker username and password. None needed if authentication on Broker is disabled.");
-		}
+    if (
+      (options.pactBrokerUsername && !options.pactBrokerPassword) ||
+      (options.pactBrokerPassword && !options.pactBrokerUsername)
+    ) {
+      throw new Error(
+        'Must provide both Pact Broker username and password. None needed if authentication on Broker is disabled.',
+      );
+    }
 
-		this.options = options;
-	}
+    this.options = options;
+  }
 
-	public createMessage(): q.Promise<any> {
-		logger.info(`Creating message pact`);
-		const deferred = q.defer<any>();
-		const instance = pactUtil.spawnBinary(`${pactStandalone.messagePath}`, this.options, this.__argMapping);
-		const output: any[] = [];
-		instance.stdout.on("data", (l) => output.push(l));
-		instance.stderr.on("data", (l) => output.push(l));
-		instance.once("close", (code) => {
-			const o = output.join("\n");
-			logger.info(o);
+  public createMessage(): q.Promise<any> {
+    logger.info(`Creating message pact`);
+    const deferred = q.defer<any>();
+    const instance = pactUtil.spawnBinary(
+      `${pactStandalone.messagePath}`,
+      this.options,
+      this.__argMapping,
+    );
+    const output: any[] = [];
+    instance.stdout.on('data', l => output.push(l));
+    instance.stderr.on('data', l => output.push(l));
+    instance.once('close', code => {
+      const o = output.join('\n');
+      logger.info(o);
 
-			if (code === 0) {
-				return deferred.resolve(o);
-			} else {
-				return deferred.reject(o);
-			}
+      if (code === 0) {
+        return deferred.resolve(o);
+      } else {
+        return deferred.reject(o);
+      }
+    });
 
-		});
-
-		return deferred.promise;
-	}
+    return deferred.promise;
+  }
 }
 
 export default (options: MessageOptions) => new Message(options);
 
 export interface MessageOptions extends SpawnArguments {
-	content?: string;
-	dir?: string;
-	consumer?: string;
-	provider?: string;
-	pactFileWriteMode?: "overwrite" | "update" | "merge";
-	spec?: number;
+  content?: string;
+  dir?: string;
+  consumer?: string;
+  provider?: string;
+  pactFileWriteMode?: 'overwrite' | 'update' | 'merge';
+  spec?: number;
 }

--- a/src/pact-standalone.spec.ts
+++ b/src/pact-standalone.spec.ts
@@ -1,242 +1,253 @@
 /* global describe:true, before:true, after:true, it:true, global:true, process:true */
 /* tslint:disable:no-string-literal */
-import * as fs from "fs";
-import * as path from "path";
-import * as chai from "chai";
-import install from "../standalone/install";
-import util from "./pact-util";
-import {PactStandalone, standalone} from "./pact-standalone";
+import * as fs from 'fs';
+import * as path from 'path';
+import * as chai from 'chai';
+import install from '../standalone/install';
+import util from './pact-util';
+import { PactStandalone, standalone } from './pact-standalone';
 
 const expect = chai.expect;
 const basePath = util.cwd;
 
 // Needs to stay a function and not an arrow function to access mocha 'this' context
-describe("Pact Standalone", function() {
-	// Set timeout to 10 minutes because downloading binaries might take a while.
-	this.timeout(600000);
+describe('Pact Standalone', function() {
+  // Set timeout to 10 minutes because downloading binaries might take a while.
+  this.timeout(600000);
 
-	let pact: PactStandalone;
+  let pact: PactStandalone;
 
-	// reinstall the correct binary for the system for all other tests that might use it.
-	after(() => install());
+  // reinstall the correct binary for the system for all other tests that might use it.
+  after(() => install());
 
-	it("should return an object with cwd, file and fullPath properties that is platform specific", () => {
-		pact = standalone();
-		expect(pact).to.be.an("object");
-		expect(pact.cwd).to.be.ok;
-		expect(pact.brokerPath).to.contain("pact-broker");
-		expect(pact.brokerFullPath).to.contain("pact-broker");
-		expect(pact.mockServicePath).to.contain("pact-mock-service");
-		expect(pact.mockServiceFullPath).to.contain("pact-mock-service");
-		expect(pact.stubPath).to.contain("pact-stub-service");
-		expect(pact.stubFullPath).to.contain("pact-stub-service");
-		expect(pact.verifierPath).to.contain("pact-provider-verifier");
-		expect(pact.verifierFullPath).to.contain("pact-provider-verifier");
-		expect(pact.pactPath).to.contain("pact");
-		expect(pact.pactFullPath).to.contain("pact");		
-	});
+  it('should return an object with cwd, file and fullPath properties that is platform specific', () => {
+    pact = standalone();
+    expect(pact).to.be.an('object');
+    expect(pact.cwd).to.be.ok;
+    expect(pact.brokerPath).to.contain('pact-broker');
+    expect(pact.brokerFullPath).to.contain('pact-broker');
+    expect(pact.mockServicePath).to.contain('pact-mock-service');
+    expect(pact.mockServiceFullPath).to.contain('pact-mock-service');
+    expect(pact.stubPath).to.contain('pact-stub-service');
+    expect(pact.stubFullPath).to.contain('pact-stub-service');
+    expect(pact.verifierPath).to.contain('pact-provider-verifier');
+    expect(pact.verifierFullPath).to.contain('pact-provider-verifier');
+    expect(pact.pactPath).to.contain('pact');
+    expect(pact.pactFullPath).to.contain('pact');
+  });
 
-	it("should return the base directory of the project with 'cwd' (where the package.json file is)", () => {
-		expect(fs.existsSync(path.resolve(pact.cwd, "package.json"))).to.be.true;
-	});
+  it("should return the base directory of the project with 'cwd' (where the package.json file is)", () => {
+    expect(fs.existsSync(path.resolve(pact.cwd, 'package.json'))).to.be.true;
+  });
 
-	describe("Check if OS specific files are there", () => {
-		describe("OSX", () => {
-			before(() => install("darwin"));
+  describe('Check if OS specific files are there', () => {
+    describe('OSX', () => {
+      before(() => install('darwin'));
 
-			beforeEach(() => pact = standalone("darwin"));
+      beforeEach(() => (pact = standalone('darwin')));
 
-			it("broker relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.brokerPath))).to.be.true;
-			});
+      it('broker relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.brokerPath))).to.be
+          .true;
+      });
 
-			it("broker full path", () => {
-				expect(fs.existsSync(pact.brokerFullPath)).to.be.true;
-			});
+      it('broker full path', () => {
+        expect(fs.existsSync(pact.brokerFullPath)).to.be.true;
+      });
 
-			it("mock service relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.mockServicePath))).to.be.true;
-			});
+      it('mock service relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.mockServicePath))).to
+          .be.true;
+      });
 
-			it("mock service full path", () => {
-				expect(fs.existsSync(pact.mockServiceFullPath)).to.be.true;
-			});
+      it('mock service full path', () => {
+        expect(fs.existsSync(pact.mockServiceFullPath)).to.be.true;
+      });
 
-			it("stub relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.stubPath))).to.be.true;
-			});
+      it('stub relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.stubPath))).to.be.true;
+      });
 
-			it("stub full path", () => {
-				expect(fs.existsSync(pact.stubFullPath)).to.be.true;
-			});
+      it('stub full path', () => {
+        expect(fs.existsSync(pact.stubFullPath)).to.be.true;
+      });
 
-			it("provider verifier relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.verifierPath))).to.be.true;
-			});
+      it('provider verifier relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.verifierPath))).to.be
+          .true;
+      });
 
-			it("provider verifier full path", () => {
-				expect(fs.existsSync(pact.verifierFullPath)).to.be.true;
-			});
-			
-			it("pact relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.pactPath))).to.be.true;
-			});
+      it('provider verifier full path', () => {
+        expect(fs.existsSync(pact.verifierFullPath)).to.be.true;
+      });
 
-			it("pact full path", () => {
-				expect(fs.existsSync(pact.pactFullPath)).to.be.true;
-			});
-		});
+      it('pact relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.pactPath))).to.be.true;
+      });
 
-		describe("Linux ia32", () => {
-			before(() => install("linux", "ia32"));
+      it('pact full path', () => {
+        expect(fs.existsSync(pact.pactFullPath)).to.be.true;
+      });
+    });
 
-			beforeEach(() => pact = standalone("linux", "ia32"));
+    describe('Linux ia32', () => {
+      before(() => install('linux', 'ia32'));
 
-			it("broker relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.brokerPath))).to.be.true;
-			});
+      beforeEach(() => (pact = standalone('linux', 'ia32')));
 
-			it("broker full path", () => {
-				expect(fs.existsSync(pact.brokerFullPath)).to.be.true;
-			});
+      it('broker relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.brokerPath))).to.be
+          .true;
+      });
 
-			it("mock service relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.mockServicePath))).to.be.true;
-			});
+      it('broker full path', () => {
+        expect(fs.existsSync(pact.brokerFullPath)).to.be.true;
+      });
 
-			it("mock service full path", () => {
-				expect(fs.existsSync(pact.mockServiceFullPath)).to.be.true;
-			});
+      it('mock service relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.mockServicePath))).to
+          .be.true;
+      });
 
-			it("stub relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.stubPath))).to.be.true;
-			});
+      it('mock service full path', () => {
+        expect(fs.existsSync(pact.mockServiceFullPath)).to.be.true;
+      });
 
-			it("stub full path", () => {
-				expect(fs.existsSync(pact.stubFullPath)).to.be.true;
-			});
+      it('stub relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.stubPath))).to.be.true;
+      });
 
-			it("provider verifier relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.verifierPath))).to.be.true;
-			});
+      it('stub full path', () => {
+        expect(fs.existsSync(pact.stubFullPath)).to.be.true;
+      });
 
-			it("provider verifier full path", () => {
-				expect(fs.existsSync(pact.verifierFullPath)).to.be.true;
-			});
-			
-			it("pact relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.pactPath))).to.be.true;
-			});
+      it('provider verifier relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.verifierPath))).to.be
+          .true;
+      });
 
-			it("pact full path", () => {
-				expect(fs.existsSync(pact.pactFullPath)).to.be.true;
-			});
-		});
+      it('provider verifier full path', () => {
+        expect(fs.existsSync(pact.verifierFullPath)).to.be.true;
+      });
 
-		describe("Linux X64", () => {
-			before(() => install("linux", "x64"));
+      it('pact relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.pactPath))).to.be.true;
+      });
 
-			beforeEach(() => pact = standalone("linux", "x64"));
+      it('pact full path', () => {
+        expect(fs.existsSync(pact.pactFullPath)).to.be.true;
+      });
+    });
 
-			it("broker relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.brokerPath))).to.be.true;
-			});
+    describe('Linux X64', () => {
+      before(() => install('linux', 'x64'));
 
-			it("broker full path", () => {
-				expect(fs.existsSync(pact.brokerFullPath)).to.be.true;
-			});
+      beforeEach(() => (pact = standalone('linux', 'x64')));
 
-			it("mock service relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.mockServicePath))).to.be.true;
-			});
+      it('broker relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.brokerPath))).to.be
+          .true;
+      });
 
-			it("mock service full path", () => {
-				expect(fs.existsSync(pact.mockServiceFullPath)).to.be.true;
-			});
+      it('broker full path', () => {
+        expect(fs.existsSync(pact.brokerFullPath)).to.be.true;
+      });
 
-			it("stub relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.stubPath))).to.be.true;
-			});
+      it('mock service relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.mockServicePath))).to
+          .be.true;
+      });
 
-			it("stub full path", () => {
-				expect(fs.existsSync(pact.stubFullPath)).to.be.true;
-			});
+      it('mock service full path', () => {
+        expect(fs.existsSync(pact.mockServiceFullPath)).to.be.true;
+      });
 
-			it("provider verifier relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.verifierPath))).to.be.true;
-			});
+      it('stub relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.stubPath))).to.be.true;
+      });
 
-			it("provider verifier full path", () => {
-				expect(fs.existsSync(pact.verifierFullPath)).to.be.true;
-			});
-			
-			it("pact relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.pactPath))).to.be.true;
-			});
+      it('stub full path', () => {
+        expect(fs.existsSync(pact.stubFullPath)).to.be.true;
+      });
 
-			it("pact full path", () => {
-				expect(fs.existsSync(pact.pactFullPath)).to.be.true;
-			});
-		});
+      it('provider verifier relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.verifierPath))).to.be
+          .true;
+      });
 
-		describe("Windows", () => {
-			before(() => install("win32"));
+      it('provider verifier full path', () => {
+        expect(fs.existsSync(pact.verifierFullPath)).to.be.true;
+      });
 
-			beforeEach(() => pact = standalone("win32"));
+      it('pact relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.pactPath))).to.be.true;
+      });
 
-			it("should add '.bat' to the end of the binary names", () => {
-					expect(pact.brokerPath).to.contain("pact-broker.bat");
-					expect(pact.brokerFullPath).to.contain("pact-broker.bat");
-					expect(pact.mockServicePath).to.contain("pact-mock-service.bat");
-					expect(pact.mockServiceFullPath).to.contain("pact-mock-service.bat");
-					expect(pact.stubPath).to.contain("pact-stub-service.bat");
-					expect(pact.stubFullPath).to.contain("pact-stub-service.bat");
-					expect(pact.verifierPath).to.contain("pact-provider-verifier.bat");
-					expect(pact.verifierFullPath).to.contain("pact-provider-verifier.bat");
-					expect(pact.pactPath).to.contain("pact.bat");
-					expect(pact.pactFullPath).to.contain("pact.bat");
-				}
-			);
+      it('pact full path', () => {
+        expect(fs.existsSync(pact.pactFullPath)).to.be.true;
+      });
+    });
 
-			it("broker relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.brokerPath))).to.be.true;
-			});
+    describe('Windows', () => {
+      before(() => install('win32'));
 
-			it("broker full path", () => {
-				expect(fs.existsSync(pact.brokerFullPath)).to.be.true;
-			});
+      beforeEach(() => (pact = standalone('win32')));
 
-			it("mock service relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.mockServicePath))).to.be.true;
-			});
+      it("should add '.bat' to the end of the binary names", () => {
+        expect(pact.brokerPath).to.contain('pact-broker.bat');
+        expect(pact.brokerFullPath).to.contain('pact-broker.bat');
+        expect(pact.mockServicePath).to.contain('pact-mock-service.bat');
+        expect(pact.mockServiceFullPath).to.contain('pact-mock-service.bat');
+        expect(pact.stubPath).to.contain('pact-stub-service.bat');
+        expect(pact.stubFullPath).to.contain('pact-stub-service.bat');
+        expect(pact.verifierPath).to.contain('pact-provider-verifier.bat');
+        expect(pact.verifierFullPath).to.contain('pact-provider-verifier.bat');
+        expect(pact.pactPath).to.contain('pact.bat');
+        expect(pact.pactFullPath).to.contain('pact.bat');
+      });
 
-			it("mock service full path", () => {
-				expect(fs.existsSync(pact.mockServiceFullPath)).to.be.true;
-			});
+      it('broker relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.brokerPath))).to.be
+          .true;
+      });
 
-			it("stub relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.stubPath))).to.be.true;
-			});
+      it('broker full path', () => {
+        expect(fs.existsSync(pact.brokerFullPath)).to.be.true;
+      });
 
-			it("stub full path", () => {
-				expect(fs.existsSync(pact.stubFullPath)).to.be.true;
-			});
+      it('mock service relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.mockServicePath))).to
+          .be.true;
+      });
 
-			it("provider verifier relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.verifierPath))).to.be.true;
-			});
+      it('mock service full path', () => {
+        expect(fs.existsSync(pact.mockServiceFullPath)).to.be.true;
+      });
 
-			it("provider verifier full path", () => {
-				expect(fs.existsSync(pact.verifierFullPath)).to.be.true;
-			});
-			
-			it("pact relative path", () => {
-				expect(fs.existsSync(path.resolve(basePath, pact.pactPath))).to.be.true;
-			});
+      it('stub relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.stubPath))).to.be.true;
+      });
 
-			it("pact full path", () => {
-				expect(fs.existsSync(pact.pactFullPath)).to.be.true;
-			});
-		});
-	});
+      it('stub full path', () => {
+        expect(fs.existsSync(pact.stubFullPath)).to.be.true;
+      });
+
+      it('provider verifier relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.verifierPath))).to.be
+          .true;
+      });
+
+      it('provider verifier full path', () => {
+        expect(fs.existsSync(pact.verifierFullPath)).to.be.true;
+      });
+
+      it('pact relative path', () => {
+        expect(fs.existsSync(path.resolve(basePath, pact.pactPath))).to.be.true;
+      });
+
+      it('pact full path', () => {
+        expect(fs.existsSync(pact.pactFullPath)).to.be.true;
+      });
+    });
+  });
 });

--- a/src/pact-standalone.ts
+++ b/src/pact-standalone.ts
@@ -1,50 +1,58 @@
-import * as path from "path";
-import {getBinaryEntry} from "../standalone/install";
-import util from "./pact-util";
+import * as path from 'path';
+import { getBinaryEntry } from '../standalone/install';
+import util from './pact-util';
 
 export interface PactStandalone {
-	cwd: string;
-	brokerPath: string;
-	brokerFullPath: string;
-	mockServicePath: string;
-	mockServiceFullPath: string;
-	stubPath: string;
-	stubFullPath: string;
-	verifierPath: string;
-	verifierFullPath: string;
-	messagePath: string;
-	messageFullPath: string;
-	pactPath: string;
-	pactFullPath: string;
+  cwd: string;
+  brokerPath: string;
+  brokerFullPath: string;
+  mockServicePath: string;
+  mockServiceFullPath: string;
+  stubPath: string;
+  stubFullPath: string;
+  verifierPath: string;
+  verifierFullPath: string;
+  messagePath: string;
+  messageFullPath: string;
+  pactPath: string;
+  pactFullPath: string;
 }
 
-export const standalone = (platform?: string, arch?: string): PactStandalone => {
-	platform = platform || process.platform;
-	arch = arch || process.arch;
-	const binName = (name: string)  => `${name}${util.isWindows(platform) ? ".bat" : ""}`;
-	const mock = binName("pact-mock-service");
-	const message = binName("pact-message");
-	const verify = binName("pact-provider-verifier");
-	const broker = binName("pact-broker");
-	const stub = binName("pact-stub-service");
-	const pact = binName("pact");
-	const basePath = path.join("standalone", getBinaryEntry(platform, arch).folderName, "bin");
+export const standalone = (
+  platform?: string,
+  arch?: string,
+): PactStandalone => {
+  platform = platform || process.platform;
+  arch = arch || process.arch;
+  const binName = (name: string) =>
+    `${name}${util.isWindows(platform) ? '.bat' : ''}`;
+  const mock = binName('pact-mock-service');
+  const message = binName('pact-message');
+  const verify = binName('pact-provider-verifier');
+  const broker = binName('pact-broker');
+  const stub = binName('pact-stub-service');
+  const pact = binName('pact');
+  const basePath = path.join(
+    'standalone',
+    getBinaryEntry(platform, arch).folderName,
+    'bin',
+  );
 
-	return {
-		cwd: util.cwd,
-		brokerPath: path.join(basePath, broker),
-		brokerFullPath: path.resolve(util.cwd, basePath, broker).trim(),
-		messagePath: path.join(basePath, message),
-		messageFullPath: path.resolve(util.cwd, basePath, message).trim(),
-		mockServicePath: path.join(basePath, mock),
-		mockServiceFullPath: path.resolve(util.cwd, basePath, mock).trim(),
-		stubPath: path.join(basePath, stub),
-		stubFullPath: path.resolve(util.cwd, basePath, stub).trim(),
-		pactPath: path.join(basePath, pact),
-		pactFullPath: path.resolve(util.cwd, basePath, pact).trim(),
-		verifierPath: path.join(basePath, verify),
-		verifierFullPath: path.resolve(util.cwd, basePath, verify).trim()
-	};
+  return {
+    cwd: util.cwd,
+    brokerPath: path.join(basePath, broker),
+    brokerFullPath: path.resolve(util.cwd, basePath, broker).trim(),
+    messagePath: path.join(basePath, message),
+    messageFullPath: path.resolve(util.cwd, basePath, message).trim(),
+    mockServicePath: path.join(basePath, mock),
+    mockServiceFullPath: path.resolve(util.cwd, basePath, mock).trim(),
+    stubPath: path.join(basePath, stub),
+    stubFullPath: path.resolve(util.cwd, basePath, stub).trim(),
+    pactPath: path.join(basePath, pact),
+    pactFullPath: path.resolve(util.cwd, basePath, pact).trim(),
+    verifierPath: path.join(basePath, verify),
+    verifierFullPath: path.resolve(util.cwd, basePath, verify).trim(),
+  };
 };
 
 export default standalone();

--- a/src/pact-util.spec.ts
+++ b/src/pact-util.spec.ts
@@ -1,92 +1,116 @@
-import chai = require("chai");
-import chaiAsPromised = require("chai-as-promised");
-import pactUtil, {DEFAULT_ARG} from "./pact-util";
+import chai = require('chai');
+import chaiAsPromised = require('chai-as-promised');
+import pactUtil, { DEFAULT_ARG } from './pact-util';
 
 const expect = chai.expect;
 
 chai.use(chaiAsPromised);
 
-describe("Pact Util Spec", () => {
-	describe("createArguments", () => {
-		describe("when called with an object", () => {
-			it("should return an array of all arguments", () => {
-				const result = pactUtil.createArguments({providerBaseUrl: "http://localhost",}, {providerBaseUrl: "--provider-base-url",});
-				expect(result).to.be.an("array").that.includes("--provider-base-url");
-				expect(result.length).to.be.equal(2);
-			});
+describe('Pact Util Spec', () => {
+  describe('createArguments', () => {
+    describe('when called with an object', () => {
+      it('should return an array of all arguments', () => {
+        const result = pactUtil.createArguments(
+          { providerBaseUrl: 'http://localhost' },
+          { providerBaseUrl: '--provider-base-url' },
+        );
+        expect(result)
+          .to.be.an('array')
+          .that.includes('--provider-base-url');
+        expect(result.length).to.be.equal(2);
+      });
 
-			it("should wrap its argument values in quotes", () => {
-				const result = pactUtil.createArguments({
-					providerBaseUrl: "http://localhost",
-					pactUrls: ["http://idontexist"]
-				}, {
-					providerBaseUrl: "--provider-base-url",
-					pactUrls: "--pact-urls"
-				});
-				expect(result).to.include("--provider-base-url");
-				expect(result).to.include("'http://localhost'");
-				expect(result).to.include("--pact-urls");
-				expect(result).to.include("'http://idontexist'");
-			});
-		});
-		describe("when called with an array", () => {
-			describe("with one element",() => {
-				it("should return an array of all arguments", () => {
-					const result = pactUtil.createArguments([{providerBaseUrl: "http://localhost",}], {providerBaseUrl: "--provider-base-url",});
-					expect(result).to.be.an("array").that.includes("--provider-base-url");
-					expect(result.length).to.be.equal(2);
-				});
+      it('should wrap its argument values in quotes', () => {
+        const result = pactUtil.createArguments(
+          {
+            providerBaseUrl: 'http://localhost',
+            pactUrls: ['http://idontexist'],
+          },
+          {
+            providerBaseUrl: '--provider-base-url',
+            pactUrls: '--pact-urls',
+          },
+        );
+        expect(result).to.include('--provider-base-url');
+        expect(result).to.include("'http://localhost'");
+        expect(result).to.include('--pact-urls');
+        expect(result).to.include("'http://idontexist'");
+      });
+    });
+    describe('when called with an array', () => {
+      describe('with one element', () => {
+        it('should return an array of all arguments', () => {
+          const result = pactUtil.createArguments(
+            [{ providerBaseUrl: 'http://localhost' }],
+            {
+              providerBaseUrl: '--provider-base-url',
+            },
+          );
+          expect(result)
+            .to.be.an('array')
+            .that.includes('--provider-base-url');
+          expect(result.length).to.be.equal(2);
+        });
 
-				it("should wrap its argument values in quotes", () => {
-					const result = pactUtil.createArguments([{
-						providerBaseUrl: "http://localhost",
-						pactUrls: ["http://idontexist"]
-					}], {
-						providerBaseUrl: "--provider-base-url",
-						pactUrls: "--pact-urls"
-					});
-					expect(result).to.include("--provider-base-url");
-					expect(result).to.include("'http://localhost'");
-					expect(result).to.include("--pact-urls");
-					expect(result).to.include("'http://idontexist'");
-				});
-			});
-			describe("with multiple elements",() => {
-				it("should wrap its argument values in quotes", () => {
-					const result = pactUtil.createArguments(
-						[
-							{participant: "one"},
-							{version: "v1"},
-							{participant: "two"},
-							{version: "v2"}
-						],
-						{version: "--version" ,participant: "--participant",}
-					);
+        it('should wrap its argument values in quotes', () => {
+          const result = pactUtil.createArguments(
+            [
+              {
+                providerBaseUrl: 'http://localhost',
+                pactUrls: ['http://idontexist'],
+              },
+            ],
+            {
+              providerBaseUrl: '--provider-base-url',
+              pactUrls: '--pact-urls',
+            },
+          );
+          expect(result).to.include('--provider-base-url');
+          expect(result).to.include("'http://localhost'");
+          expect(result).to.include('--pact-urls');
+          expect(result).to.include("'http://idontexist'");
+        });
+      });
+      describe('with multiple elements', () => {
+        it('should wrap its argument values in quotes', () => {
+          const result = pactUtil.createArguments(
+            [
+              { participant: 'one' },
+              { version: 'v1' },
+              { participant: 'two' },
+              { version: 'v2' },
+            ],
+            { version: '--version', participant: '--participant' },
+          );
 
-					expect(result).to.be.an("array");
-					expect(result).to.eql(
-						["--participant",
-						"'one'",
-						"--version",
-						"'v1'",
-						"--participant",
-						"'two'",
-						"--version",
-						"'v2'"]);
-				});
-			});
-		});
+          expect(result).to.be.an('array');
+          expect(result).to.eql([
+            '--participant',
+            "'one'",
+            '--version',
+            "'v1'",
+            '--participant',
+            "'two'",
+            '--version',
+            "'v2'",
+          ]);
+        });
+      });
+    });
 
-		it("should make DEFAULT values first, everything else after", () => {
-			const result = pactUtil.createArguments({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["http://idontexist"]
-			}, {
-				providerBaseUrl: "--provider-base-url",
-				pactUrls: DEFAULT_ARG
-			});
-			expect(result.length).to.be.equal(3);
-			expect(result[0]).to.be.equal("'http://idontexist'");
-		});
-	});
+    it('should make DEFAULT values first, everything else after', () => {
+      const result = pactUtil.createArguments(
+        {
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['http://idontexist'],
+        },
+        {
+          providerBaseUrl: '--provider-base-url',
+          pactUrls: DEFAULT_ARG,
+        },
+      );
+      expect(result.length).to.be.equal(3);
+      expect(result[0]).to.be.equal("'http://idontexist'");
+    });
+  });
 });

--- a/src/pact-util.ts
+++ b/src/pact-util.ts
@@ -1,109 +1,136 @@
 // tslint:disable:no-string-literal
-import cp = require("child_process");
-import logger from "./logger";
-import {ChildProcess, SpawnOptions} from "child_process";
-import * as path from "path";
+import cp = require('child_process');
+import logger from './logger';
+import { ChildProcess, SpawnOptions } from 'child_process';
+import * as path from 'path';
 
-const _ = require("underscore");
-const checkTypes = require("check-types");
+const _ = require('underscore');
+const checkTypes = require('check-types');
 
-export const DEFAULT_ARG = "DEFAULT";
+export const DEFAULT_ARG = 'DEFAULT';
 
 export class PactUtil {
-	private static createArgumentsFromObject(args: SpawnArguments, mappings: { [id: string]: string }): string[] {
-		return _.chain(args)
-			.reduce((acc: any, value: any, key: any) => {
-				if (value && mappings[key]) {
-					let mapping = mappings[key];
-					let f = acc.push.bind(acc);
-					if (mapping === DEFAULT_ARG) {
-						mapping = "";
-						f = acc.unshift.bind(acc);
-					}
-					_.map(checkTypes.array(value) ? value : [value], (v: any) => f([mapping, `'${v}'`]));
-				}
-				return acc;
-			}, [])
-			.flatten()
-			.compact()
-			.value();
-	}
+  private static createArgumentsFromObject(
+    args: SpawnArguments,
+    mappings: { [id: string]: string },
+  ): string[] {
+    return _.chain(args)
+      .reduce((acc: any, value: any, key: any) => {
+        if (value && mappings[key]) {
+          let mapping = mappings[key];
+          let f = acc.push.bind(acc);
+          if (mapping === DEFAULT_ARG) {
+            mapping = '';
+            f = acc.unshift.bind(acc);
+          }
+          _.map(checkTypes.array(value) ? value : [value], (v: any) =>
+            f([mapping, `'${v}'`]),
+          );
+        }
+        return acc;
+      }, [])
+      .flatten()
+      .compact()
+      .value();
+  }
 
-	public createArguments(args: SpawnArguments | SpawnArguments[], mappings: { [id: string]: string }): string[] {
-		return _.chain(args instanceof Array ? args : [args]).map((x: SpawnArguments) => PactUtil.createArgumentsFromObject(x, mappings)).flatten().value();
-	}
+  public createArguments(
+    args: SpawnArguments | SpawnArguments[],
+    mappings: { [id: string]: string },
+  ): string[] {
+    return _.chain(args instanceof Array ? args : [args])
+      .map((x: SpawnArguments) =>
+        PactUtil.createArgumentsFromObject(x, mappings),
+      )
+      .flatten()
+      .value();
+  }
 
-	public get cwd(): string {
-		return path.resolve(__dirname, "..");
-	}
+  public get cwd(): string {
+    return path.resolve(__dirname, '..');
+  }
 
-	public spawnBinary(command: string, args: SpawnArguments | SpawnArguments[] = {}, argMapping: { [id: string]: string } = {}): ChildProcess {
-		const envVars = JSON.parse(JSON.stringify(process.env)); // Create copy of environment variables
-		// Remove environment variable if there
-		// This is a hack to prevent some weird Travelling Ruby behaviour with Gems
-		// https://github.com/pact-foundation/pact-mock-service-npm/issues/16
-		delete envVars["RUBYGEMS_GEMDEPS"];
+  public spawnBinary(
+    command: string,
+    args: SpawnArguments | SpawnArguments[] = {},
+    argMapping: { [id: string]: string } = {},
+  ): ChildProcess {
+    const envVars = JSON.parse(JSON.stringify(process.env)); // Create copy of environment variables
+    // Remove environment variable if there
+    // This is a hack to prevent some weird Travelling Ruby behaviour with Gems
+    // https://github.com/pact-foundation/pact-mock-service-npm/issues/16
+    delete envVars['RUBYGEMS_GEMDEPS'];
 
-		let file: string;
-		let opts: SpawnOptions = {
-			cwd: this.cwd,
-			detached: !this.isWindows(),
-			env: envVars
-		};
+    let file: string;
+    let opts: SpawnOptions = {
+      cwd: this.cwd,
+      detached: !this.isWindows(),
+      env: envVars,
+    };
 
-		let cmd: string = [command].concat(this.createArguments(args, argMapping)).join(" ");
+    let cmd: string = [command]
+      .concat(this.createArguments(args, argMapping))
+      .join(' ');
 
-		let spawnArgs: string[];
-		if (this.isWindows()) {
-			file = "cmd.exe";
-			spawnArgs = ["/s", "/c", cmd];
-			(opts as any).windowsVerbatimArguments = true;
-		} else {
-			cmd = `./${cmd}`;
-			file = "/bin/sh";
-			spawnArgs = ["-c", cmd];
-		}
+    let spawnArgs: string[];
+    if (this.isWindows()) {
+      file = 'cmd.exe';
+      spawnArgs = ['/s', '/c', cmd];
+      (opts as any).windowsVerbatimArguments = true;
+    } else {
+      cmd = `./${cmd}`;
+      file = '/bin/sh';
+      spawnArgs = ['-c', cmd];
+    }
 
-		logger.debug(`Starting pact binary with '${_.flatten([file, args, JSON.stringify(opts)])}'`);
-		const instance = cp.spawn(file, spawnArgs, opts);
+    logger.debug(
+      `Starting pact binary with '${_.flatten([
+        file,
+        args,
+        JSON.stringify(opts),
+      ])}'`,
+    );
+    const instance = cp.spawn(file, spawnArgs, opts);
 
-		instance.stdout.setEncoding("utf8");
-		instance.stderr.setEncoding("utf8");
-		instance.stdout.on("data", logger.debug.bind(logger));
-		instance.stderr.on("data", logger.debug.bind(logger));
-		instance.on("error", logger.error.bind(logger));
-		instance.once("close", (code) => {
-			if (code !== 0) {
-				logger.warn(`Pact exited with code ${code}.`);
-			}
-		});
+    instance.stdout.setEncoding('utf8');
+    instance.stderr.setEncoding('utf8');
+    instance.stdout.on('data', logger.debug.bind(logger));
+    instance.stderr.on('data', logger.debug.bind(logger));
+    instance.on('error', logger.error.bind(logger));
+    instance.once('close', code => {
+      if (code !== 0) {
+        logger.warn(`Pact exited with code ${code}.`);
+      }
+    });
 
-		logger.info(`Created '${cmd}' process with PID: ${instance.pid}`);
-		return instance;
-	}
+    logger.info(`Created '${cmd}' process with PID: ${instance.pid}`);
+    return instance;
+  }
 
-	public killBinary(binary: ChildProcess): boolean {
-		if (binary) {
-			const pid = binary.pid;
-			logger.info(`Removing Pact with PID: ${pid}`);
-			binary.removeAllListeners();
-			// Killing instance, since windows can't send signals, must kill process forcefully
-			try {
-				this.isWindows() ? cp.execSync(`taskkill /f /t /pid ${pid}`) : process.kill(-pid, "SIGINT");
-			} catch (e) {
-				return false;
-			}
-		}
-		return true;
-	}
+  public killBinary(binary: ChildProcess): boolean {
+    if (binary) {
+      const pid = binary.pid;
+      logger.info(`Removing Pact with PID: ${pid}`);
+      binary.removeAllListeners();
+      // Killing instance, since windows can't send signals, must kill process forcefully
+      try {
+        this.isWindows()
+          ? cp.execSync(`taskkill /f /t /pid ${pid}`)
+          : process.kill(-pid, 'SIGINT');
+      } catch (e) {
+        return false;
+      }
+    }
+    return true;
+  }
 
-	public isWindows(platform: string = process.platform): boolean {
-		return platform === "win32";
-	}
+  public isWindows(platform: string = process.platform): boolean {
+    return platform === 'win32';
+  }
 }
 
 export interface SpawnArguments {
-	[id: string]: string | string[] | boolean | number | undefined;
+  [id: string]: string | string[] | boolean | number | undefined;
 }
 
 export default new PactUtil();

--- a/src/pact.spec.ts
+++ b/src/pact.spec.ts
@@ -1,240 +1,262 @@
-import chai = require("chai");
-import path = require("path");
-import chaiAsPromised = require("chai-as-promised");
-import fs = require("fs");
-import pact from "./pact";
+import chai = require('chai');
+import path = require('path');
+import chaiAsPromised = require('chai-as-promised');
+import fs = require('fs');
+import pact from './pact';
 
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
-describe("Pact Spec", () => {
-	afterEach(() => pact.removeAllServers());
+describe('Pact Spec', () => {
+  afterEach(() => pact.removeAllServers());
 
-	describe("Set Log Level", () => {
-		let originalLogLevel: any;
-		// Reset log level after the tests
-		before(() => originalLogLevel = pact.logLevel());
-		after(() => pact.logLevel(originalLogLevel));
+  describe('Set Log Level', () => {
+    let originalLogLevel: any;
+    // Reset log level after the tests
+    before(() => (originalLogLevel = pact.logLevel()));
+    after(() => pact.logLevel(originalLogLevel));
 
-		context("when setting a log level", () => {
-			it("should be able to set log level 'trace'", () => {
-				pact.logLevel("trace");
-				expect(pact.logLevel()).to.be.equal(10);
-			});
+    context('when setting a log level', () => {
+      it("should be able to set log level 'trace'", () => {
+        pact.logLevel('trace');
+        expect(pact.logLevel()).to.be.equal(10);
+      });
 
-			it("should be able to set log level 'debug'", () => {
-				pact.logLevel("debug");
-				expect(pact.logLevel()).to.be.equal(20);
-			});
+      it("should be able to set log level 'debug'", () => {
+        pact.logLevel('debug');
+        expect(pact.logLevel()).to.be.equal(20);
+      });
 
-			it("should be able to set log level 'info'", () => {
-				pact.logLevel("info");
-				expect(pact.logLevel()).to.be.equal(30);
-			});
+      it("should be able to set log level 'info'", () => {
+        pact.logLevel('info');
+        expect(pact.logLevel()).to.be.equal(30);
+      });
 
-			it("should be able to set log level 'warn'", () => {
-				pact.logLevel("warn");
-				expect(pact.logLevel()).to.be.equal(40);
-			});
+      it("should be able to set log level 'warn'", () => {
+        pact.logLevel('warn');
+        expect(pact.logLevel()).to.be.equal(40);
+      });
 
-			it("should be able to set log level 'error'", () => {
-				pact.logLevel("error");
-				expect(pact.logLevel()).to.be.equal(50);
-			});
+      it("should be able to set log level 'error'", () => {
+        pact.logLevel('error');
+        expect(pact.logLevel()).to.be.equal(50);
+      });
 
-			it("should be able to set log level 'fatal'", () => {
-				pact.logLevel("fatal");
-				expect(pact.logLevel()).to.be.equal(60);
-			});
-		});
-	});
+      it("should be able to set log level 'fatal'", () => {
+        pact.logLevel('fatal');
+        expect(pact.logLevel()).to.be.equal(60);
+      });
+    });
+  });
 
-	describe("Create serverFactory", () => {
-		let dirPath: string;
-		const monkeypatchFile: string = path.resolve(__dirname, "../test/monkeypatch.rb");
+  describe('Create serverFactory', () => {
+    let dirPath: string;
+    const monkeypatchFile: string = path.resolve(
+      __dirname,
+      '../test/monkeypatch.rb',
+    );
 
-		beforeEach(() => dirPath = path.resolve(__dirname, `../.tmp/${Math.floor(Math.random() * 1000)}`));
+    beforeEach(
+      () =>
+        (dirPath = path.resolve(
+          __dirname,
+          `../.tmp/${Math.floor(Math.random() * 1000)}`,
+        )),
+    );
 
-		afterEach(() => {
-			try {
-				if (fs.statSync(dirPath).isDirectory()) {
-					fs.rmdirSync(dirPath);
-				}
-			} catch (e) {
-			}
-		});
+    afterEach(() => {
+      try {
+        if (fs.statSync(dirPath).isDirectory()) {
+          fs.rmdirSync(dirPath);
+        }
+      } catch (e) {}
+    });
 
-		context("when no options are set", () => {
-			it("should use defaults and return serverFactory", () => {
-				let server = pact.createServer();
-				expect(server).to.be.an("object");
-				expect(server.options).to.be.an("object");
-				expect(server.options).to.contain.all.keys(["cors", "ssl", "host", "dir"]);
-				expect(server.start).to.be.a("function");
-				expect(server.stop).to.be.a("function");
-				expect(server.delete).to.be.a("function");
-			});
-		});
+    context('when no options are set', () => {
+      it('should use defaults and return serverFactory', () => {
+        let server = pact.createServer();
+        expect(server).to.be.an('object');
+        expect(server.options).to.be.an('object');
+        expect(server.options).to.contain.all.keys([
+          'cors',
+          'ssl',
+          'host',
+          'dir',
+        ]);
+        expect(server.start).to.be.a('function');
+        expect(server.stop).to.be.a('function');
+        expect(server.delete).to.be.a('function');
+      });
+    });
 
-		context("when user specifies valid options", () => {
-			it("should return serverFactory using specified options", () => {
-				let options = {
-					port: 9500,
-					host: "localhost",
-					dir: dirPath,
-					ssl: true,
-					cors: true,
-					log: "log.txt",
-					spec: 1,
-					consumer: "consumerName",
-					provider: "providerName",
-					monkeypatch: monkeypatchFile
-				};
-				let server = pact.createServer(options);
-				expect(server).to.be.an("object");
-				expect(server.options).to.be.an("object");
-				expect(server.options.port).to.equal(options.port);
-				expect(server.options.host).to.equal(options.host);
-				expect(server.options.dir).to.equal(options.dir);
-				expect(server.options.ssl).to.equal(options.ssl);
-				expect(server.options.cors).to.equal(options.cors);
-				expect(server.options.log).to.equal(options.log);
-				expect(server.options.spec).to.equal(options.spec);
-				expect(server.options.consumer).to.equal(options.consumer);
-				expect(server.options.provider).to.equal(options.provider);
-				expect(server.options.monkeypatch).to.equal(options.monkeypatch);
-			});
-		});
+    context('when user specifies valid options', () => {
+      it('should return serverFactory using specified options', () => {
+        let options = {
+          port: 9500,
+          host: 'localhost',
+          dir: dirPath,
+          ssl: true,
+          cors: true,
+          log: 'log.txt',
+          spec: 1,
+          consumer: 'consumerName',
+          provider: 'providerName',
+          monkeypatch: monkeypatchFile,
+        };
+        let server = pact.createServer(options);
+        expect(server).to.be.an('object');
+        expect(server.options).to.be.an('object');
+        expect(server.options.port).to.equal(options.port);
+        expect(server.options.host).to.equal(options.host);
+        expect(server.options.dir).to.equal(options.dir);
+        expect(server.options.ssl).to.equal(options.ssl);
+        expect(server.options.cors).to.equal(options.cors);
+        expect(server.options.log).to.equal(options.log);
+        expect(server.options.spec).to.equal(options.spec);
+        expect(server.options.consumer).to.equal(options.consumer);
+        expect(server.options.provider).to.equal(options.provider);
+        expect(server.options.monkeypatch).to.equal(options.monkeypatch);
+      });
+    });
 
-		context("when user specifies invalid port", () => {
-			it("should return an error on negative port number", () => {
-				expect(() => pact.createServer({port: -42})).to.throw(Error);
-			});
+    context('when user specifies invalid port', () => {
+      it('should return an error on negative port number', () => {
+        expect(() => pact.createServer({ port: -42 })).to.throw(Error);
+      });
 
-			it("should return an error on non-integer", () => {
-				expect(() => {
-					pact.createServer({port: 42.42});
-				}).to.throw(Error);
-			});
+      it('should return an error on non-integer', () => {
+        expect(() => {
+          pact.createServer({ port: 42.42 });
+        }).to.throw(Error);
+      });
 
-			it("should return an error on non-number", () => {
-				expect(() => pact.createServer({port: "99"} as any)).to.throw(Error);
-			});
+      it('should return an error on non-number', () => {
+        expect(() => pact.createServer({ port: '99' } as any)).to.throw(Error);
+      });
 
-			it("should return an error on outside port range", () => {
-				expect(() => {
-					pact.createServer({port: 99999});
-				}).to.throw(Error);
-			});
-		});
+      it('should return an error on outside port range', () => {
+        expect(() => {
+          pact.createServer({ port: 99999 });
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies port that's currently in use", () => {
-			it("should return a port conflict error", () => {
-				pact.createServer({port: 5100});
-				expect(() => pact.createServer({port: 5100})).to.throw(Error);
-			});
-		});
+    context("when user specifies port that's currently in use", () => {
+      it('should return a port conflict error', () => {
+        pact.createServer({ port: 5100 });
+        expect(() => pact.createServer({ port: 5100 })).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid host", () => {
-			it("should return an error on non-string", () => {
-				expect(() => pact.createServer({host: 12} as any)).to.throw(Error);
-			});
-		});
+    context('when user specifies invalid host', () => {
+      it('should return an error on non-string', () => {
+        expect(() => pact.createServer({ host: 12 } as any)).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid pact directory", () => {
-			it("should create the directory for us", () => {
-				pact.createServer({dir: dirPath});
-				expect(fs.statSync(dirPath).isDirectory()).to.be.true;
-			});
-		});
+    context('when user specifies invalid pact directory', () => {
+      it('should create the directory for us', () => {
+        pact.createServer({ dir: dirPath });
+        expect(fs.statSync(dirPath).isDirectory()).to.be.true;
+      });
+    });
 
-		context("when user specifies invalid ssl", () => {
-			it("should return an error on non-boolean", () => {
-				expect(() => pact.createServer({ssl: 1} as any)).to.throw(Error);
-			});
-		});
+    context('when user specifies invalid ssl', () => {
+      it('should return an error on non-boolean', () => {
+        expect(() => pact.createServer({ ssl: 1 } as any)).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid cors", () => {
-			it("should return an error on non-boolean", () => {
-				expect(() => pact.createServer({cors: 1} as any)).to.throw(Error);
-			});
-		});
+    context('when user specifies invalid cors', () => {
+      it('should return an error on non-boolean', () => {
+        expect(() => pact.createServer({ cors: 1 } as any)).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid spec", () => {
-			it("should return an error on non-number", () => {
-				expect(() => pact.createServer({spec: "1"} as any)).to.throw(Error);
-			});
+    context('when user specifies invalid spec', () => {
+      it('should return an error on non-number', () => {
+        expect(() => pact.createServer({ spec: '1' } as any)).to.throw(Error);
+      });
 
-			it("should return an error on negative number", () => {
-				expect(() => {
-					pact.createServer({spec: -12});
-				}).to.throw(Error);
-			});
+      it('should return an error on negative number', () => {
+        expect(() => {
+          pact.createServer({ spec: -12 });
+        }).to.throw(Error);
+      });
 
-			it("should return an error on non-integer", () => {
-				expect(() => {
-					pact.createServer({spec: 3.14});
-				}).to.throw(Error);
-			});
-		});
+      it('should return an error on non-integer', () => {
+        expect(() => {
+          pact.createServer({ spec: 3.14 });
+        }).to.throw(Error);
+      });
+    });
 
-		context("when user specifies invalid consumer name", () => {
-			it("should return an error on non-string", () => {
-				expect(() => pact.createServer({consumer: 1234} as any)).to.throw(Error);
-			});
-		});
+    context('when user specifies invalid consumer name', () => {
+      it('should return an error on non-string', () => {
+        expect(() => pact.createServer({ consumer: 1234 } as any)).to.throw(
+          Error,
+        );
+      });
+    });
 
-		context("when user specifies invalid provider name", () => {
-			it("should return an error on non-string", () => {
-				expect(() => pact.createServer({provider: 2341} as any)).to.throw(Error);
-			});
-		});
+    context('when user specifies invalid provider name', () => {
+      it('should return an error on non-string', () => {
+        expect(() => pact.createServer({ provider: 2341 } as any)).to.throw(
+          Error,
+        );
+      });
+    });
 
-		context("when user specifies invalid monkeypatch", () => {
-			it("should return an error on invalid path", () => {
-				expect(() => {
-					pact.createServer({monkeypatch: "some-ruby-file.rb"});
-				}).to.throw(Error);
-			});
-		});
-	});
+    context('when user specifies invalid monkeypatch', () => {
+      it('should return an error on invalid path', () => {
+        expect(() => {
+          pact.createServer({ monkeypatch: 'some-ruby-file.rb' });
+        }).to.throw(Error);
+      });
+    });
+  });
 
-	describe("List servers", () => {
-		context("when called and there are no servers", () => {
-			it("should return an empty list", () => {
-				expect(pact.listServers()).to.be.empty;
-			});
-		});
+  describe('List servers', () => {
+    context('when called and there are no servers', () => {
+      it('should return an empty list', () => {
+        expect(pact.listServers()).to.be.empty;
+      });
+    });
 
-		context("when called and there are servers in list", () => {
-			it("should return a list of all servers", () => {
-				pact.createServer({port: 1234});
-				pact.createServer({port: 1235});
-				pact.createServer({port: 1236});
-				expect(pact.listServers()).to.have.length(3);
-			});
-		});
+    context('when called and there are servers in list', () => {
+      it('should return a list of all servers', () => {
+        pact.createServer({ port: 1234 });
+        pact.createServer({ port: 1235 });
+        pact.createServer({ port: 1236 });
+        expect(pact.listServers()).to.have.length(3);
+      });
+    });
 
-		context("when server is removed", () => {
-			it("should update the list", () => {
-				pact.createServer({port: 1234});
-				pact.createServer({port: 1235});
-				return pact.createServer({port: 1236})
-					.delete()
-					.then(() => expect(pact.listServers()).to.have.length(2));
-			});
-		});
-	});
+    context('when server is removed', () => {
+      it('should update the list', () => {
+        pact.createServer({ port: 1234 });
+        pact.createServer({ port: 1235 });
+        return pact
+          .createServer({ port: 1236 })
+          .delete()
+          .then(() => expect(pact.listServers()).to.have.length(2));
+      });
+    });
+  });
 
-	describe("Remove all servers", () => {
-		context("when removeAll() is called and there are servers to remove", () => {
-			it("should remove all servers", () => {
-				pact.createServer({port: 1234});
-				pact.createServer({port: 1235});
-				pact.createServer({port: 1236});
-				return pact.removeAllServers()
-					.then(() => expect(pact.listServers()).to.be.empty);
-			});
-		});
-	});
+  describe('Remove all servers', () => {
+    context(
+      'when removeAll() is called and there are servers to remove',
+      () => {
+        it('should remove all servers', () => {
+          pact.createServer({ port: 1234 });
+          pact.createServer({ port: 1235 });
+          pact.createServer({ port: 1236 });
+          return pact
+            .removeAllServers()
+            .then(() => expect(pact.listServers()).to.be.empty);
+        });
+      },
+    );
+  });
 });

--- a/src/pact.ts
+++ b/src/pact.ts
@@ -1,156 +1,192 @@
-import * as q from "q";
-import * as path from "path";
-import serverFactory, {Server, ServerOptions} from "./server";
-import stubFactory, {Stub, StubOptions} from "./stub";
-import verifierFactory, {VerifierOptions} from "./verifier";
-import messageFactory, {MessageOptions} from "./message";
-import publisherFactory, {PublisherOptions} from "./publisher";
-import canDeployFactory, {CanDeployOptions} from "./can-deploy";
-import util from "./pact-util";
-import logger, {LogLevels} from "./logger";
-import {AbstractService} from "./service";
-import * as _ from "underscore";
-const mkdirp = require("mkdirp");
-const rimraf = require("rimraf");
+import * as q from 'q';
+import * as path from 'path';
+import serverFactory, { Server, ServerOptions } from './server';
+import stubFactory, { Stub, StubOptions } from './stub';
+import verifierFactory, { VerifierOptions } from './verifier';
+import messageFactory, { MessageOptions } from './message';
+import publisherFactory, { PublisherOptions } from './publisher';
+import canDeployFactory, { CanDeployOptions } from './can-deploy';
+import util from './pact-util';
+import logger, { LogLevels } from './logger';
+import { AbstractService } from './service';
+import * as _ from 'underscore';
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
 
 export class Pact {
-	private __servers: Server[] = [];
-	private __stubs: Stub[] = [];
+  private __servers: Server[] = [];
+  private __stubs: Stub[] = [];
 
-	constructor() {
-		// Check to see if we hit into Windows Long Path issue
-		if(util.isWindows()) {
-			try {
-				// Trying to trigger windows error by creating path that's over 260 characters long
-				const name = "Jctyo0NXwbPN6Y1o8p2TkicKma2kfqmXwVLw6ypBX47uktBPX9FM9kbPraQXsAUZuT6BvenTbnWczXzuN4js0KB9e7P5cccxvmXPYcFhJnBvPSKGH1FlTqEOsjl8djk3md";
-				const dir = mkdirp.sync(path.resolve(__dirname, name, name));
-				dir && rimraf.sync(dir);
-			} catch {
-				logger.warn("WARNING: Windows Long Paths is not enabled and might cause Pact to crash if the path is too long. " +
-					"To fix this issue, please consult https://github.com/pact-foundation/pact-node#enable-long-paths`");
-			}
-		}
+  constructor() {
+    // Check to see if we hit into Windows Long Path issue
+    if (util.isWindows()) {
+      try {
+        // Trying to trigger windows error by creating path that's over 260 characters long
+        const name =
+          'Jctyo0NXwbPN6Y1o8p2TkicKma2kfqmXwVLw6ypBX47uktBPX9FM9kbPraQXsAUZuT6BvenTbnWczXzuN4js0KB9e7P5cccxvmXPYcFhJnBvPSKGH1FlTqEOsjl8djk3md';
+        const dir = mkdirp.sync(path.resolve(__dirname, name, name));
+        dir && rimraf.sync(dir);
+      } catch {
+        logger.warn(
+          'WARNING: Windows Long Paths is not enabled and might cause Pact to crash if the path is too long. ' +
+            'To fix this issue, please consult https://github.com/pact-foundation/pact-node#enable-long-paths`',
+        );
+      }
+    }
 
-		// Listen for Node exiting or someone killing the process
-		// Must remove all the instances of Pact mock service
-		process.once("exit", () => this.removeAll());
-		process.once("SIGINT", () => process.exit());
-	}
+    // Listen for Node exiting or someone killing the process
+    // Must remove all the instances of Pact mock service
+    process.once('exit', () => this.removeAll());
+    process.once('SIGINT', () => process.exit());
+  }
 
-	public logLevel(level?: LogLevels): number | void {
-		return level ? logger.level(level) : logger.level();
-	}
+  public logLevel(level?: LogLevels): number | void {
+    return level ? logger.level(level) : logger.level();
+  }
 
-	// Creates server with specified options
-	public createServer(options: ServerOptions = {}): Server {
-		if (options && options.port && _.some(this.__servers, (s: Server) => s.options.port === options.port)) {
-			let msg = `Port '${options.port}' is already in use by another process.`;
-			logger.error(msg);
-			throw new Error(msg);
-		}
+  // Creates server with specified options
+  public createServer(options: ServerOptions = {}): Server {
+    if (
+      options &&
+      options.port &&
+      _.some(this.__servers, (s: Server) => s.options.port === options.port)
+    ) {
+      let msg = `Port '${options.port}' is already in use by another process.`;
+      logger.error(msg);
+      throw new Error(msg);
+    }
 
-		let server = serverFactory(options);
-		this.__servers.push(server);
-		logger.info(`Creating Pact Server with options: \n${this.__stringifyOptions(server.options)}`);
+    let server = serverFactory(options);
+    this.__servers.push(server);
+    logger.info(
+      `Creating Pact Server with options: \n${this.__stringifyOptions(
+        server.options,
+      )}`,
+    );
 
-		// Listen to server delete events, to remove from server list
-		server.once(AbstractService.Events.DELETE_EVENT, (s: Server) => {
-			logger.info(`Deleting Pact Server with options: \n${this.__stringifyOptions(s.options)}`);
-			this.__servers = _.without(this.__servers, s);
-		});
+    // Listen to server delete events, to remove from server list
+    server.once(AbstractService.Events.DELETE_EVENT, (s: Server) => {
+      logger.info(
+        `Deleting Pact Server with options: \n${this.__stringifyOptions(
+          s.options,
+        )}`,
+      );
+      this.__servers = _.without(this.__servers, s);
+    });
 
-		return server;
-	}
+    return server;
+  }
 
-	// Return arrays of all servers
-	public listServers(): Server[] {
-		return this.__servers;
-	}
+  // Return arrays of all servers
+  public listServers(): Server[] {
+    return this.__servers;
+  }
 
-	// Remove all the servers that have been created
-	// Return promise of all others
-	public removeAllServers(): q.Promise<Server[]> {
-		if (this.__servers.length === 0) {
-			return q(this.__servers);
-		}
+  // Remove all the servers that have been created
+  // Return promise of all others
+  public removeAllServers(): q.Promise<Server[]> {
+    if (this.__servers.length === 0) {
+      return q(this.__servers);
+    }
 
-		logger.info("Removing all Pact servers.");
-		return q.all<Server>(_.map(this.__servers, (server: Server) => server.delete() as PromiseLike<Server>));
-	}
+    logger.info('Removing all Pact servers.');
+    return q.all<Server>(
+      _.map(
+        this.__servers,
+        (server: Server) => server.delete() as PromiseLike<Server>,
+      ),
+    );
+  }
 
-	// Creates stub with specified options
-	public createStub(options: StubOptions = {}): Stub {
-		if (options && options.port && _.some(this.__stubs, (s: Stub) => s.options.port === options.port)) {
-			let msg = `Port '${options.port}' is already in use by another process.`;
-			logger.error(msg);
-			throw new Error(msg);
-		}
+  // Creates stub with specified options
+  public createStub(options: StubOptions = {}): Stub {
+    if (
+      options &&
+      options.port &&
+      _.some(this.__stubs, (s: Stub) => s.options.port === options.port)
+    ) {
+      let msg = `Port '${options.port}' is already in use by another process.`;
+      logger.error(msg);
+      throw new Error(msg);
+    }
 
-		let stub = stubFactory(options);
-		this.__stubs.push(stub);
-		logger.info(`Creating Pact Stub with options: \n${this.__stringifyOptions(stub.options)}`);
+    let stub = stubFactory(options);
+    this.__stubs.push(stub);
+    logger.info(
+      `Creating Pact Stub with options: \n${this.__stringifyOptions(
+        stub.options,
+      )}`,
+    );
 
-		// Listen to stub delete events, to remove from stub list
-		stub.once(AbstractService.Events.DELETE_EVENT, (s: Stub) => {
-			logger.info(`Deleting Pact Stub with options: \n${this.__stringifyOptions(s.options)}`);
-			this.__stubs = _.without(this.__stubs, s);
-		});
+    // Listen to stub delete events, to remove from stub list
+    stub.once(AbstractService.Events.DELETE_EVENT, (s: Stub) => {
+      logger.info(
+        `Deleting Pact Stub with options: \n${this.__stringifyOptions(
+          s.options,
+        )}`,
+      );
+      this.__stubs = _.without(this.__stubs, s);
+    });
 
-		return stub;
-	}
+    return stub;
+  }
 
-	// Return arrays of all stubs
-	public listStubs(): Stub[] {
-		return this.__stubs;
-	}
+  // Return arrays of all stubs
+  public listStubs(): Stub[] {
+    return this.__stubs;
+  }
 
-	// Remove all the stubs that have been created
-	// Return promise of all others
-	public removeAllStubs(): q.Promise<Stub[]> {
-		if (this.__stubs.length === 0) {
-			return q(this.__stubs);
-		}
+  // Remove all the stubs that have been created
+  // Return promise of all others
+  public removeAllStubs(): q.Promise<Stub[]> {
+    if (this.__stubs.length === 0) {
+      return q(this.__stubs);
+    }
 
-		logger.info("Removing all Pact stubs.");
-		return q.all<Stub>(_.map(this.__stubs, (stub: Stub) => stub.delete() as PromiseLike<Stub>));
-	}
+    logger.info('Removing all Pact stubs.');
+    return q.all<Stub>(
+      _.map(this.__stubs, (stub: Stub) => stub.delete() as PromiseLike<Stub>),
+    );
+  }
 
-	// Remove all the servers and stubs
-	public removeAll(): q.Promise<AbstractService[]> {
-		return q.all<AbstractService>(_.flatten([this.removeAllStubs(), this.removeAllServers()]));
-	}
+  // Remove all the servers and stubs
+  public removeAll(): q.Promise<AbstractService[]> {
+    return q.all<AbstractService>(
+      _.flatten([this.removeAllStubs(), this.removeAllServers()]),
+    );
+  }
 
-	// Run the Pact Verification process
-	public verifyPacts(options: VerifierOptions): q.Promise<string> {
-		logger.info("Verifying Pacts.");
-		return verifierFactory(options).verify();
-	}
+  // Run the Pact Verification process
+  public verifyPacts(options: VerifierOptions): q.Promise<string> {
+    logger.info('Verifying Pacts.');
+    return verifierFactory(options).verify();
+  }
 
-	// Run the Message Pact creation process
-	public createMessage(options: MessageOptions): q.Promise<string> {
-		logger.info("Creating Message");
-		return messageFactory(options).createMessage();
-	}
+  // Run the Message Pact creation process
+  public createMessage(options: MessageOptions): q.Promise<string> {
+    logger.info('Creating Message');
+    return messageFactory(options).createMessage();
+  }
 
-	// Publish Pacts to a Pact Broker
-	public publishPacts(options: PublisherOptions): q.Promise<any[]> {
-		logger.info("Publishing Pacts to Broker");
-		return publisherFactory(options).publish();
-	}
+  // Publish Pacts to a Pact Broker
+  public publishPacts(options: PublisherOptions): q.Promise<any[]> {
+    logger.info('Publishing Pacts to Broker');
+    return publisherFactory(options).publish();
+  }
 
-	// Use can-i-deploy to determine if it is safe to deploy
-	public canDeploy(options: CanDeployOptions): q.Promise<any[]> {
-		logger.info("Checking if it it possible to deploy");
-		return canDeployFactory(options).canDeploy();
-	}
+  // Use can-i-deploy to determine if it is safe to deploy
+  public canDeploy(options: CanDeployOptions): q.Promise<any[]> {
+    logger.info('Checking if it it possible to deploy');
+    return canDeployFactory(options).canDeploy();
+  }
 
-	private __stringifyOptions(obj: ServerOptions): string {
-		return _.chain(obj)
-			.pairs()
-			.map((v: string[]) => v.join(" = "))
-			.value()
-			.join(",\n");
-	}
+  private __stringifyOptions(obj: ServerOptions): string {
+    return _.chain(obj)
+      .pairs()
+      .map((v: string[]) => v.join(' = '))
+      .value()
+      .join(',\n');
+  }
 }
 
 export default new Pact();

--- a/src/publisher.spec.ts
+++ b/src/publisher.spec.ts
@@ -1,102 +1,108 @@
 // tslint:disable:no-string-literal
 
-import path = require("path");
-import fs = require("fs");
-import chai = require("chai");
-import chaiAsPromised = require("chai-as-promised");
-import publisherFactory, {PublisherOptions} from "./publisher";
-import logger from "./logger";
-import brokerMock from "../test/integration/broker-mock";
-import * as http from "http";
+import path = require('path');
+import fs = require('fs');
+import chai = require('chai');
+import chaiAsPromised = require('chai-as-promised');
+import publisherFactory, { PublisherOptions } from './publisher';
+import logger from './logger';
+import brokerMock from '../test/integration/broker-mock';
+import * as http from 'http';
 
-const rimraf = require("rimraf");
-const mkdirp = require("mkdirp");
+const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
-describe("Publish Spec", () => {
+describe('Publish Spec', () => {
+  const PORT = Math.floor(Math.random() * 999) + 9000;
+  const pactFile = path.resolve(
+    __dirname,
+    '../test/integration/me-they-success.json',
+  );
+  let server: http.Server;
+  let absolutePath: string;
+  let relativePath: string;
 
-	const PORT = Math.floor(Math.random() * 999) + 9000;
-	const pactFile = path.resolve(__dirname, "../test/integration/me-they-success.json");
-	let server: http.Server;
-	let absolutePath: string;
-	let relativePath: string;
+  before(() =>
+    brokerMock(PORT).then(s => {
+      logger.debug(`Pact Broker Mock listening on port: ${PORT}`);
+      server = s;
+    }),
+  );
 
-	before(() => brokerMock(PORT).then((s) => {
-		logger.debug(`Pact Broker Mock listening on port: ${PORT}`);
-		server = s;
-	}));
+  after(() => server.close());
 
-	after(() => server.close());
+  beforeEach(() => {
+    relativePath = `.tmp/${Math.floor(Math.random() * 1000)}`;
+    absolutePath = path.resolve(__dirname, '..', relativePath);
+    mkdirp.sync(absolutePath);
+  });
 
-	beforeEach(() => {
-		relativePath = `.tmp/${Math.floor(Math.random() * 1000)}`;
-		absolutePath = path.resolve(__dirname, "..", relativePath);
-		mkdirp.sync(absolutePath);
-	});
+  afterEach(() => {
+    if (fs.existsSync(absolutePath)) {
+      rimraf.sync(absolutePath);
+    }
+  });
 
-	afterEach(() => {
-		if (fs.existsSync(absolutePath)) {
-			rimraf.sync(absolutePath);
-		}
-	});
+  context('when invalid options are set', () => {
+    it('should fail with an Error when not given pactBroker', () => {
+      expect(() => {
+        publisherFactory({
+          pactFilesOrDirs: [absolutePath],
+          consumerVersion: '1.0.0',
+        } as PublisherOptions);
+      }).to.throw(Error);
+    });
 
-	context("when invalid options are set", () => {
-		it("should fail with an Error when not given pactBroker", () => {
-			expect(() => {
-				publisherFactory({
-					pactFilesOrDirs: [absolutePath],
-					consumerVersion: "1.0.0"
-				} as PublisherOptions);
-			}).to.throw(Error);
-		});
+    it('should fail with an Error when not given consumerVersion', () => {
+      expect(() => {
+        publisherFactory({
+          pactBroker: 'http://localhost',
+          pactFilesOrDirs: [absolutePath],
+        } as PublisherOptions);
+      }).to.throw(Error);
+    });
 
-		it("should fail with an Error when not given consumerVersion", () => {
-			expect(() => {
-				publisherFactory({
-					pactBroker: "http://localhost",
-					pactFilesOrDirs: [absolutePath]
-				} as PublisherOptions);
-			}).to.throw(Error);
-		});
+    it('should fail with an error when not given pactFilesOrDirs', () => {
+      expect(() => {
+        publisherFactory({
+          pactBroker: 'http://localhost',
+          consumerVersion: '1.0.0',
+        } as PublisherOptions);
+      }).to.throw(Error);
+    });
 
-		it("should fail with an error when not given pactFilesOrDirs", () => {
-			expect(() => {
-				publisherFactory({
-					pactBroker: "http://localhost",
-					consumerVersion: "1.0.0"
-				} as PublisherOptions);
-			}).to.throw(Error);
-		});
+    it('should fail with an Error when given Pact paths that do not exist', () => {
+      expect(() => {
+        publisherFactory({
+          pactBroker: 'http://localhost',
+          pactFilesOrDirs: ['test.json'],
+          consumerVersion: '1.0.0',
+        });
+      }).to.throw(Error);
+    });
+  });
 
-		it("should fail with an Error when given Pact paths that do not exist", () => {
-			expect(() => {
-				publisherFactory({
-					pactBroker: "http://localhost",
-					pactFilesOrDirs: ["test.json"],
-					consumerVersion: "1.0.0"
-				});
-			}).to.throw(Error);
-		});
-	});
+  context('when valid options are set', () => {
+    it('should return an absolute path when a relative one is given', () => {
+      expect(
+        publisherFactory({
+          pactBroker: 'http://localhost',
+          pactFilesOrDirs: [relativePath],
+          consumerVersion: '1.0.0',
+        }).options.pactFilesOrDirs[0],
+      ).to.be.equal(path.resolve(__dirname, '..', relativePath));
+    });
 
-	context("when valid options are set", () => {
-		it("should return an absolute path when a relative one is given", () => {
-			expect(publisherFactory({
-				pactBroker: "http://localhost",
-				pactFilesOrDirs: [relativePath],
-				consumerVersion: "1.0.0"
-			}).options.pactFilesOrDirs[0]).to.be.equal(path.resolve(__dirname, "..", relativePath));
-		});
-
-		it("should return a Publisher object when given the correct arguments", () => {
-			const p = publisherFactory({
-				pactBroker: "http://localhost",
-				pactFilesOrDirs: [pactFile],
-				consumerVersion: "1.0.0"
-			});
-			expect(p).to.be.ok;
-			expect(p.publish).to.be.a("function");
-		});
-	});
+    it('should return a Publisher object when given the correct arguments', () => {
+      const p = publisherFactory({
+        pactBroker: 'http://localhost',
+        pactFilesOrDirs: [pactFile],
+        consumerVersion: '1.0.0',
+      });
+      expect(p).to.be.ok;
+      expect(p.publish).to.be.a('function');
+    });
+  });
 });

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -1,106 +1,132 @@
-import q = require("q");
-import path = require("path");
-import fs = require("fs");
-import logger from "./logger";
-import pactUtil, {DEFAULT_ARG, SpawnArguments} from "./pact-util";
-import {deprecate} from "util";
-import pactStandalone from "./pact-standalone";
-const checkTypes = require("check-types");
+import q = require('q');
+import path = require('path');
+import fs = require('fs');
+import logger from './logger';
+import pactUtil, { DEFAULT_ARG, SpawnArguments } from './pact-util';
+import { deprecate } from 'util';
+import pactStandalone from './pact-standalone';
+const checkTypes = require('check-types');
 
 export class Publisher {
-	public static create = deprecate(
-		(options: PublisherOptions) => new Publisher(options),
-		"Create function will be removed in future release, please use the default export function or use `new Publisher()`");
+  public static create = deprecate(
+    (options: PublisherOptions) => new Publisher(options),
+    'Create function will be removed in future release, please use the default export function or use `new Publisher()`',
+  );
 
-	public readonly options: PublisherOptions;
-	private readonly __argMapping = {
-		"pactFilesOrDirs": DEFAULT_ARG,
-		"pactBroker": "--broker-base-url",
-		"pactBrokerUsername": "--broker-username",
-		"pactBrokerPassword": "--broker-password",
-		"pactBrokerToken": "--broker-token",
-		"tags": "--tag",
-		"consumerVersion": "--consumer-app-version",
-		"verbose": "--verbose"
-	};
+  public readonly options: PublisherOptions;
+  private readonly __argMapping = {
+    pactFilesOrDirs: DEFAULT_ARG,
+    pactBroker: '--broker-base-url',
+    pactBrokerUsername: '--broker-username',
+    pactBrokerPassword: '--broker-password',
+    pactBrokerToken: '--broker-token',
+    tags: '--tag',
+    consumerVersion: '--consumer-app-version',
+    verbose: '--verbose',
+  };
 
-	constructor(options: PublisherOptions) {
-		options = options || {};
-		// Setting defaults
-		options.tags = options.tags || [];
-		options.timeout = options.timeout || 60000;
+  constructor(options: PublisherOptions) {
+    options = options || {};
+    // Setting defaults
+    options.tags = options.tags || [];
+    options.timeout = options.timeout || 60000;
 
-		checkTypes.assert.nonEmptyString(options.pactBroker, "Must provide the pactBroker argument");
-		checkTypes.assert.nonEmptyString(options.consumerVersion, "Must provide the consumerVersion argument");
-		checkTypes.assert.arrayLike(options.pactFilesOrDirs, "Must provide the pactFilesOrDirs argument");
-		checkTypes.assert.nonEmptyArray(options.pactFilesOrDirs, "Must provide the pactFilesOrDirs argument with an array");
+    checkTypes.assert.nonEmptyString(
+      options.pactBroker,
+      'Must provide the pactBroker argument',
+    );
+    checkTypes.assert.nonEmptyString(
+      options.consumerVersion,
+      'Must provide the consumerVersion argument',
+    );
+    checkTypes.assert.arrayLike(
+      options.pactFilesOrDirs,
+      'Must provide the pactFilesOrDirs argument',
+    );
+    checkTypes.assert.nonEmptyArray(
+      options.pactFilesOrDirs,
+      'Must provide the pactFilesOrDirs argument with an array',
+    );
 
-		if (options.pactFilesOrDirs) {
-			checkTypes.assert.array.of.string(options.pactFilesOrDirs);
+    if (options.pactFilesOrDirs) {
+      checkTypes.assert.array.of.string(options.pactFilesOrDirs);
 
-			// Resolve all paths as absolute paths
-			options.pactFilesOrDirs = options.pactFilesOrDirs.map((v) => {
-				const newPath = path.resolve(v);
-				if(!fs.existsSync(newPath)) {
-					throw new Error(`Path '${v}' given in pactFilesOrDirs does not exists.`);
-				}
-				return newPath;
-			});
-		}
+      // Resolve all paths as absolute paths
+      options.pactFilesOrDirs = options.pactFilesOrDirs.map(v => {
+        const newPath = path.resolve(v);
+        if (!fs.existsSync(newPath)) {
+          throw new Error(
+            `Path '${v}' given in pactFilesOrDirs does not exists.`,
+          );
+        }
+        return newPath;
+      });
+    }
 
-		if (options.pactBroker) {
-			checkTypes.assert.string(options.pactBroker);
-		}
+    if (options.pactBroker) {
+      checkTypes.assert.string(options.pactBroker);
+    }
 
-		if (options.pactBrokerUsername) {
-			checkTypes.assert.string(options.pactBrokerUsername);
-		}
+    if (options.pactBrokerUsername) {
+      checkTypes.assert.string(options.pactBrokerUsername);
+    }
 
-		if (options.pactBrokerPassword) {
-			checkTypes.assert.string(options.pactBrokerPassword);
-		}
+    if (options.pactBrokerPassword) {
+      checkTypes.assert.string(options.pactBrokerPassword);
+    }
 
-		if ((options.pactBrokerUsername && !options.pactBrokerPassword) || (options.pactBrokerPassword && !options.pactBrokerUsername)) {
-			throw new Error("Must provide both Pact Broker username and password. None needed if authentication on Broker is disabled.");
-		}
+    if (
+      (options.pactBrokerUsername && !options.pactBrokerPassword) ||
+      (options.pactBrokerPassword && !options.pactBrokerUsername)
+    ) {
+      throw new Error(
+        'Must provide both Pact Broker username and password. None needed if authentication on Broker is disabled.',
+      );
+    }
 
-		this.options = options;
-	}
+    this.options = options;
+  }
 
-	public publish(): q.Promise<string[]> {
-		logger.info(`Publishing pacts to broker at: ${this.options.pactBroker}`);
-		const deferred = q.defer<string[]>();
-		const instance = pactUtil.spawnBinary(`${pactStandalone.brokerPath} publish`, this.options, this.__argMapping);
-		const output: any[] = [];
-		instance.stdout.on("data", (l) => output.push(l));
-		instance.stderr.on("data", (l) => output.push(l));
-		instance.once("close", (code) => {
-			const o = output.join("\n");
-			const pactUrls = /^https?:\/\/.*\/pacts\/.*$/igm.exec(o);
-			if (code !== 0 || !pactUrls) {
-				logger.error(`Could not publish pact:\n${o}`);
-				return deferred.reject(new Error(o));
-			}
+  public publish(): q.Promise<string[]> {
+    logger.info(`Publishing pacts to broker at: ${this.options.pactBroker}`);
+    const deferred = q.defer<string[]>();
+    const instance = pactUtil.spawnBinary(
+      `${pactStandalone.brokerPath} publish`,
+      this.options,
+      this.__argMapping,
+    );
+    const output: any[] = [];
+    instance.stdout.on('data', l => output.push(l));
+    instance.stderr.on('data', l => output.push(l));
+    instance.once('close', code => {
+      const o = output.join('\n');
+      const pactUrls = /^https?:\/\/.*\/pacts\/.*$/gim.exec(o);
+      if (code !== 0 || !pactUrls) {
+        logger.error(`Could not publish pact:\n${o}`);
+        return deferred.reject(new Error(o));
+      }
 
-			logger.info(o);
-			return deferred.resolve(pactUrls);
-		});
+      logger.info(o);
+      return deferred.resolve(pactUrls);
+    });
 
-		return deferred.promise
-			.timeout(this.options.timeout as number, `Timeout waiting for verification process to complete (PID: ${instance.pid})`);
-	}
+    return deferred.promise.timeout(
+      this.options.timeout as number,
+      `Timeout waiting for verification process to complete (PID: ${instance.pid})`,
+    );
+  }
 }
 
 export default (options: PublisherOptions) => new Publisher(options);
 
 export interface PublisherOptions extends SpawnArguments {
-	pactFilesOrDirs: string[];
-	pactBroker: string;
-	consumerVersion: string;
-	pactBrokerUsername?: string;
-	pactBrokerPassword?: string;
-	pactBrokerToken?: string;
-	tags?: string[];
-	verbose?: boolean;
-	timeout?: number;
+  pactFilesOrDirs: string[];
+  pactBroker: string;
+  consumerVersion: string;
+  pactBrokerUsername?: string;
+  pactBrokerPassword?: string;
+  pactBrokerToken?: string;
+  tags?: string[];
+  verbose?: boolean;
+  timeout?: number;
 }

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -1,341 +1,392 @@
 // tslint:disable:no-string-literal
 
-import serverFactory from "./server";
-import chai = require("chai");
-import chaiAsPromised = require("chai-as-promised");
-import fs = require("fs");
-import path = require("path");
-import q = require("q");
-import _ = require("underscore");
+import serverFactory from './server';
+import chai = require('chai');
+import chaiAsPromised = require('chai-as-promised');
+import fs = require('fs');
+import path = require('path');
+import q = require('q');
+import _ = require('underscore');
 
-const mkdirp = require("mkdirp");
-const rimraf = require("rimraf");
+const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe("Server Spec", () => {
-	let server: any;
-	const monkeypatchFile: string = path.resolve(__dirname, "../test/monkeypatch.rb");
+describe('Server Spec', () => {
+  let server: any;
+  const monkeypatchFile: string = path.resolve(
+    __dirname,
+    '../test/monkeypatch.rb',
+  );
 
-	afterEach(() => server ? server.delete() : null);
+  afterEach(() => (server ? server.delete() : null));
 
-	let absolutePath: string;
-	let relativePath: string;
+  let absolutePath: string;
+  let relativePath: string;
 
-	const relativeSSLCertPath = "test/ssl/server.crt";
-	const absoluteSSLCertPath = path.resolve(__dirname, "..", relativeSSLCertPath);
-	const relativeSSLKeyPath = "test/ssl/server.key";
-	const absoluteSSLKeyPath = path.resolve(__dirname, "..", relativeSSLKeyPath);
+  const relativeSSLCertPath = 'test/ssl/server.crt';
+  const absoluteSSLCertPath = path.resolve(
+    __dirname,
+    '..',
+    relativeSSLCertPath,
+  );
+  const relativeSSLKeyPath = 'test/ssl/server.key';
+  const absoluteSSLKeyPath = path.resolve(__dirname, '..', relativeSSLKeyPath);
 
-	beforeEach(() => {
-		relativePath = `.tmp/${Math.floor(Math.random() * 1000)}`;
-		absolutePath = path.resolve(__dirname, "..", relativePath);
-		mkdirp.sync(absolutePath);
-	});
+  beforeEach(() => {
+    relativePath = `.tmp/${Math.floor(Math.random() * 1000)}`;
+    absolutePath = path.resolve(__dirname, '..', relativePath);
+    mkdirp.sync(absolutePath);
+  });
 
-	afterEach(() => {
-		if (fs.existsSync(absolutePath)) {
-			rimraf.sync(absolutePath);
-		}
-	});
+  afterEach(() => {
+    if (fs.existsSync(absolutePath)) {
+      rimraf.sync(absolutePath);
+    }
+  });
 
-	describe("Start server", () => {
-		context("when no options are set", () => {
-			it("should start correctly with defaults", () => {
-				server = serverFactory();
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
-		});
+  describe('Start server', () => {
+    context('when no options are set', () => {
+      it('should start correctly with defaults', () => {
+        server = serverFactory();
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
+    });
 
-		context("when invalid options are set", () => {
-			it("should fail if custom ssl certs do not exist", () => {
-				expect(() => serverFactory({
-					ssl: true,
-					sslcert: "does/not/exist",
-					sslkey: absoluteSSLKeyPath
-				})).to.throw(Error);
-			});
+    context('when invalid options are set', () => {
+      it('should fail if custom ssl certs do not exist', () => {
+        expect(() =>
+          serverFactory({
+            ssl: true,
+            sslcert: 'does/not/exist',
+            sslkey: absoluteSSLKeyPath,
+          }),
+        ).to.throw(Error);
+      });
 
-			it("should fail if custom ssl keys do not exist", () => {
-				expect(() => serverFactory({
-					ssl: true,
-					sslcert: absoluteSSLCertPath,
-					sslkey: "does/not/exist"
-				})).to.throw(Error);
-			});
+      it('should fail if custom ssl keys do not exist', () => {
+        expect(() =>
+          serverFactory({
+            ssl: true,
+            sslcert: absoluteSSLCertPath,
+            sslkey: 'does/not/exist',
+          }),
+        ).to.throw(Error);
+      });
 
-			it("should fail if custom ssl cert is set, but ssl key isn't", () => {
-				expect(() => serverFactory({
-					ssl: true,
-					sslcert: absoluteSSLCertPath
-				})).to.throw(Error);
-			});
+      it("should fail if custom ssl cert is set, but ssl key isn't", () => {
+        expect(() =>
+          serverFactory({
+            ssl: true,
+            sslcert: absoluteSSLCertPath,
+          }),
+        ).to.throw(Error);
+      });
 
-			it("should fail if custom ssl key is set, but ssl cert isn't", () => {
-				expect(() => serverFactory({
-					ssl: true,
-					sslkey: absoluteSSLKeyPath
-				})).to.throw(Error);
-			});
+      it("should fail if custom ssl key is set, but ssl cert isn't", () => {
+        expect(() =>
+          serverFactory({
+            ssl: true,
+            sslkey: absoluteSSLKeyPath,
+          }),
+        ).to.throw(Error);
+      });
 
-			it("should fail if incorrect pactFileWriteMode provided", () => {
-				expect(() => serverFactory({
-					pactFileWriteMode: "notarealoption",
-				} as any)).to.throw(Error);
-			});
+      it('should fail if incorrect pactFileWriteMode provided', () => {
+        expect(() =>
+          serverFactory({
+            pactFileWriteMode: 'notarealoption',
+          } as any),
+        ).to.throw(Error);
+      });
 
-			it("should fail if incorrect logLevel provided", () => {
-				expect(() => serverFactory({
-					logLevel: "nolog",
-				} as any)).to.throw(Error);
-			});
-		});
+      it('should fail if incorrect logLevel provided', () => {
+        expect(() =>
+          serverFactory({
+            logLevel: 'nolog',
+          } as any),
+        ).to.throw(Error);
+      });
+    });
 
-		context("when valid options are set", () => {
-			it("should start correctly when instance is delayed", () => {
-				server = serverFactory();
+    context('when valid options are set', () => {
+      it('should start correctly when instance is delayed', () => {
+        server = serverFactory();
 
-				const waitForServerUp = (server as any)["__waitForServiceUp"].bind(server);
-				return q.allSettled([
-					waitForServerUp(server.options),
-					q.delay(5000).then(() => server.start())
-				]).then((results) => expect(_.reduce(results, (m, r) => m && r.state === "fulfilled")).to.be.true);
-			});
+        const waitForServerUp = (server as any)['__waitForServiceUp'].bind(
+          server,
+        );
+        return q
+          .allSettled([
+            waitForServerUp(server.options),
+            q.delay(5000).then(() => server.start()),
+          ])
+          .then(
+            results =>
+              expect(_.reduce(results, (m, r) => m && r.state === 'fulfilled'))
+                .to.be.true,
+          );
+      });
 
-			it("should start correctly with ssl", () => {
-				server = serverFactory({ssl: true});
-				expect(server.options.ssl).to.equal(true);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with ssl', () => {
+        server = serverFactory({ ssl: true });
+        expect(server.options.ssl).to.equal(true);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with custom ssl cert/key", () => {
-				server = serverFactory({
-					ssl: true,
-					sslcert: absoluteSSLCertPath,
-					sslkey: absoluteSSLKeyPath
-				});
-				expect(server.options.ssl).to.equal(true);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with custom ssl cert/key', () => {
+        server = serverFactory({
+          ssl: true,
+          sslcert: absoluteSSLCertPath,
+          sslkey: absoluteSSLKeyPath,
+        });
+        expect(server.options.ssl).to.equal(true);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with custom ssl cert/key but without specifying ssl flag", () => {
-				server = serverFactory({
-					sslcert: absoluteSSLCertPath,
-					sslkey: absoluteSSLKeyPath
-				});
+      it('should start correctly with custom ssl cert/key but without specifying ssl flag', () => {
+        server = serverFactory({
+          sslcert: absoluteSSLCertPath,
+          sslkey: absoluteSSLKeyPath,
+        });
 
-				expect(server.options.ssl).to.equal(true);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+        expect(server.options.ssl).to.equal(true);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with cors", () => {
-				server = serverFactory({cors: true});
-				expect(server.options.cors).to.equal(true);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with cors', () => {
+        server = serverFactory({ cors: true });
+        expect(server.options.cors).to.equal(true);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with port", () => {
-				const port = Math.floor(Math.random() * 999) + 9000;
-				server = serverFactory({port: port});
-				expect(server.options.port).to.equal(port);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with port', () => {
+        const port = Math.floor(Math.random() * 999) + 9000;
+        server = serverFactory({ port: port });
+        expect(server.options.port).to.equal(port);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with host", () => {
-				const host = "localhost";
-				server = serverFactory({host: host});
-				expect(server.options.host).to.equal(host);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with host', () => {
+        const host = 'localhost';
+        server = serverFactory({ host: host });
+        expect(server.options.host).to.equal(host);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with spec version 1", () => {
-				server = serverFactory({spec: 1});
-				expect(server.options.spec).to.equal(1);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with spec version 1', () => {
+        server = serverFactory({ spec: 1 });
+        expect(server.options.spec).to.equal(1);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with spec version 2", () => {
-				server = serverFactory({spec: 2});
-				expect(server.options.spec).to.equal(2);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with spec version 2', () => {
+        server = serverFactory({ spec: 2 });
+        expect(server.options.spec).to.equal(2);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with log", () => {
-				const logPath = path.resolve(absolutePath, "log.txt");
-				server = serverFactory({log: logPath});
-				expect(server.options.log).to.equal(logPath);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with log', () => {
+        const logPath = path.resolve(absolutePath, 'log.txt');
+        server = serverFactory({ log: logPath });
+        expect(server.options.log).to.equal(logPath);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with consumer name", () => {
-				const consumerName = "cName";
-				server = serverFactory({consumer: consumerName});
-				expect(server.options.consumer).to.equal(consumerName);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with consumer name', () => {
+        const consumerName = 'cName';
+        server = serverFactory({ consumer: consumerName });
+        expect(server.options.consumer).to.equal(consumerName);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with provider name", () => {
-				const providerName = "pName";
-				server = serverFactory({provider: providerName});
-				expect(server.options.provider).to.equal(providerName);
-				return expect(server.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with provider name', () => {
+        const providerName = 'pName';
+        server = serverFactory({ provider: providerName });
+        expect(server.options.provider).to.equal(providerName);
+        return expect(server.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with monkeypatch", () => {
-				const s = serverFactory({monkeypatch: monkeypatchFile});
-				expect(s.options.monkeypatch).to.equal(monkeypatchFile);
-				return expect(s.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with monkeypatch', () => {
+        const s = serverFactory({ monkeypatch: monkeypatchFile });
+        expect(s.options.monkeypatch).to.equal(monkeypatchFile);
+        return expect(s.start()).to.eventually.be.fulfilled;
+      });
 
-			context("Paths", () => {
-				it("should start correctly with dir, absolute path", () => {
-					server = serverFactory({dir: relativePath});
-					expect(server.options.dir).to.equal(absolutePath);
-					return expect(server.start()).to.eventually.be.fulfilled;
-				});
+      context('Paths', () => {
+        it('should start correctly with dir, absolute path', () => {
+          server = serverFactory({ dir: relativePath });
+          expect(server.options.dir).to.equal(absolutePath);
+          return expect(server.start()).to.eventually.be.fulfilled;
+        });
 
-				it("should start correctly with log, relative paths", () => {
-					const logPath = path.join(relativePath, "log.txt");
-					server = serverFactory({log: logPath});
-					expect(server.options.log).to.equal(path.resolve(logPath));
-					return expect(server.start()).to.eventually.be.fulfilled;
-				});
+        it('should start correctly with log, relative paths', () => {
+          const logPath = path.join(relativePath, 'log.txt');
+          server = serverFactory({ log: logPath });
+          expect(server.options.log).to.equal(path.resolve(logPath));
+          return expect(server.start()).to.eventually.be.fulfilled;
+        });
 
-				it("should start correctly with custom ssl cert/key, relative paths", () => {
-					server = serverFactory({
-						sslcert: relativeSSLCertPath,
-						sslkey: relativeSSLKeyPath
-					});
-					expect(server.options.sslcert).to.equal(absoluteSSLCertPath);
-					expect(server.options.sslkey).to.equal(absoluteSSLKeyPath);
-					return expect(server.start()).to.eventually.be.fulfilled;
-				});
-			});
+        it('should start correctly with custom ssl cert/key, relative paths', () => {
+          server = serverFactory({
+            sslcert: relativeSSLCertPath,
+            sslkey: relativeSSLKeyPath,
+          });
+          expect(server.options.sslcert).to.equal(absoluteSSLCertPath);
+          expect(server.options.sslkey).to.equal(absoluteSSLKeyPath);
+          return expect(server.start()).to.eventually.be.fulfilled;
+        });
+      });
 
-			context("File Write Mode", () => {
-				it("should start correctly with 'overwrite'", () =>
-					expect(serverFactory({
-						pactFileWriteMode: "overwrite",
-					}).start()).to.eventually.be.fulfilled);
+      context('File Write Mode', () => {
+        it("should start correctly with 'overwrite'", () =>
+          expect(
+            serverFactory({
+              pactFileWriteMode: 'overwrite',
+            }).start(),
+          ).to.eventually.be.fulfilled);
 
-				it("should start correctly with 'merge'", () =>
-					expect(serverFactory({
-						pactFileWriteMode: "merge",
-					}).start()).to.eventually.be.fulfilled);
+        it("should start correctly with 'merge'", () =>
+          expect(
+            serverFactory({
+              pactFileWriteMode: 'merge',
+            }).start(),
+          ).to.eventually.be.fulfilled);
 
-				it("should start correctly with 'update'", () =>
-					expect(serverFactory({
-						pactFileWriteMode: "update",
-					}).start()).to.eventually.be.fulfilled);
-			});
+        it("should start correctly with 'update'", () =>
+          expect(
+            serverFactory({
+              pactFileWriteMode: 'update',
+            }).start(),
+          ).to.eventually.be.fulfilled);
+      });
 
-			context("Log Level", () => {
-				it("should start correctly with 'debug'", () => {
-					return q.allSettled([
-						expect(serverFactory({
-							logLevel: "debug",
-						}).start()).to.eventually.be.fulfilled,
+      context('Log Level', () => {
+        it("should start correctly with 'debug'", () => {
+          return q.allSettled([
+            expect(
+              serverFactory({
+                logLevel: 'debug',
+              }).start(),
+            ).to.eventually.be.fulfilled,
 
-						expect(serverFactory({
-							logLevel: "DEBUG",
-						} as any).start()).to.eventually.be.fulfilled,
-					]);
-				});
+            expect(
+              serverFactory({
+                logLevel: 'DEBUG',
+              } as any).start(),
+            ).to.eventually.be.fulfilled,
+          ]);
+        });
 
-				it("should start correctly with 'info'", () => {
-					return q.allSettled([
-						expect(serverFactory({
-							logLevel: "info",
-						}).start()).to.eventually.be.fulfilled,
+        it("should start correctly with 'info'", () => {
+          return q.allSettled([
+            expect(
+              serverFactory({
+                logLevel: 'info',
+              }).start(),
+            ).to.eventually.be.fulfilled,
 
-						expect(serverFactory({
-							logLevel: "INFO",
-						} as any).start()).to.eventually.be.fulfilled,
-					]);
-				});
+            expect(
+              serverFactory({
+                logLevel: 'INFO',
+              } as any).start(),
+            ).to.eventually.be.fulfilled,
+          ]);
+        });
 
-				it("should start correctly with 'warn'", () => {
-					return q.allSettled([
-						expect(serverFactory({
-							logLevel: "warn",
-						}).start()).to.eventually.be.fulfilled,
+        it("should start correctly with 'warn'", () => {
+          return q.allSettled([
+            expect(
+              serverFactory({
+                logLevel: 'warn',
+              }).start(),
+            ).to.eventually.be.fulfilled,
 
-						expect(serverFactory({
-							logLevel: "WARN",
-						} as any).start()).to.eventually.be.fulfilled,
-					]);
-				});
+            expect(
+              serverFactory({
+                logLevel: 'WARN',
+              } as any).start(),
+            ).to.eventually.be.fulfilled,
+          ]);
+        });
 
-				it("should start correctly with 'error'", () => {
-					return q.allSettled([
-						expect(serverFactory({
-							logLevel: "error",
-						}).start()).to.eventually.be.fulfilled,
+        it("should start correctly with 'error'", () => {
+          return q.allSettled([
+            expect(
+              serverFactory({
+                logLevel: 'error',
+              }).start(),
+            ).to.eventually.be.fulfilled,
 
-						expect(serverFactory({
-							logLevel: "ERROR",
-						} as any).start()).to.eventually.be.fulfilled,
-					]);
-				});
-			});
-		});
+            expect(
+              serverFactory({
+                logLevel: 'ERROR',
+              } as any).start(),
+            ).to.eventually.be.fulfilled,
+          ]);
+        });
+      });
+    });
 
-		it("should dispatch event when starting", (done) => {
-			server = serverFactory();
-			server.once("start", () => done());
-			server.start();
-		});
+    it('should dispatch event when starting', done => {
+      server = serverFactory();
+      server.once('start', () => done());
+      server.start();
+    });
 
-		it("should change running state to true", () => {
-			server = serverFactory();
-			return server.start()
-				.then(() => expect((server as any)["__running"]).to.be.true);
-		});
-	});
+    it('should change running state to true', () => {
+      server = serverFactory();
+      return server
+        .start()
+        .then(() => expect((server as any)['__running']).to.be.true);
+    });
+  });
 
-	describe("Stop server", () => {
-		context("when already started", () => {
-			it("should stop running", () => {
-				server = serverFactory();
-				return server.start().then(() => server.stop());
-			});
+  describe('Stop server', () => {
+    context('when already started', () => {
+      it('should stop running', () => {
+        server = serverFactory();
+        return server.start().then(() => server.stop());
+      });
 
-			it("should dispatch event when stopping", (done) => {
-				server = serverFactory();
-				server.once("stop", () => done());
-				server.start().then(() => server.stop());
-			});
+      it('should dispatch event when stopping', done => {
+        server = serverFactory();
+        server.once('stop', () => done());
+        server.start().then(() => server.stop());
+      });
 
-			it("should change running state to false", () => {
-				server = serverFactory();
-				return server.start()
-					.then(() => server.stop())
-					.then(() => expect((server as any)["__running"]).to.be.false);
-			});
-		});
-	});
+      it('should change running state to false', () => {
+        server = serverFactory();
+        return server
+          .start()
+          .then(() => server.stop())
+          .then(() => expect((server as any)['__running']).to.be.false);
+      });
+    });
+  });
 
-	describe("Delete server", () => {
-		context("when already running", () => {
-			it("should stop & delete server", () => {
-				server = serverFactory();
-				return server.start()
-					.then(() => server.delete());
-			});
+  describe('Delete server', () => {
+    context('when already running', () => {
+      it('should stop & delete server', () => {
+        server = serverFactory();
+        return server.start().then(() => server.delete());
+      });
 
-			it("should dispatch event when deleting", (done) => {
-				server = serverFactory();
-				server.once("delete", () => done());
-				server.start().then(() => server.delete());
-			});
+      it('should dispatch event when deleting', done => {
+        server = serverFactory();
+        server.once('delete', () => done());
+        server.start().then(() => server.delete());
+      });
 
-			it("should change running state to false", () => {
-				server = serverFactory();
-				return server.start()
-					.then(() => server.delete())
-					.then(() => expect((server as any)["__running"]).to.be.false);
-			});
-		});
-	});
+      it('should change running state to false', () => {
+        server = serverFactory();
+        return server
+          .start()
+          .then(() => server.delete())
+          .then(() => expect((server as any)['__running']).to.be.false);
+      });
+    });
+  });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,120 +1,129 @@
 // tslint:disable:no-string-literal
-import {AbstractService} from "./service";
-import {SpawnArguments} from "./pact-util";
-import {deprecate} from "util";
-import pact from "./pact-standalone";
-import path = require("path");
-import fs = require("fs");
+import { AbstractService } from './service';
+import { SpawnArguments } from './pact-util';
+import { deprecate } from 'util';
+import pact from './pact-standalone';
+import path = require('path');
+import fs = require('fs');
 
-const mkdirp = require("mkdirp");
-const checkTypes = require("check-types");
+const mkdirp = require('mkdirp');
+const checkTypes = require('check-types');
 
 export class Server extends AbstractService {
-	public static create = deprecate(
-		(options?: ServerOptions) => new Server(options),
-		"Create function will be removed in future release, please use the default export function or use `new Server()`");
+  public static create = deprecate(
+    (options?: ServerOptions) => new Server(options),
+    'Create function will be removed in future release, please use the default export function or use `new Server()`',
+  );
 
-	public readonly options: ServerOptions;
+  public readonly options: ServerOptions;
 
-	constructor(options?: ServerOptions) {
-		options = options || {};
-		options.dir = options.dir ? path.resolve(options.dir) : process.cwd(); // Use directory relative to cwd
-		options.pactFileWriteMode = options.pactFileWriteMode || "overwrite";
+  constructor(options?: ServerOptions) {
+    options = options || {};
+    options.dir = options.dir ? path.resolve(options.dir) : process.cwd(); // Use directory relative to cwd
+    options.pactFileWriteMode = options.pactFileWriteMode || 'overwrite';
 
-		if (options.spec) {
-			checkTypes.assert.number(options.spec);
-			checkTypes.assert.integer(options.spec);
-			checkTypes.assert.positive(options.spec);
-		}
+    if (options.spec) {
+      checkTypes.assert.number(options.spec);
+      checkTypes.assert.integer(options.spec);
+      checkTypes.assert.positive(options.spec);
+    }
 
-		if (options.dir) {
-			const dir = path.resolve(options.dir);
-			try {
-				fs.statSync(dir).isDirectory();
-			} catch (e) {
-				mkdirp.sync(dir);
-			}
-		}
+    if (options.dir) {
+      const dir = path.resolve(options.dir);
+      try {
+        fs.statSync(dir).isDirectory();
+      } catch (e) {
+        mkdirp.sync(dir);
+      }
+    }
 
-		if (options.log) {
-			options.log = path.resolve(options.log);
-		}
+    if (options.log) {
+      options.log = path.resolve(options.log);
+    }
 
-		if (options.sslcert) {
-			options.sslcert = path.resolve(options.sslcert);
-		}
+    if (options.sslcert) {
+      options.sslcert = path.resolve(options.sslcert);
+    }
 
-		if (options.sslkey) {
-			options.sslkey = path.resolve(options.sslkey);
-		}
+    if (options.sslkey) {
+      options.sslkey = path.resolve(options.sslkey);
+    }
 
-		if (options.consumer) {
-			checkTypes.assert.string(options.consumer);
-		}
+    if (options.consumer) {
+      checkTypes.assert.string(options.consumer);
+    }
 
-		if (options.provider) {
-			checkTypes.assert.string(options.provider);
-		}
+    if (options.provider) {
+      checkTypes.assert.string(options.provider);
+    }
 
-		checkTypes.assert.includes(["overwrite", "update", "merge"], options.pactFileWriteMode);
+    checkTypes.assert.includes(
+      ['overwrite', 'update', 'merge'],
+      options.pactFileWriteMode,
+    );
 
-		if(options.logLevel) {
-			options.logLevel = options.logLevel.toLowerCase() as any;
-			checkTypes.assert.includes([ "debug", "info", "warn", "error"], options.logLevel);
-		}
+    if (options.logLevel) {
+      options.logLevel = options.logLevel.toLowerCase() as any;
+      checkTypes.assert.includes(
+        ['debug', 'info', 'warn', 'error'],
+        options.logLevel,
+      );
+    }
 
-		if (options.monkeypatch) {
-			checkTypes.assert.string(options.monkeypatch);
-			try {
-				fs.statSync(path.normalize(options.monkeypatch)).isFile();
-			} catch (e) {
-				throw new Error(`Monkeypatch ruby file not found at path: ${options.monkeypatch}`);
-			}
-		}
+    if (options.monkeypatch) {
+      checkTypes.assert.string(options.monkeypatch);
+      try {
+        fs.statSync(path.normalize(options.monkeypatch)).isFile();
+      } catch (e) {
+        throw new Error(
+          `Monkeypatch ruby file not found at path: ${options.monkeypatch}`,
+        );
+      }
+    }
 
-		let opts: any = options;
+    let opts: any = options;
 
-		// Need to uppercase logLevel for ruby
-		if(options.logLevel) {
-			opts = JSON.parse(JSON.stringify(options));
-			opts.logLevel = options.logLevel.toUpperCase();
-		}
+    // Need to uppercase logLevel for ruby
+    if (options.logLevel) {
+      opts = JSON.parse(JSON.stringify(options));
+      opts.logLevel = options.logLevel.toUpperCase();
+    }
 
-		super(`${pact.mockServicePath} service`, opts, {
-			"port": "--port",
-			"host": "--host",
-			"log": "--log",
-			"ssl": "--ssl",
-			"sslcert": "--sslcert",
-			"sslkey": "--sslkey",
-			"cors": "--cors",
-			"dir": "--pact_dir",
-			"spec": "--pact_specification_version",
-			"pactFileWriteMode": "--pact-file-write-mode",
-			"consumer": "--consumer",
-			"provider": "--provider",
-			"monkeypatch": "--monkeypatch",
-			"logLevel": "--log-level"
-		});
-	}
+    super(`${pact.mockServicePath} service`, opts, {
+      port: '--port',
+      host: '--host',
+      log: '--log',
+      ssl: '--ssl',
+      sslcert: '--sslcert',
+      sslkey: '--sslkey',
+      cors: '--cors',
+      dir: '--pact_dir',
+      spec: '--pact_specification_version',
+      pactFileWriteMode: '--pact-file-write-mode',
+      consumer: '--consumer',
+      provider: '--provider',
+      monkeypatch: '--monkeypatch',
+      logLevel: '--log-level',
+    });
+  }
 }
 
 // Creates a new instance of the pact server with the specified option
 export default (options?: ServerOptions) => new Server(options);
 
 export interface ServerOptions extends SpawnArguments {
-	port?: number;
-	ssl?: boolean;
-	cors?: boolean;
-	dir?: string;
-	host?: string;
-	sslcert?: string;
-	sslkey?: string;
-	log?: string;
-	spec?: number;
-	consumer?: string;
-	provider?: string;
-	monkeypatch?: string;
-	logLevel?: "debug" | "info" | "warn" | "error";
-	pactFileWriteMode?: "overwrite" | "update" | "merge";
+  port?: number;
+  ssl?: boolean;
+  cors?: boolean;
+  dir?: string;
+  host?: string;
+  sslcert?: string;
+  sslkey?: string;
+  log?: string;
+  spec?: number;
+  consumer?: string;
+  provider?: string;
+  monkeypatch?: string;
+  logLevel?: 'debug' | 'info' | 'warn' | 'error';
+  pactFileWriteMode?: 'overwrite' | 'update' | 'merge';
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,15 +1,15 @@
 // tslint:disable:no-string-literal
 
-import path = require("path");
-import fs = require("fs");
-import events = require("events");
-import http = require("request");
-import q = require("q");
-import logger from "./logger";
-import pactUtil, {SpawnArguments} from "./pact-util";
-import {ChildProcess} from "child_process";
-const mkdirp = require("mkdirp");
-const checkTypes = require("check-types");
+import path = require('path');
+import fs = require('fs');
+import events = require('events');
+import http = require('request');
+import q = require('q');
+import logger from './logger';
+import pactUtil, { SpawnArguments } from './pact-util';
+import { ChildProcess } from 'child_process';
+const mkdirp = require('mkdirp');
+const checkTypes = require('check-types');
 
 // Get a reference to the global setTimeout object in case it is mocked by a testing library later
 const setTimeout = global.setTimeout;
@@ -19,234 +19,272 @@ const RETRY_AMOUNT = 60;
 const PROCESS_TIMEOUT = 30000;
 
 export abstract class AbstractService extends events.EventEmitter {
-	public static get Events() {
-		return {
-			START_EVENT: "start",
-			STOP_EVENT: "stop",
-			DELETE_EVENT: "delete"
-		};
-	}
+  public static get Events() {
+    return {
+      START_EVENT: 'start',
+      STOP_EVENT: 'stop',
+      DELETE_EVENT: 'delete',
+    };
+  }
 
-	public readonly options: ServiceOptions;
-	protected __argMapping: any;
-	protected __running: boolean;
-	protected __instance: ChildProcess;
-	protected __serviceCommand: string;
+  public readonly options: ServiceOptions;
+  protected __argMapping: any;
+  protected __running: boolean;
+  protected __instance: ChildProcess;
+  protected __serviceCommand: string;
 
-	constructor(command: string, options: ServiceOptions, argMapping: any) {
-		super();
+  constructor(command: string, options: ServiceOptions, argMapping: any) {
+    super();
 
-		// defaults
-		options.ssl = options.ssl || false;
-		options.cors = options.cors || false;
-		options.host = options.host || "localhost";
+    // defaults
+    options.ssl = options.ssl || false;
+    options.cors = options.cors || false;
+    options.host = options.host || 'localhost';
 
-		// port checking
-		if (options.port) {
-			checkTypes.assert.number(options.port);
-			checkTypes.assert.integer(options.port);
-			checkTypes.assert.positive(options.port);
-			checkTypes.assert.inRange(options.port, 0, 65535);
+    // port checking
+    if (options.port) {
+      checkTypes.assert.number(options.port);
+      checkTypes.assert.integer(options.port);
+      checkTypes.assert.positive(options.port);
+      checkTypes.assert.inRange(options.port, 0, 65535);
 
-			if (checkTypes.not.inRange(options.port, 1024, 49151)) {
-				logger.warn("Like a Boss, you used a port outside of the recommended range (1024 to 49151); I too like to live dangerously.");
-			}
-		}
+      if (checkTypes.not.inRange(options.port, 1024, 49151)) {
+        logger.warn(
+          'Like a Boss, you used a port outside of the recommended range (1024 to 49151); I too like to live dangerously.',
+        );
+      }
+    }
 
-		// ssl check
-		checkTypes.assert.boolean(options.ssl);
+    // ssl check
+    checkTypes.assert.boolean(options.ssl);
 
-		// Throw error if one ssl option is set, but not the other
-		if ((options.sslcert && !options.sslkey) || (!options.sslcert && options.sslkey)) {
-			throw new Error("Custom ssl certificate and key must be specified together.");
-		}
+    // Throw error if one ssl option is set, but not the other
+    if (
+      (options.sslcert && !options.sslkey) ||
+      (!options.sslcert && options.sslkey)
+    ) {
+      throw new Error(
+        'Custom ssl certificate and key must be specified together.',
+      );
+    }
 
-		// check certs/keys exist for SSL
-		if (options.sslcert) {
-			try {
-				fs.statSync(path.normalize(options.sslcert)).isFile();
-			} catch (e) {
-				throw new Error(`Custom ssl certificate not found at path: ${options.sslcert}`);
-			}
-		}
+    // check certs/keys exist for SSL
+    if (options.sslcert) {
+      try {
+        fs.statSync(path.normalize(options.sslcert)).isFile();
+      } catch (e) {
+        throw new Error(
+          `Custom ssl certificate not found at path: ${options.sslcert}`,
+        );
+      }
+    }
 
-		if (options.sslkey) {
-			try {
-				fs.statSync(path.normalize(options.sslkey)).isFile();
-			} catch (e) {
-				throw new Error(`Custom ssl key not found at path: ${options.sslkey}`);
-			}
-		}
+    if (options.sslkey) {
+      try {
+        fs.statSync(path.normalize(options.sslkey)).isFile();
+      } catch (e) {
+        throw new Error(`Custom ssl key not found at path: ${options.sslkey}`);
+      }
+    }
 
-		// If both sslcert and sslkey option has been specified, let's assume the user wants to enable ssl
-		if (options.sslcert && options.sslkey) {
-			options.ssl = true;
-		}
+    // If both sslcert and sslkey option has been specified, let's assume the user wants to enable ssl
+    if (options.sslcert && options.sslkey) {
+      options.ssl = true;
+    }
 
-		// cors check
-		checkTypes.assert.boolean(options.cors);
+    // cors check
+    checkTypes.assert.boolean(options.cors);
 
-		// log check
-		if (options.log) {
-			const fileObj = path.parse(path.normalize(options.log));
-			try {
-				fs.statSync(fileObj.dir).isDirectory();
-			} catch (e) {
-				// If log path doesn't exist, create it
-				mkdirp.sync(fileObj.dir);
-			}
-		}
+    // log check
+    if (options.log) {
+      const fileObj = path.parse(path.normalize(options.log));
+      try {
+        fs.statSync(fileObj.dir).isDirectory();
+      } catch (e) {
+        // If log path doesn't exist, create it
+        mkdirp.sync(fileObj.dir);
+      }
+    }
 
-		// host check
-		if (options.host) {
-			checkTypes.assert.string(options.host);
-		}
+    // host check
+    if (options.host) {
+      checkTypes.assert.string(options.host);
+    }
 
-		this.options = options;
-		this.__running = false;
-		this.__serviceCommand = command;
-		this.__argMapping = argMapping;
-	}
+    this.options = options;
+    this.__running = false;
+    this.__serviceCommand = command;
+    this.__argMapping = argMapping;
+  }
 
-	public start(): q.Promise<AbstractService> {
-		if (this.__instance && this.__instance.connected) {
-			logger.warn(`You already have a process running with PID: ${this.__instance.pid}`);
-			return q.resolve(this);
-		}
+  public start(): q.Promise<AbstractService> {
+    if (this.__instance && this.__instance.connected) {
+      logger.warn(
+        `You already have a process running with PID: ${this.__instance.pid}`,
+      );
+      return q.resolve(this);
+    }
 
-		this.__instance = this.spawnBinary();
-		this.__instance.once("close", () => this.stop());
+    this.__instance = this.spawnBinary();
+    this.__instance.once('close', () => this.stop());
 
-		if (!this.options.port) {
-			// if port isn't specified, listen for it when pact runs
-			const catchPort = (data: any) => {
-				const match = data.match(/port=([0-9]+)/);
-				if (match && match[1]) {
-					this.options.port = parseInt(match[1], 10);
-					this.__instance.stdout.removeListener("data", catchPort);
-					logger.info(`Pact running on port ${this.options.port}`);
-				}
-			};
+    if (!this.options.port) {
+      // if port isn't specified, listen for it when pact runs
+      const catchPort = (data: any) => {
+        const match = data.match(/port=([0-9]+)/);
+        if (match && match[1]) {
+          this.options.port = parseInt(match[1], 10);
+          this.__instance.stdout.removeListener('data', catchPort);
+          logger.info(`Pact running on port ${this.options.port}`);
+        }
+      };
 
-			this.__instance.stdout.on("data", catchPort);
-		}
+      this.__instance.stdout.on('data', catchPort);
+    }
 
-		this.__instance.stderr.on("data", (data:any) => logger.error(`Pact Binary Error: ${data}`));
+    this.__instance.stderr.on('data', (data: any) =>
+      logger.error(`Pact Binary Error: ${data}`),
+    );
 
-		// check service is available
-		return this.__waitForServiceUp()
-			.timeout(PROCESS_TIMEOUT, `Couldn't start Pact with PID: ${this.__instance.pid}`)
-			.then(() => {
-				this.__running = true;
-				this.emit(AbstractService.Events.START_EVENT, this);
-				return this;
-			});
-	}
+    // check service is available
+    return this.__waitForServiceUp()
+      .timeout(
+        PROCESS_TIMEOUT,
+        `Couldn't start Pact with PID: ${this.__instance.pid}`,
+      )
+      .then(() => {
+        this.__running = true;
+        this.emit(AbstractService.Events.START_EVENT, this);
+        return this;
+      });
+  }
 
-	// Stop the instance
-	public stop(): q.Promise<AbstractService> {
-		const pid = this.__instance ? this.__instance.pid : -1;
-		return q(pactUtil.killBinary(this.__instance))
-			.then(() => this.__waitForServiceDown())
-			.timeout(PROCESS_TIMEOUT, `Couldn't stop Pact with PID '${pid}'`)
-			.then(() => {
-				this.__running = false;
-				this.emit(AbstractService.Events.STOP_EVENT, this);
-				return this;
-			});
-	}
+  // Stop the instance
+  public stop(): q.Promise<AbstractService> {
+    const pid = this.__instance ? this.__instance.pid : -1;
+    return q(pactUtil.killBinary(this.__instance))
+      .then(() => this.__waitForServiceDown())
+      .timeout(PROCESS_TIMEOUT, `Couldn't stop Pact with PID '${pid}'`)
+      .then(() => {
+        this.__running = false;
+        this.emit(AbstractService.Events.STOP_EVENT, this);
+        return this;
+      });
+  }
 
-	// Deletes this instance and emit an event
-	public delete(): q.Promise<AbstractService> {
-		return this.stop().tap(() => this.emit(AbstractService.Events.DELETE_EVENT, this));
-	}
+  // Deletes this instance and emit an event
+  public delete(): q.Promise<AbstractService> {
+    return this.stop().tap(() =>
+      this.emit(AbstractService.Events.DELETE_EVENT, this),
+    );
+  }
 
-	// Subclass responsible for spawning the process
-	protected spawnBinary(): ChildProcess {
-		return pactUtil.spawnBinary(this.__serviceCommand, this.options, this.__argMapping);
-	}
+  // Subclass responsible for spawning the process
+  protected spawnBinary(): ChildProcess {
+    return pactUtil.spawnBinary(
+      this.__serviceCommand,
+      this.options,
+      this.__argMapping,
+    );
+  }
 
-	// Wait for the service to be initialized and ready
-	protected __waitForServiceUp(): q.Promise<any> {
-		let amount = 0;
-		const deferred = q.defer();
+  // Wait for the service to be initialized and ready
+  protected __waitForServiceUp(): q.Promise<any> {
+    let amount = 0;
+    const deferred = q.defer();
 
-		const retry = () => {
-			if (amount >= RETRY_AMOUNT) {
-				deferred.reject(new Error("Pact startup failed; tried calling service 10 times with no result."));
-			}
-			setTimeout(check.bind(this), CHECKTIME);
-		};
+    const retry = () => {
+      if (amount >= RETRY_AMOUNT) {
+        deferred.reject(
+          new Error(
+            'Pact startup failed; tried calling service 10 times with no result.',
+          ),
+        );
+      }
+      setTimeout(check.bind(this), CHECKTIME);
+    };
 
-		const check = () => {
-			amount++;
-			if (this.options.port) {
-				this.__call(this.options).then(() => deferred.resolve(), retry.bind(this));
-			} else {
-				retry();
-			}
-		};
+    const check = () => {
+      amount++;
+      if (this.options.port) {
+        this.__call(this.options).then(
+          () => deferred.resolve(),
+          retry.bind(this),
+        );
+      } else {
+        retry();
+      }
+    };
 
-		check(); // Check first time, start polling
-		return deferred.promise;
-	}
+    check(); // Check first time, start polling
+    return deferred.promise;
+  }
 
-	protected __waitForServiceDown(): q.Promise<any> {
-		let amount = 0;
-		const deferred = q.defer();
+  protected __waitForServiceDown(): q.Promise<any> {
+    let amount = 0;
+    const deferred = q.defer();
 
-		const check = () => {
-			amount++;
-			if (this.options.port) {
-				this.__call(this.options).then(() => {
-					if (amount >= RETRY_AMOUNT) {
-						deferred.reject(new Error("Pact stop failed; tried calling service 10 times with no result."));
-						return;
-					}
-					setTimeout(check, CHECKTIME);
-				}, () => deferred.resolve());
-			} else {
-				deferred.resolve();
-			}
-		};
+    const check = () => {
+      amount++;
+      if (this.options.port) {
+        this.__call(this.options).then(
+          () => {
+            if (amount >= RETRY_AMOUNT) {
+              deferred.reject(
+                new Error(
+                  'Pact stop failed; tried calling service 10 times with no result.',
+                ),
+              );
+              return;
+            }
+            setTimeout(check, CHECKTIME);
+          },
+          () => deferred.resolve(),
+        );
+      } else {
+        deferred.resolve();
+      }
+    };
 
-		check(); // Check first time, start polling
-		return deferred.promise;
-	}
+    check(); // Check first time, start polling
+    return deferred.promise;
+  }
 
-	private __call(options: ServiceOptions): q.Promise<any> {
-		const deferred = q.defer();
-		const config: any = {
-			uri: `http${options.ssl ? "s" : ""}://${options.host}:${options.port}`,
-			method: "GET",
-			headers: {
-				"X-Pact-Mock-Service": true,
-				"Content-Type": "application/json"
-			}
-		};
+  private __call(options: ServiceOptions): q.Promise<any> {
+    const deferred = q.defer();
+    const config: any = {
+      uri: `http${options.ssl ? 's' : ''}://${options.host}:${options.port}`,
+      method: 'GET',
+      headers: {
+        'X-Pact-Mock-Service': true,
+        'Content-Type': 'application/json',
+      },
+    };
 
-		if (options.ssl) {
-			process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-			config.agentOptions = {};
-			config.agentOptions.rejectUnauthorized = false;
-			config.agentOptions.requestCert = false;
-			config.agentOptions.agent = false;
-		}
+    if (options.ssl) {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+      config.agentOptions = {};
+      config.agentOptions.rejectUnauthorized = false;
+      config.agentOptions.requestCert = false;
+      config.agentOptions.agent = false;
+    }
 
-		http(config, (err: any, res: any) => {
-			(!err && res.statusCode === 200) ? deferred.resolve() : deferred.reject(`HTTP Error: '${JSON.stringify(err ? err : res)}'`);
-		});
+    http(config, (err: any, res: any) => {
+      !err && res.statusCode === 200
+        ? deferred.resolve()
+        : deferred.reject(`HTTP Error: '${JSON.stringify(err ? err : res)}'`);
+    });
 
-		return deferred.promise;
-	}
+    return deferred.promise;
+  }
 }
 
 export interface ServiceOptions extends SpawnArguments {
-	port?: number;
-	ssl?: boolean;
-	cors?: boolean;
-	host?: string;
-	sslcert?: string;
-	sslkey?: string;
-	log?: string;
+  port?: number;
+  ssl?: boolean;
+  cors?: boolean;
+  host?: string;
+  sslcert?: string;
+  sslkey?: string;
+  log?: string;
 }

--- a/src/stub.spec.ts
+++ b/src/stub.spec.ts
@@ -1,204 +1,232 @@
 // tslint:disable:no-string-literal
 
-import stubFactory from "./stub";
-import chai = require("chai");
-import chaiAsPromised = require("chai-as-promised");
-import fs = require("fs");
-import path = require("path");
-import q = require("q");
-import _ = require("underscore");
+import stubFactory from './stub';
+import chai = require('chai');
+import chaiAsPromised = require('chai-as-promised');
+import fs = require('fs');
+import path = require('path');
+import q = require('q');
+import _ = require('underscore');
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe("Stub Spec", () => {
-	let stub: any;
-	const validDefaults = {
-		pactUrls: [path.resolve(__dirname, "../test/integration/me-they-success.json")]
-	};
+describe('Stub Spec', () => {
+  let stub: any;
+  const validDefaults = {
+    pactUrls: [
+      path.resolve(__dirname, '../test/integration/me-they-success.json'),
+    ],
+  };
 
-	afterEach(() => stub ? stub.delete().then(() => stub = null) : null);
+  afterEach(() => (stub ? stub.delete().then(() => (stub = null)) : null));
 
-	describe("Start stub", () => {
-		context("when invalid options are set", () => {
-			it("should fail if custom ssl certs do not exist", () => {
-				expect(() => stubFactory({
-					ssl: true,
-					sslcert: "does/not/exist",
-					sslkey: path.resolve(__dirname, "../test/ssl/server.key")
-				})).to.throw(Error);
-			});
+  describe('Start stub', () => {
+    context('when invalid options are set', () => {
+      it('should fail if custom ssl certs do not exist', () => {
+        expect(() =>
+          stubFactory({
+            ssl: true,
+            sslcert: 'does/not/exist',
+            sslkey: path.resolve(__dirname, '../test/ssl/server.key'),
+          }),
+        ).to.throw(Error);
+      });
 
-			it("should fail if custom ssl keys do not exist", () => {
-				expect(() => stubFactory({
-					ssl: true,
-					sslcert: path.resolve(__dirname, "../test/ssl/server.crt"),
-					sslkey: "does/not/exist"
-				})).to.throw(Error);
-			});
+      it('should fail if custom ssl keys do not exist', () => {
+        expect(() =>
+          stubFactory({
+            ssl: true,
+            sslcert: path.resolve(__dirname, '../test/ssl/server.crt'),
+            sslkey: 'does/not/exist',
+          }),
+        ).to.throw(Error);
+      });
 
-			it("should fail if custom ssl cert is set, but ssl key isn't", () => {
-				expect(() => stubFactory({
-					ssl: true,
-					sslcert: path.resolve(__dirname, "../test/ssl/server.crt")
-				})).to.throw(Error);
-			});
+      it("should fail if custom ssl cert is set, but ssl key isn't", () => {
+        expect(() =>
+          stubFactory({
+            ssl: true,
+            sslcert: path.resolve(__dirname, '../test/ssl/server.crt'),
+          }),
+        ).to.throw(Error);
+      });
 
-			it("should fail if custom ssl key is set, but ssl cert isn't", () => {
-				expect(() => stubFactory({
-					ssl: true,
-					sslkey: path.resolve(__dirname, "../test/ssl/server.key")
-				})).to.throw(Error);
-			});
-		});
+      it("should fail if custom ssl key is set, but ssl cert isn't", () => {
+        expect(() =>
+          stubFactory({
+            ssl: true,
+            sslkey: path.resolve(__dirname, '../test/ssl/server.key'),
+          }),
+        ).to.throw(Error);
+      });
+    });
 
-		context("when valid options are set", () => {
-			let dirPath: string;
+    context('when valid options are set', () => {
+      let dirPath: string;
 
-			beforeEach(() => dirPath = path.resolve(__dirname, `../.tmp/${Math.floor(Math.random() * 1000)}`));
+      beforeEach(
+        () =>
+          (dirPath = path.resolve(
+            __dirname,
+            `../.tmp/${Math.floor(Math.random() * 1000)}`,
+          )),
+      );
 
-			afterEach(() => {
-				try {
-					if (fs.statSync(dirPath).isDirectory()) {
-						fs.rmdirSync(dirPath);
-					}
-				} catch (e) {
-				}
-			});
+      afterEach(() => {
+        try {
+          if (fs.statSync(dirPath).isDirectory()) {
+            fs.rmdirSync(dirPath);
+          }
+        } catch (e) {}
+      });
 
-			it("should start correctly when instance is delayed", () => {
-				stub = stubFactory(validDefaults);
+      it('should start correctly when instance is delayed', () => {
+        stub = stubFactory(validDefaults);
 
-				const waitForStubUp = (stub as any)["__waitForServiceUp"].bind(stub);
-				return q.allSettled([
-					waitForStubUp(stub.options),
-					q.delay(5000).then(() => stub.start())
-				]).then((results) => expect(_.reduce(results, (m, r) => m && r.state === "fulfilled")).to.be.true);
-			});
+        const waitForStubUp = (stub as any)['__waitForServiceUp'].bind(stub);
+        return q
+          .allSettled([
+            waitForStubUp(stub.options),
+            q.delay(5000).then(() => stub.start()),
+          ])
+          .then(
+            results =>
+              expect(_.reduce(results, (m, r) => m && r.state === 'fulfilled'))
+                .to.be.true,
+          );
+      });
 
-			it("should start correctly with valid pact URLs", () => {
-				stub = stubFactory(validDefaults);
-				return expect(stub.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with valid pact URLs', () => {
+        stub = stubFactory(validDefaults);
+        return expect(stub.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with valid pact URLs with spaces in it", () => {
-				stub = stubFactory({
-					pactUrls: [path.resolve(__dirname, "../test/integration/me-they-weird path-success.json")]
-				});
-				return expect(stub.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with valid pact URLs with spaces in it', () => {
+        stub = stubFactory({
+          pactUrls: [
+            path.resolve(
+              __dirname,
+              '../test/integration/me-they-weird path-success.json',
+            ),
+          ],
+        });
+        return expect(stub.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with ssl", () => {
-				stub = stubFactory( {...validDefaults, ssl: true});
-				expect(stub.options.ssl).to.equal(true);
-				return expect(stub.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with ssl', () => {
+        stub = stubFactory({ ...validDefaults, ssl: true });
+        expect(stub.options.ssl).to.equal(true);
+        return expect(stub.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with custom ssl cert/key", () => {
-				stub = stubFactory({
-					...validDefaults,
-					ssl: true,
-					sslcert: path.resolve(__dirname, "../test/ssl/server.crt"),
-					sslkey: path.resolve(__dirname, "../test/ssl/server.key")
-				});
-				expect(stub.options.ssl).to.equal(true);
-				return expect(stub.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with custom ssl cert/key', () => {
+        stub = stubFactory({
+          ...validDefaults,
+          ssl: true,
+          sslcert: path.resolve(__dirname, '../test/ssl/server.crt'),
+          sslkey: path.resolve(__dirname, '../test/ssl/server.key'),
+        });
+        expect(stub.options.ssl).to.equal(true);
+        return expect(stub.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with custom ssl cert/key but without specifying ssl flag", () => {
-				stub = stubFactory({
-					...validDefaults,
-					sslcert: path.resolve(__dirname, "../test/ssl/server.crt"),
-					sslkey: path.resolve(__dirname, "../test/ssl/server.key")
-				});
+      it('should start correctly with custom ssl cert/key but without specifying ssl flag', () => {
+        stub = stubFactory({
+          ...validDefaults,
+          sslcert: path.resolve(__dirname, '../test/ssl/server.crt'),
+          sslkey: path.resolve(__dirname, '../test/ssl/server.key'),
+        });
 
-				expect(stub.options.ssl).to.equal(true);
-				return expect(stub.start()).to.eventually.be.fulfilled;
-			});
+        expect(stub.options.ssl).to.equal(true);
+        return expect(stub.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with cors", () => {
-				stub = stubFactory({...validDefaults, cors: true});
-				expect(stub.options.cors).to.equal(true);
-				return expect(stub.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with cors', () => {
+        stub = stubFactory({ ...validDefaults, cors: true });
+        expect(stub.options.cors).to.equal(true);
+        return expect(stub.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with port", () => {
-				const port = Math.floor(Math.random() * 999) + 9000;
-				stub = stubFactory({...validDefaults, port: port});
-				expect(stub.options.port).to.equal(port);
-				return expect(stub.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with port', () => {
+        const port = Math.floor(Math.random() * 999) + 9000;
+        stub = stubFactory({ ...validDefaults, port: port });
+        expect(stub.options.port).to.equal(port);
+        return expect(stub.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with host", () => {
-				const host = "localhost";
-				stub = stubFactory({...validDefaults, host: host});
-				expect(stub.options.host).to.equal(host);
-				return expect(stub.start()).to.eventually.be.fulfilled;
-			});
+      it('should start correctly with host', () => {
+        const host = 'localhost';
+        stub = stubFactory({ ...validDefaults, host: host });
+        expect(stub.options.host).to.equal(host);
+        return expect(stub.start()).to.eventually.be.fulfilled;
+      });
 
-			it("should start correctly with log", () => {
-				const logPath = path.resolve(dirPath, "log.txt");
-				stub = stubFactory({...validDefaults, log: logPath});
-				expect(stub.options.log).to.equal(logPath);
-				return expect(stub.start()).to.eventually.be.fulfilled;
-			});
-		});
+      it('should start correctly with log', () => {
+        const logPath = path.resolve(dirPath, 'log.txt');
+        stub = stubFactory({ ...validDefaults, log: logPath });
+        expect(stub.options.log).to.equal(logPath);
+        return expect(stub.start()).to.eventually.be.fulfilled;
+      });
+    });
 
-		it("should dispatch event when starting", (done) => {
-			stub = stubFactory(validDefaults);
-			stub.once("start", () => done());
-			stub.start();
-		});
+    it('should dispatch event when starting', done => {
+      stub = stubFactory(validDefaults);
+      stub.once('start', () => done());
+      stub.start();
+    });
 
-		it("should change running state to true", () => {
-			stub = stubFactory(validDefaults);
-			return stub.start()
-				.then(() => expect((stub as any)["__running"]).to.be.true);
-		});
-	});
+    it('should change running state to true', () => {
+      stub = stubFactory(validDefaults);
+      return stub
+        .start()
+        .then(() => expect((stub as any)['__running']).to.be.true);
+    });
+  });
 
-	describe("Stop stub", () => {
-		context("when already started", () => {
-			it("should stop running", () => {
-				stub = stubFactory(validDefaults);
-				return stub.start().then(() => stub.stop());
-			});
+  describe('Stop stub', () => {
+    context('when already started', () => {
+      it('should stop running', () => {
+        stub = stubFactory(validDefaults);
+        return stub.start().then(() => stub.stop());
+      });
 
-			it("should dispatch event when stopping", (done) => {
-				stub = stubFactory(validDefaults);
-				stub.once("stop", () => done());
-				stub.start().then(() => stub.stop());
-			});
+      it('should dispatch event when stopping', done => {
+        stub = stubFactory(validDefaults);
+        stub.once('stop', () => done());
+        stub.start().then(() => stub.stop());
+      });
 
-			it("should change running state to false", () => {
-				stub = stubFactory(validDefaults);
-				return stub.start()
-					.then(() => stub.stop())
-					.then(() => expect((stub as any)["__running"]).to.be.false);
-			});
-		});
-	});
+      it('should change running state to false', () => {
+        stub = stubFactory(validDefaults);
+        return stub
+          .start()
+          .then(() => stub.stop())
+          .then(() => expect((stub as any)['__running']).to.be.false);
+      });
+    });
+  });
 
-	describe("Delete stub", () => {
-		context("when already running", () => {
-			it("should stop & delete stub", () => {
-				stub = stubFactory(validDefaults);
-				return stub.start()
-					.then(() => stub.delete());
-			});
+  describe('Delete stub', () => {
+    context('when already running', () => {
+      it('should stop & delete stub', () => {
+        stub = stubFactory(validDefaults);
+        return stub.start().then(() => stub.delete());
+      });
 
-			it("should dispatch event when deleting", (done) => {
-				stub = stubFactory(validDefaults);
-				stub.once("delete", () => done());
-				stub.start().then(() => stub.delete());
-			});
+      it('should dispatch event when deleting', done => {
+        stub = stubFactory(validDefaults);
+        stub.once('delete', () => done());
+        stub.start().then(() => stub.delete());
+      });
 
-			it("should change running state to false", () => {
-				stub = stubFactory(validDefaults);
-				return stub.start()
-					.then(() => stub.delete())
-					.then(() => expect((stub as any)["__running"]).to.be.false);
-			});
-		});
-	});
+      it('should change running state to false', () => {
+        stub = stubFactory(validDefaults);
+        return stub
+          .start()
+          .then(() => stub.delete())
+          .then(() => expect((stub as any)['__running']).to.be.false);
+      });
+    });
+  });
 });

--- a/src/stub.ts
+++ b/src/stub.ts
@@ -1,52 +1,55 @@
 // tslint:disable:no-string-literal
-import {DEFAULT_ARG, SpawnArguments} from "./pact-util";
-import {AbstractService} from "./service";
-import {deprecate} from "util";
+import { DEFAULT_ARG, SpawnArguments } from './pact-util';
+import { AbstractService } from './service';
+import { deprecate } from 'util';
 
-import pact from "./pact-standalone";
-const checkTypes = require("check-types");
+import pact from './pact-standalone';
+const checkTypes = require('check-types');
 
 export class Stub extends AbstractService {
+  public static create = deprecate(
+    (options?: StubOptions) => new Stub(options),
+    'Create function will be removed in future release, please use the default export function or use `new Stub()`',
+  );
 
-	public static create = deprecate(
-		(options?: StubOptions) => new Stub(options),
-		"Create function will be removed in future release, please use the default export function or use `new Stub()`");
+  public readonly options: StubOptions;
 
-	public readonly options: StubOptions;
+  constructor(options?: StubOptions) {
+    options = options || {};
+    options.pactUrls = options.pactUrls || [];
 
-	constructor(options?: StubOptions) {
-		options = options || {};
-		options.pactUrls = options.pactUrls || [];
+    if (options.pactUrls) {
+      checkTypes.assert.array.of.string(options.pactUrls);
+    }
 
-		if (options.pactUrls) {
-			checkTypes.assert.array.of.string(options.pactUrls);
-		}
+    checkTypes.assert.not.emptyArray(
+      options.pactUrls,
+      'Must provide the pactUrls argument',
+    );
 
-		checkTypes.assert.not.emptyArray(options.pactUrls, "Must provide the pactUrls argument");
-
-		super(`${pact.stubPath}`, options, {
-			"pactUrls": DEFAULT_ARG,
-			"port": "--port",
-			"host": "--host",
-			"log": "--log",
-			"ssl": "--ssl",
-			"sslcert": "--sslcert",
-			"sslkey": "--sslkey",
-			"cors": "--cors",
-		});
-	}
+    super(`${pact.stubPath}`, options, {
+      pactUrls: DEFAULT_ARG,
+      port: '--port',
+      host: '--host',
+      log: '--log',
+      ssl: '--ssl',
+      sslcert: '--sslcert',
+      sslkey: '--sslkey',
+      cors: '--cors',
+    });
+  }
 }
 
 // Creates a new instance of the pact stub with the specified option
 export default (options?: StubOptions) => new Stub(options);
 
 export interface StubOptions extends SpawnArguments {
-	pactUrls?: string[];
-	port?: number;
-	ssl?: boolean;
-	cors?: boolean;
-	host?: string;
-	sslcert?: string;
-	sslkey?: string;
-	log?: string;
+  pactUrls?: string[];
+  port?: number;
+  ssl?: boolean;
+  cors?: boolean;
+  host?: string;
+  sslcert?: string;
+  sslkey?: string;
+  log?: string;
 }

--- a/src/verifier.spec.ts
+++ b/src/verifier.spec.ts
@@ -1,233 +1,274 @@
-import path = require("path");
-import chai = require("chai");
-import chaiAsPromised = require("chai-as-promised");
-import verifierFactory, {VerifierOptions} from "./verifier";
+import path = require('path');
+import chai = require('chai');
+import chaiAsPromised = require('chai-as-promised');
+import verifierFactory, { VerifierOptions } from './verifier';
 
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
-describe("Verifier Spec", () => {
-	const currentDir = (process && process.mainModule) ? process.mainModule.filename : "";
+describe('Verifier Spec', () => {
+  const currentDir =
+    process && process.mainModule ? process.mainModule.filename : '';
 
-	context("when automatically finding pacts from a broker", () => {
-		context("when not given --pact-urls and only --provider", () => {
-			it("should fail with an error", () => {
-				expect(() => verifierFactory({
-					providerBaseUrl: "http://localhost",
-					provider: "someprovider"
-				})).to.throw(Error);
-			});
-		});
+  context('when automatically finding pacts from a broker', () => {
+    context('when not given --pact-urls and only --provider', () => {
+      it('should fail with an error', () => {
+        expect(() =>
+          verifierFactory({
+            providerBaseUrl: 'http://localhost',
+            provider: 'someprovider',
+          }),
+        ).to.throw(Error);
+      });
+    });
 
-		context("when not given --pact-urls and only --pact-broker-url", () => {
-			it("should fail with an error", () => {
-				expect(() => verifierFactory({
-					providerBaseUrl: "http://localhost",
-					pactBrokerUrl: "http://foo.com"
-				})).to.throw(Error);
-			});
-		});
+    context('when not given --pact-urls and only --pact-broker-url', () => {
+      it('should fail with an error', () => {
+        expect(() =>
+          verifierFactory({
+            providerBaseUrl: 'http://localhost',
+            pactBrokerUrl: 'http://foo.com',
+          }),
+        ).to.throw(Error);
+      });
+    });
 
-		context("when given valid arguments", () => {
-			it("should return a Verifier object", () => {
-				const verifier = verifierFactory({
-					providerBaseUrl: "http://localhost",
-					pactBrokerUrl: "http://foo.com",
-					provider: "someprovider"
-				});
-				expect(verifier).to.be.a("object");
-				expect(verifier).to.respondTo("verify");
-			});
-		});
-	});
+    context('when given valid arguments', () => {
+      it('should return a Verifier object', () => {
+        const verifier = verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactBrokerUrl: 'http://foo.com',
+          provider: 'someprovider',
+        });
+        expect(verifier).to.be.a('object');
+        expect(verifier).to.respondTo('verify');
+      });
+    });
+  });
 
-	context("when not given --pact-urls or --provider-base-url", () => {
-		it("should fail with an error", () => {
-			expect(() => verifierFactory({} as VerifierOptions)).to.throw(Error);
-		});
-	});
+  context('when not given --pact-urls or --provider-base-url', () => {
+    it('should fail with an error', () => {
+      expect(() => verifierFactory({} as VerifierOptions)).to.throw(Error);
+    });
+  });
 
-	context("when given --provider-states-setup-url", () => {
-		it("should fail with an error", () => {
-			expect(() => verifierFactory({
-				"providerStatesSetupUrl": "http://foo/provider-states/setup"
-			} as VerifierOptions)).to.throw(Error);
-		});
-	});
+  context('when given --provider-states-setup-url', () => {
+    it('should fail with an error', () => {
+      expect(() =>
+        verifierFactory({
+          providerStatesSetupUrl: 'http://foo/provider-states/setup',
+        } as VerifierOptions),
+      ).to.throw(Error);
+    });
+  });
 
-	context("when given local Pact URLs that don't exist", () => {
-		it("should fail with an error", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["test.json"]
-			})).to.throw(Error);
-		});
-	});
+  context("when given local Pact URLs that don't exist", () => {
+    it('should fail with an error', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['test.json'],
+        }),
+      ).to.throw(Error);
+    });
+  });
 
-	context("when given an invalid timeout", () => {
-		it("should fail with an error", () => {
-			expect(() => {
-				verifierFactory({
-					providerBaseUrl: "http://localhost",
-					pactUrls: ["http://idontexist"],
-					timeout: -10
-				});
-			}).to.throw(Error);
-		});
-	});
+  context('when given an invalid timeout', () => {
+    it('should fail with an error', () => {
+      expect(() => {
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['http://idontexist'],
+          timeout: -10,
+        });
+      }).to.throw(Error);
+    });
+  });
 
-	context("when user specifies monkeypatch", () => {
-		it("should return an error on invalid path", () => {
-			expect(() => {
-				verifierFactory({
-					providerBaseUrl: "http://localhost",
-					pactUrls: ["http://idontexist"],
-					monkeypatch: "some-ruby-file.rb"
-				});
-			}).to.throw(Error);
-		});
-	});
+  context('when user specifies monkeypatch', () => {
+    it('should return an error on invalid path', () => {
+      expect(() => {
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['http://idontexist'],
+          monkeypatch: 'some-ruby-file.rb',
+        });
+      }).to.throw(Error);
+    });
+  });
 
-	context("when given remote Pact URLs that don't exist", () => {
-		it("should pass through to the Pact Verifier regardless", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["http://idontexist"]
-			})).to.not.throw(Error);
-		});
-	});
+  context("when given remote Pact URLs that don't exist", () => {
+    it('should pass through to the Pact Verifier regardless', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['http://idontexist'],
+        }),
+      ).to.not.throw(Error);
+    });
+  });
 
-	context("when given local Pact URLs that do exist", () => {
-		it("should not fail", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: [path.dirname(currentDir)]
-			})).to.not.throw(Error);
-		});
-	});
+  context('when given local Pact URLs that do exist', () => {
+    it('should not fail', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: [path.dirname(currentDir)],
+        }),
+      ).to.not.throw(Error);
+    });
+  });
 
-	context("when requested to publish verification results to a Pact Broker", () => {
-		context("and specifies a provider version", () => {
-			it("should pass through to the Pact Verifier", () => {
-				expect(() => verifierFactory({
-					providerBaseUrl: "http://localhost",
-					pactUrls: ["http://idontexist"],
-					publishVerificationResult: true,
-					providerVersion: "1.0.0"
-				})).to.not.throw(Error);
-			});
-		});
-	});
+  context(
+    'when requested to publish verification results to a Pact Broker',
+    () => {
+      context('and specifies a provider version', () => {
+        it('should pass through to the Pact Verifier', () => {
+          expect(() =>
+            verifierFactory({
+              providerBaseUrl: 'http://localhost',
+              pactUrls: ['http://idontexist'],
+              publishVerificationResult: true,
+              providerVersion: '1.0.0',
+            }),
+          ).to.not.throw(Error);
+        });
+      });
+    },
+  );
 
-	context("when requested to publish verification results to a Pact Broker", () => {
-		context("and does not specify provider version", () => {
-			it("should fail with an error", () => {
-				expect(() => verifierFactory({
-					providerBaseUrl: "http://localhost",
-					pactUrls: ["http://idontexist"],
-					publishVerificationResult: true
-				})).to.throw(Error);
-			});
-		});
-	});
+  context(
+    'when requested to publish verification results to a Pact Broker',
+    () => {
+      context('and does not specify provider version', () => {
+        it('should fail with an error', () => {
+          expect(() =>
+            verifierFactory({
+              providerBaseUrl: 'http://localhost',
+              pactUrls: ['http://idontexist'],
+              publishVerificationResult: true,
+            }),
+          ).to.throw(Error);
+        });
+      });
+    },
+  );
 
-	context("when given the correct arguments", () => {
-		it("should return a Verifier object", () => {
-			const verifier = verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["http://idontexist"]
-			});
-			expect(verifier).to.be.a("object");
-			expect(verifier).to.respondTo("verify");
-		});
-	});
+  context('when given the correct arguments', () => {
+    it('should return a Verifier object', () => {
+      const verifier = verifierFactory({
+        providerBaseUrl: 'http://localhost',
+        pactUrls: ['http://idontexist'],
+      });
+      expect(verifier).to.be.a('object');
+      expect(verifier).to.respondTo('verify');
+    });
+  });
 
-	context("when an using format option", () => {
-		it("should work with either 'json' or 'xml'", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["http://idontexist"],
-				format: "xml"
-			} as any)).to.not.throw(Error);
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["http://idontexist"],
-				format: "json"
-			} as any)).to.not.throw(Error);
-		});
+  context('when an using format option', () => {
+    it("should work with either 'json' or 'xml'", () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['http://idontexist'],
+          format: 'xml',
+        } as any),
+      ).to.not.throw(Error);
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['http://idontexist'],
+          format: 'json',
+        } as any),
+      ).to.not.throw(Error);
+    });
 
-		it("should throw an error with anything but a string", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["http://idontexist"],
-				format: 10
-			} as any)).to.throw(Error);
-		});
+    it('should throw an error with anything but a string', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['http://idontexist'],
+          format: 10,
+        } as any),
+      ).to.throw(Error);
+    });
 
-		it("should throw an error with the wrong string", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["http://idontexist"],
-				format: "jsonformat"
-			} as any)).to.throw(Error);
-		});
+    it('should throw an error with the wrong string', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['http://idontexist'],
+          format: 'jsonformat',
+        } as any),
+      ).to.throw(Error);
+    });
 
-		it("should work with a case insensitive string", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: ["http://idontexist"],
-				format: "XML"
-			} as any)).to.not.throw(Error);
-		});
-	});
+    it('should work with a case insensitive string', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: ['http://idontexist'],
+          format: 'XML',
+        } as any),
+      ).to.not.throw(Error);
+    });
+  });
 
-	context("when pactBrokerBaseUrl is not provided", () => {
-		it("should not fail", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: [path.dirname(currentDir)]
-			})).to.not.throw(Error);
-		});
-	});
+  context('when pactBrokerBaseUrl is not provided', () => {
+    it('should not fail', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: [path.dirname(currentDir)],
+        }),
+      ).to.not.throw(Error);
+    });
+  });
 
-	context("when pactBrokerBaseUrl is provided", () => {
-		it("should not fail", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: [path.dirname(currentDir)],
-				pactBrokerBaseUrl: "http://localhost"
-			})).to.not.throw(Error);
-		});
-	});
+  context('when pactBrokerBaseUrl is provided', () => {
+    it('should not fail', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: [path.dirname(currentDir)],
+          pactBrokerBaseUrl: 'http://localhost',
+        }),
+      ).to.not.throw(Error);
+    });
+  });
 
-	context("when consumerVersionTag is not provided", () => {
-		it("should not fail", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: [path.dirname(currentDir)]
-			})).to.not.throw(Error);
-		});
-	});
+  context('when consumerVersionTag is not provided', () => {
+    it('should not fail', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: [path.dirname(currentDir)],
+        }),
+      ).to.not.throw(Error);
+    });
+  });
 
-	context("when consumerVersionTag is provided as a string", () => {
-		it("should convert the argument to an array", () => {
-			const v = verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: [path.dirname(currentDir)],
-				consumerVersionTag: "tag-1"
-			});
+  context('when consumerVersionTag is provided as a string', () => {
+    it('should convert the argument to an array', () => {
+      const v = verifierFactory({
+        providerBaseUrl: 'http://localhost',
+        pactUrls: [path.dirname(currentDir)],
+        consumerVersionTag: 'tag-1',
+      });
 
-			expect(v.options.consumerVersionTag).to.deep.eq(["tag-1"]);
-		});
-	});
+      expect(v.options.consumerVersionTag).to.deep.eq(['tag-1']);
+    });
+  });
 
-	context("when consumerVersionTag is provided as an array", () => {
-		it("should not fail", () => {
-			expect(() => verifierFactory({
-				providerBaseUrl: "http://localhost",
-				pactUrls: [path.dirname(currentDir)],
-				consumerVersionTag: ["tag-1"]
-			})).to.not.throw(Error);
-		});
-	});
+  context('when consumerVersionTag is provided as an array', () => {
+    it('should not fail', () => {
+      expect(() =>
+        verifierFactory({
+          providerBaseUrl: 'http://localhost',
+          pactUrls: [path.dirname(currentDir)],
+          consumerVersionTag: ['tag-1'],
+        }),
+      ).to.not.throw(Error);
+    });
+  });
 });

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -1,191 +1,220 @@
-import path = require("path");
-import url = require("url");
-import logger from "./logger";
-import pactUtil, {DEFAULT_ARG, SpawnArguments} from "./pact-util";
-import q = require("q");
-import pactStandalone from "./pact-standalone";
-const _ = require("underscore");
-const checkTypes = require("check-types");
-const unixify = require("unixify");
+import path = require('path');
+import url = require('url');
+import logger from './logger';
+import pactUtil, { DEFAULT_ARG, SpawnArguments } from './pact-util';
+import q = require('q');
+import pactStandalone from './pact-standalone';
+const _ = require('underscore');
+const checkTypes = require('check-types');
+const unixify = require('unixify');
 
-import fs = require("fs");
-import {deprecate} from "util";
+import fs = require('fs');
+import { deprecate } from 'util';
 
 export class Verifier {
-	public static create = deprecate(
-		(options: VerifierOptions) => new Verifier(options),
-		"Create function will be removed in future release, please use the default export function or use `new Verifier()`");
+  public static create = deprecate(
+    (options: VerifierOptions) => new Verifier(options),
+    'Create function will be removed in future release, please use the default export function or use `new Verifier()`',
+  );
 
-	public readonly options: VerifierOptions;
-	private readonly __argMapping = {
-		"pactUrls": DEFAULT_ARG,
-		"providerBaseUrl": "--provider-base-url",
-		"pactBrokerUrl": "--pact-broker-base-url",
-		"providerStatesSetupUrl": "--provider-states-setup-url",
-		"pactBrokerUsername": "--broker-username",
-		"pactBrokerPassword": "--broker-password",
-		"pactBrokerToken": "--broker-token",
-		"consumerVersionTag": "--consumer-version-tag",
-		"publishVerificationResult": "--publish-verification-results",
-		"providerVersion": "--provider-app-version",
-		"provider": "--provider",
-		"customProviderHeaders": "--custom-provider-header",
-		"monkeypatch": "--monkeypatch",
-		"format": "--format",
-		"out": "--out",
-	};
+  public readonly options: VerifierOptions;
+  private readonly __argMapping = {
+    pactUrls: DEFAULT_ARG,
+    providerBaseUrl: '--provider-base-url',
+    pactBrokerUrl: '--pact-broker-base-url',
+    providerStatesSetupUrl: '--provider-states-setup-url',
+    pactBrokerUsername: '--broker-username',
+    pactBrokerPassword: '--broker-password',
+    pactBrokerToken: '--broker-token',
+    consumerVersionTag: '--consumer-version-tag',
+    publishVerificationResult: '--publish-verification-results',
+    providerVersion: '--provider-app-version',
+    provider: '--provider',
+    customProviderHeaderu: '--custom-provider-header',
+    monkeypatch: '--monkeypatch',
+    format: '--format',
+    out: '--out',
+  };
 
-	constructor(options: VerifierOptions) {
-		options = options || {};
-		options.pactBrokerUrl = options.pactBrokerUrl || "";
-		options.pactUrls = options.pactUrls || [];
-		options.provider = options.provider || "";
-		options.providerStatesSetupUrl = options.providerStatesSetupUrl || "";
-		options.timeout = options.timeout || 30000;
-		options.consumerVersionTag = options.consumerVersionTag || [];
+  constructor(options: VerifierOptions) {
+    options = options || {};
+    options.pactBrokerUrl = options.pactBrokerUrl || '';
+    options.pactUrls = options.pactUrls || [];
+    options.provider = options.provider || '';
+    options.providerStatesSetupUrl = options.providerStatesSetupUrl || '';
+    options.timeout = options.timeout || 30000;
+    options.consumerVersionTag = options.consumerVersionTag || [];
 
-		if (options.consumerVersionTag && checkTypes.string(options.consumerVersionTag)) {
-			options.consumerVersionTag = [options.consumerVersionTag as string];
-		}
-		checkTypes.assert.array.of.string(options.consumerVersionTag);
+    if (
+      options.consumerVersionTag &&
+      checkTypes.string(options.consumerVersionTag)
+    ) {
+      options.consumerVersionTag = [options.consumerVersionTag as string];
+    }
+    checkTypes.assert.array.of.string(options.consumerVersionTag);
 
-		options.pactUrls = _.chain(options.pactUrls)
-			.map((uri: string) => {
-				// only check local files
-				if (!/https?:/.test(url.parse(uri).protocol || "")) { // If it's not a URL, check if file is available
-					try {
-						fs.statSync(path.normalize(uri)).isFile();
+    options.pactUrls = _.chain(options.pactUrls)
+      .map((uri: string) => {
+        // only check local files
+        if (!/https?:/.test(url.parse(uri).protocol || '')) {
+          // If it's not a URL, check if file is available
+          try {
+            fs.statSync(path.normalize(uri)).isFile();
 
-						// Unixify the paths. Pact in multiple places uses URI and matching and
-						// hasn"t really taken Windows into account. This is much easier, albeit
-						// might be a problem on non root-drives
-						// options.pactUrls.push(uri);
-						return unixify(uri);
-					} catch (e) {
-						throw new Error(`Pact file: ${uri} doesn"t exist`);
-					}
-				}
-				// HTTP paths are OK
-				return uri;
-			})
-			.compact()
-			.value();
+            // Unixify the paths. Pact in multiple places uses URI and matching and
+            // hasn"t really taken Windows into account. This is much easier, albeit
+            // might be a problem on non root-drives
+            // options.pactUrls.push(uri);
+            return unixify(uri);
+          } catch (e) {
+            throw new Error(`Pact file: ${uri} doesn"t exist`);
+          }
+        }
+        // HTTP paths are OK
+        return uri;
+      })
+      .compact()
+      .value();
 
-		checkTypes.assert.nonEmptyString(options.providerBaseUrl, "Must provide the providerBaseUrl argument");
+    checkTypes.assert.nonEmptyString(
+      options.providerBaseUrl,
+      'Must provide the providerBaseUrl argument',
+    );
 
-		if (checkTypes.emptyArray(options.pactUrls) && !options.pactBrokerUrl) {
-			throw new Error("Must provide the pactUrls argument if no pactBrokerUrl provided");
-		}
+    if (checkTypes.emptyArray(options.pactUrls) && !options.pactBrokerUrl) {
+      throw new Error(
+        'Must provide the pactUrls argument if no pactBrokerUrl provided',
+      );
+    }
 
-		if (( !options.pactBrokerUrl || _.isEmpty(options.provider)) && checkTypes.emptyArray(options.pactUrls)) {
-			throw new Error("Must provide both provider and pactBrokerUrl if pactUrls not provided.");
-		}
+    if (
+      (!options.pactBrokerUrl || _.isEmpty(options.provider)) &&
+      checkTypes.emptyArray(options.pactUrls)
+    ) {
+      throw new Error(
+        'Must provide both provider and pactBrokerUrl if pactUrls not provided.',
+      );
+    }
 
-		if (options.providerStatesSetupUrl) {
-			checkTypes.assert.string(options.providerStatesSetupUrl);
-		}
+    if (options.providerStatesSetupUrl) {
+      checkTypes.assert.string(options.providerStatesSetupUrl);
+    }
 
-		if (options.pactBrokerUsername) {
-			checkTypes.assert.string(options.pactBrokerUsername);
-		}
+    if (options.pactBrokerUsername) {
+      checkTypes.assert.string(options.pactBrokerUsername);
+    }
 
-		if (options.pactBrokerPassword) {
-			checkTypes.assert.string(options.pactBrokerPassword);
-		}
+    if (options.pactBrokerPassword) {
+      checkTypes.assert.string(options.pactBrokerPassword);
+    }
 
-		if (options.pactBrokerUrl) {
-			checkTypes.assert.string(options.pactBrokerUrl);
-		}
+    if (options.pactBrokerUrl) {
+      checkTypes.assert.string(options.pactBrokerUrl);
+    }
 
-		if (options.consumerVersionTag) {
-			checkTypes.assert.array.of.string(options.consumerVersionTag);
-		}
+    if (options.consumerVersionTag) {
+      checkTypes.assert.array.of.string(options.consumerVersionTag);
+    }
 
-		if (options.pactUrls) {
-			checkTypes.assert.array.of.string(options.pactUrls);
-		}
+    if (options.pactUrls) {
+      checkTypes.assert.array.of.string(options.pactUrls);
+    }
 
-		if (options.providerBaseUrl) {
-			checkTypes.assert.string(options.providerBaseUrl);
-		}
+    if (options.providerBaseUrl) {
+      checkTypes.assert.string(options.providerBaseUrl);
+    }
 
-		if (options.publishVerificationResult) {
-			checkTypes.assert.boolean(options.publishVerificationResult);
-		}
+    if (options.publishVerificationResult) {
+      checkTypes.assert.boolean(options.publishVerificationResult);
+    }
 
-		if (options.publishVerificationResult && !options.providerVersion) {
-			throw new Error("Must provide both or none of publishVerificationResults and providerVersion.");
-		}
+    if (options.publishVerificationResult && !options.providerVersion) {
+      throw new Error(
+        'Must provide both or none of publishVerificationResults and providerVersion.',
+      );
+    }
 
-		if (options.providerVersion) {
-			checkTypes.assert.string(options.providerVersion);
-		}
+    if (options.providerVersion) {
+      checkTypes.assert.string(options.providerVersion);
+    }
 
-		if (options.format) {
-			checkTypes.assert.string(options.format);
-			checkTypes.assert.match(options.format, /^(xml|json)$/i);
-			options.format = options.format.toLowerCase() === "xml" ? "RspecJunitFormatter" : "json";
-		}
+    if (options.format) {
+      checkTypes.assert.string(options.format);
+      checkTypes.assert.match(options.format, /^(xml|json)$/i);
+      options.format =
+        options.format.toLowerCase() === 'xml' ? 'RspecJunitFormatter' : 'json';
+    }
 
-		if (options.out) {
-			checkTypes.assert.string(options.out);
-		}
+    if (options.out) {
+      checkTypes.assert.string(options.out);
+    }
 
-		if (options.tags) {
-			logger.warn("'tags' has been deprecated as at v8.0.0, please use 'consumerVersionTag' instead");
-		}
+    if (options.tags) {
+      logger.warn(
+        "'tags' has been deprecated as at v8.0.0, please use 'consumerVersionTag' instead",
+      );
+    }
 
-		checkTypes.assert.positive(options.timeout);
+    checkTypes.assert.positive(options.timeout);
 
-		if (options.monkeypatch) {
-			checkTypes.assert.string(options.monkeypatch);
-			try {
-				fs.statSync(path.normalize(options.monkeypatch)).isFile();
-			} catch (e) {
-				throw new Error(`Monkeypatch ruby file not found at path: ${options.monkeypatch}`);
-			}
-		}
+    if (options.monkeypatch) {
+      checkTypes.assert.string(options.monkeypatch);
+      try {
+        fs.statSync(path.normalize(options.monkeypatch)).isFile();
+      } catch (e) {
+        throw new Error(
+          `Monkeypatch ruby file not found at path: ${options.monkeypatch}`,
+        );
+      }
+    }
 
-		this.options = options;
-	}
+    this.options = options;
+  }
 
-	public verify(): q.Promise<string> {
-		logger.info("Verifying Pact Files");
-		const deferred = q.defer<string>();
-		const instance = pactUtil.spawnBinary(pactStandalone.verifierPath, this.options, this.__argMapping);
-		const output: any[] = [];
-		instance.stdout.on("data", (l) => output.push(l));
-		instance.stderr.on("data", (l) => output.push(l));
-		instance.once("close", (code) => {
-			const o = output.join("\n");
-			code === 0 ? deferred.resolve(o) : deferred.reject(new Error(o));
-		});
+  public verify(): q.Promise<string> {
+    logger.info('Verifying Pact Files');
+    const deferred = q.defer<string>();
+    const instance = pactUtil.spawnBinary(
+      pactStandalone.verifierPath,
+      this.options,
+      this.__argMapping,
+    );
+    const output: any[] = [];
+    instance.stdout.on('data', l => output.push(l));
+    instance.stderr.on('data', l => output.push(l));
+    instance.once('close', code => {
+      const o = output.join('\n');
+      code === 0 ? deferred.resolve(o) : deferred.reject(new Error(o));
+    });
 
-		return deferred.promise
-			.timeout(this.options.timeout as number, `Timeout waiting for verification process to complete (PID: ${instance.pid})`)
-			.tap(() => logger.info("Pact Verification succeeded."));
-	}
+    return deferred.promise
+      .timeout(
+        this.options.timeout as number,
+        `Timeout waiting for verification process to complete (PID: ${instance.pid})`,
+      )
+      .tap(() => logger.info('Pact Verification succeeded.'));
+  }
 }
 
 // Creates a new instance of the pact server with the specified option
 export default (options: VerifierOptions) => new Verifier(options);
 
 export interface VerifierOptions extends SpawnArguments {
-	providerBaseUrl: string;
-	provider?: string;
-	pactUrls?: string[];
-	pactBrokerUrl?: string;
-	providerStatesSetupUrl?: string;
-	pactBrokerUsername?: string;
-	pactBrokerPassword?: string;
-	pactBrokerToken?: string;
-	consumerVersionTag?: string | string[];
-	customProviderHeaders?: string[];
-	publishVerificationResult?: boolean;
-	providerVersion?: string;
-	timeout?: number;
-	tags?: string[];
-	monkeypatch?: string;
-	format?: "json" | "RspecJunitFormatter";
-	out?: string;
+  providerBaseUrl: string;
+  provider?: string;
+  pactUrls?: string[];
+  pactBrokerUrl?: string;
+  providerStatesSetupUrl?: string;
+  pactBrokerUsername?: string;
+  pactBrokerPassword?: string;
+  pactBrokerToken?: string;
+  consumerVersionTag?: string | string[];
+  customProviderHeaders?: string[];
+  publishVerificationResult?: boolean;
+  providerVersion?: string;
+  timeout?: number;
+  tags?: string[];
+  monkeypatch?: string;
+  format?: 'json' | 'RspecJunitFormatter';
+  out?: string;
 }

--- a/standalone/install.spec.ts
+++ b/standalone/install.spec.ts
@@ -1,79 +1,90 @@
 /* global describe:true, before:true, after:true, it:true, global:true, process:true */
 /* tslint:disable:no-string-literal */
-import * as fs from "fs";
-import * as path from "path";
-import * as chai from "chai";
+import * as fs from 'fs';
+import * as path from 'path';
+import * as chai from 'chai';
 
 const expect = chai.expect;
 
 // Needs to stay a function and not an arrow function to access mocha 'this' context
-describe("Install", () => {
-	const packageBasePath: string = path.resolve(__dirname, "../..");
-	const packagePath: string = path.resolve(packageBasePath, "package.json");
-	beforeEach(() => {
-		// Clear require cache
-		for (let key in require.cache) {
-			delete require.cache[key];
-		}
-	});
+describe('Install', () => {
+  const packageBasePath: string = path.resolve(__dirname, '../..');
+  const packagePath: string = path.resolve(packageBasePath, 'package.json');
+  beforeEach(() => {
+    // Clear require cache
+    for (let key in require.cache) {
+      delete require.cache[key];
+    }
+  });
 
-	function createConfig() {
-		return require("./install").createConfig();
-	}
+  function createConfig() {
+    return require('./install').createConfig();
+  }
 
-	describe("Package.json Configuration", () => {
-		let packageConfig: any;
-		// Create deep copy of our current package.json
-		beforeEach(() => packageConfig = JSON.parse(JSON.stringify(require("../package.json"))));
+  describe('Package.json Configuration', () => {
+    let packageConfig: any;
+    // Create deep copy of our current package.json
+    beforeEach(
+      () =>
+        (packageConfig = JSON.parse(
+          JSON.stringify(require('../package.json')),
+        )),
+    );
 
-		afterEach(() => {
-			// Remove created package file if there
-			if (fs.existsSync(packagePath)) {
-				fs.unlinkSync(packagePath);
-			}
-		});
+    afterEach(() => {
+      // Remove created package file if there
+      if (fs.existsSync(packagePath)) {
+        fs.unlinkSync(packagePath);
+      }
+    });
 
-		describe("Binary Location", () => {
-			function setBinaryLocation(location: string, expectation?: string) {
-				packageConfig.config = {
-					pact_binary_location: location
-				};
-				fs.writeFileSync(packagePath, JSON.stringify(packageConfig));
-				const config = createConfig();
-				config.binaries.forEach((entry: any) => {
-					expect(entry.downloadLocation).to.be.equal(expectation || location);
-				});
-			}
+    describe('Binary Location', () => {
+      function setBinaryLocation(location: string, expectation?: string) {
+        packageConfig.config = {
+          pact_binary_location: location,
+        };
+        fs.writeFileSync(packagePath, JSON.stringify(packageConfig));
+        const config = createConfig();
+        config.binaries.forEach((entry: any) => {
+          expect(entry.downloadLocation).to.be.equal(expectation || location);
+        });
+      }
 
-			it("Should be able to set binary location as an absolute path", () => setBinaryLocation("/some-location/or-other", path.resolve("/some-location/or-other")));
+      it('Should be able to set binary location as an absolute path', () =>
+        setBinaryLocation(
+          '/some-location/or-other',
+          path.resolve('/some-location/or-other'),
+        ));
 
-			it("Should be able to set binary location as an relative path", () => {
-				const location = "some-location/or-other";
-				setBinaryLocation(location, path.resolve(packageBasePath, location));
-			});
+      it('Should be able to set binary location as an relative path', () => {
+        const location = 'some-location/or-other';
+        setBinaryLocation(location, path.resolve(packageBasePath, location));
+      });
 
-			it("Should be able to set binary location as an HTTP URL", () => setBinaryLocation("http://some.url"));
+      it('Should be able to set binary location as an HTTP URL', () =>
+        setBinaryLocation('http://some.url'));
 
-			it("Should be able to set binary location as an HTTPS URL", () => setBinaryLocation("https://some.url"));
-		});
+      it('Should be able to set binary location as an HTTPS URL', () =>
+        setBinaryLocation('https://some.url'));
+    });
 
-		it("Should be able to set 'do not track' from package.json config", () => {
-			const doNotTrack = true;
-			packageConfig.config = {
-				pact_do_not_track: doNotTrack
-			};
-			fs.writeFileSync(packagePath, JSON.stringify(packageConfig));
-			const config = createConfig();
-			expect(config.doNotTrack).to.be.equal(doNotTrack);
-		});
-	});
+    it("Should be able to set 'do not track' from package.json config", () => {
+      const doNotTrack = true;
+      packageConfig.config = {
+        pact_do_not_track: doNotTrack,
+      };
+      fs.writeFileSync(packagePath, JSON.stringify(packageConfig));
+      const config = createConfig();
+      expect(config.doNotTrack).to.be.equal(doNotTrack);
+    });
+  });
 
-	describe("Environment variables configuration", () => {
-		it("Should be able to set 'do not track' from environment variable 'PACT_DO_NOT_TRACK'", () => {
-			const doNotTrack = true;
-			process.env.PACT_DO_NOT_TRACK = `${doNotTrack}`;
-			const config = createConfig();
-			expect(config.doNotTrack).to.be.equal(doNotTrack);
-		});
-	});
+  describe('Environment variables configuration', () => {
+    it("Should be able to set 'do not track' from environment variable 'PACT_DO_NOT_TRACK'", () => {
+      const doNotTrack = true;
+      process.env.PACT_DO_NOT_TRACK = `${doNotTrack}`;
+      const config = createConfig();
+      expect(config.doNotTrack).to.be.equal(doNotTrack);
+    });
+  });
 });

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -1,58 +1,58 @@
-import * as http from "http";
-import * as Request from "request";
-import util from "../src/pact-util";
+import * as http from 'http';
+import * as Request from 'request';
+import util from '../src/pact-util';
 
-const path = require("path");
-const fs = require("fs");
-const urljoin = require("url-join");
-const decompress = require("decompress");
-const tar = require("tar");
-const chalk = require("chalk");
-const sumchecker = require("sumchecker");
+const path = require('path');
+const fs = require('fs');
+const urljoin = require('url-join');
+const decompress = require('decompress');
+const tar = require('tar');
+const chalk = require('chalk');
+const sumchecker = require('sumchecker');
 // Sets the request default for all calls through npm environment variables for proxy
 const request = Request.defaults({
   proxy:
     process.env.npm_config_https_proxy ||
     process.env.npm_config_proxy ||
-    undefined
+    undefined,
 });
 
 // Get latest version from https://github.com/pact-foundation/pact-ruby-standalone/releases
-export const PACT_STANDALONE_VERSION = "1.69.0";
+export const PACT_STANDALONE_VERSION = '1.69.0';
 const PACT_DEFAULT_LOCATION = `https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_STANDALONE_VERSION}/`;
 const HTTP_REGEX = /^http(s?):\/\//;
 const CONFIG = createConfig();
 
 const CIs = [
-  "CI",
-  "CONTINUOUS_INTEGRATION",
-  "ABSTRUSE_BUILD_DIR",
-  "APPVEYOR",
-  "BUDDY_WORKSPACE_URL",
-  "BUILDKITE",
-  "CF_BUILD_URL",
-  "CIRCLECI",
-  "CODEBUILD_BUILD_ARN",
-  "CONCOURSE_URL",
-  "DRONE",
-  "GITLAB_CI",
-  "GO_SERVER_URL",
-  "JENKINS_URL",
-  "PROBO_ENVIRONMENT",
-  "SEMAPHORE",
-  "SHIPPABLE",
-  "TDDIUM",
-  "TEAMCITY_VERSION",
-  "TF_BUILD",
-  "TRAVIS",
-  "WERCKER_ROOT"
+  'CI',
+  'CONTINUOUS_INTEGRATION',
+  'ABSTRUSE_BUILD_DIR',
+  'APPVEYOR',
+  'BUDDY_WORKSPACE_URL',
+  'BUILDKITE',
+  'CF_BUILD_URL',
+  'CIRCLECI',
+  'CODEBUILD_BUILD_ARN',
+  'CONCOURSE_URL',
+  'DRONE',
+  'GITLAB_CI',
+  'GO_SERVER_URL',
+  'JENKINS_URL',
+  'PROBO_ENVIRONMENT',
+  'SEMAPHORE',
+  'SHIPPABLE',
+  'TDDIUM',
+  'TEAMCITY_VERSION',
+  'TF_BUILD',
+  'TRAVIS',
+  'WERCKER_ROOT',
 ];
 
 export function createConfig(): Config {
-  const packageConfig = findPackageConfig(path.resolve(__dirname, "..", ".."));
+  const packageConfig = findPackageConfig(path.resolve(__dirname, '..', '..'));
   const PACT_BINARY_LOCATION =
     packageConfig.binaryLocation || PACT_DEFAULT_LOCATION;
-  const CHECKSUM_SUFFIX = ".checksum";
+  const CHECKSUM_SUFFIX = '.checksum';
 
   return {
     doNotTrack:
@@ -61,69 +61,69 @@ export function createConfig(): Config {
       false,
     binaries: [
       {
-        platform: "win32",
+        platform: 'win32',
         binary: `pact-${PACT_STANDALONE_VERSION}-win32.zip`,
         binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-win32.zip${CHECKSUM_SUFFIX}`,
         downloadLocation: PACT_BINARY_LOCATION,
-        folderName: `win32-${PACT_STANDALONE_VERSION}`
+        folderName: `win32-${PACT_STANDALONE_VERSION}`,
       },
       {
-        platform: "darwin",
+        platform: 'darwin',
         binary: `pact-${PACT_STANDALONE_VERSION}-osx.tar.gz`,
         binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-osx.tar.gz${CHECKSUM_SUFFIX}`,
         downloadLocation: PACT_BINARY_LOCATION,
-        folderName: `darwin-${PACT_STANDALONE_VERSION}`
+        folderName: `darwin-${PACT_STANDALONE_VERSION}`,
       },
       {
-        platform: "linux",
-        arch: "x64",
+        platform: 'linux',
+        arch: 'x64',
         binary: `pact-${PACT_STANDALONE_VERSION}-linux-x86_64.tar.gz`,
         binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-linux-x86_64.tar.gz${CHECKSUM_SUFFIX}`,
         downloadLocation: PACT_BINARY_LOCATION,
-        folderName: `linux-x64-${PACT_STANDALONE_VERSION}`
+        folderName: `linux-x64-${PACT_STANDALONE_VERSION}`,
       },
       {
-        platform: "linux",
-        arch: "ia32",
+        platform: 'linux',
+        arch: 'ia32',
         binary: `pact-${PACT_STANDALONE_VERSION}-linux-x86.tar.gz`,
         binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-linux-x86.tar.gz${CHECKSUM_SUFFIX}`,
         downloadLocation: PACT_BINARY_LOCATION,
-        folderName: `linux-ia32-${PACT_STANDALONE_VERSION}`
-      }
-    ]
+        folderName: `linux-ia32-${PACT_STANDALONE_VERSION}`,
+      },
+    ],
   };
 }
 
 function findPackageConfig(
   location: string,
-  tries: number = 10
+  tries: number = 10,
 ): PackageConfig {
   if (tries === 0) {
     return {};
   }
-  const packagePath = path.resolve(location, "package.json");
+  const packagePath = path.resolve(location, 'package.json');
   if (fs.existsSync(packagePath)) {
     const config = require(packagePath).config;
     if (config && (config.pact_binary_location || config.pact_do_not_track)) {
       return {
         binaryLocation: getBinaryLocation(
           config.pact_binary_location,
-          location
+          location,
         ),
-        doNotTrack: config.pact_do_not_track
+        doNotTrack: config.pact_do_not_track,
       };
     }
   }
 
-  return findPackageConfig(path.resolve(location, ".."), tries - 1);
+  return findPackageConfig(path.resolve(location, '..'), tries - 1);
 }
 
 function getBinaryLocation(
   location: string,
-  basePath: string
+  basePath: string,
 ): string | undefined {
   // Check if location is valid and is a string
-  if (!location || typeof location !== "string" || location.length === 0) {
+  if (!location || typeof location !== 'string' || location.length === 0) {
     return undefined;
   }
 
@@ -135,48 +135,48 @@ function getBinaryLocation(
 
 function download(data: Data): Promise<Data> {
   console.log(
-    chalk.gray(`Installing Pact Standalone Binary for ${data.platform}.`)
+    chalk.gray(`Installing Pact Standalone Binary for ${data.platform}.`),
   );
   return new Promise(
     (resolve: (f: Data) => void, reject: (e: string) => void) => {
       if (fs.existsSync(path.resolve(data.filepath))) {
-        console.log(chalk.yellow("Binary already downloaded, skipping..."));
+        console.log(chalk.yellow('Binary already downloaded, skipping...'));
         return resolve(data);
       }
       console.log(
         chalk.yellow(
-          `Downloading Pact Standalone Binary v${PACT_STANDALONE_VERSION} for platform ${data.platform} from ${data.binaryDownloadPath}`
-        )
+          `Downloading Pact Standalone Binary v${PACT_STANDALONE_VERSION} for platform ${data.platform} from ${data.binaryDownloadPath}`,
+        ),
       );
 
       // Track downloads through Google Analytics unless testing or don't want to be tracked
       if (!CONFIG.doNotTrack) {
         console.log(
           chalk.gray(
-            "Please note: we are tracking this download anonymously to gather important usage statistics. " +
-              "To disable tracking, set 'pact_do_not_track: true' in your package.json 'config' section."
-          )
+            'Please note: we are tracking this download anonymously to gather important usage statistics. ' +
+              "To disable tracking, set 'pact_do_not_track: true' in your package.json 'config' section.",
+          ),
         );
         // Trying to find all environment variables of all possible CI services to get more accurate stats
         // but it's still not 100% since not all systems have unique environment variables for their CI server
         const isCI = CIs.some(key => process.env[key] !== undefined);
         request
           .post({
-            url: "https://www.google-analytics.com/collect",
+            url: 'https://www.google-analytics.com/collect',
             form: {
               v: 1,
-              tid: "UA-117778936-1", // Tracking ID / Property ID.
+              tid: 'UA-117778936-1', // Tracking ID / Property ID.
               cid: Math.round(2147483647 * Math.random()).toString(), // Anonymous Client ID.
-              t: "screenview", // Screenview hit type.
-              an: "pact-install", // App name.
-              av: require("../package.json").version, // App version.
-              aid: "pact-node", // App Id.
+              t: 'screenview', // Screenview hit type.
+              an: 'pact-install', // App name.
+              av: require('../package.json').version, // App version.
+              aid: 'pact-node', // App Id.
               aiid: `standalone-${PACT_STANDALONE_VERSION}`, // App Installer Id.
-              cd: `download-node-${data.platform}-${isCI ? "ci" : "user"}`,
-              aip: true // Anonymise IP address
-            }
+              cd: `download-node-${data.platform}-${isCI ? 'ci' : 'user'}`,
+              aip: true, // Anonymise IP address
+            },
           })
-          .on("error", () => {}); // Ignore all errors
+          .on('error', () => {}); // Ignore all errors
       }
 
       // Get archive of release
@@ -185,37 +185,37 @@ function download(data: Data): Promise<Data> {
         downloadFileRetry(data.binaryDownloadPath, data.filepath).then(
           () => {
             console.log(
-              chalk.green(`Finished downloading binary to ${data.filepath}`)
+              chalk.green(`Finished downloading binary to ${data.filepath}`),
             );
             resolve(data);
           },
           (e: string) =>
             reject(
-              `Error downloading binary from ${data.binaryDownloadPath}: ${e}`
-            )
+              `Error downloading binary from ${data.binaryDownloadPath}: ${e}`,
+            ),
         );
       } else if (fs.existsSync(data.binaryDownloadPath)) {
         // Or else it might be a local file, try to copy it over to the correct directory
         fs.createReadStream(data.binaryDownloadPath)
-          .on("error", (e: string) =>
+          .on('error', (e: string) =>
             reject(
-              `Error reading the file at '${data.binaryDownloadPath}': ${e}`
-            )
+              `Error reading the file at '${data.binaryDownloadPath}': ${e}`,
+            ),
           )
           .pipe(
             fs
               .createWriteStream(data.filepath)
-              .on("error", (e: string) =>
-                reject(`Error writing the file to '${data.filepath}': ${e}`)
+              .on('error', (e: string) =>
+                reject(`Error writing the file to '${data.filepath}': ${e}`),
               )
-              .on("close", () => resolve(data))
+              .on('close', () => resolve(data)),
           );
       } else {
         reject(
-          `Could not get binary from '${data.binaryDownloadPath}' as it's not a URL and does not exist at the path specified.`
+          `Could not get binary from '${data.binaryDownloadPath}' as it's not a URL and does not exist at the path specified.`,
         );
       }
-    }
+    },
   );
 }
 
@@ -236,15 +236,15 @@ function extract(data: Data): Promise<void> {
   // Validate checksum to make sure it's the correct binary
   const basename = path.basename(data.filepath);
   return (
-    sumchecker("sha1", data.checksumFilepath, __dirname, basename)
+    sumchecker('sha1', data.checksumFilepath, __dirname, basename)
       .then(
         () => console.log(chalk.green(`Checksum passed for '${basename}'.`)),
         () =>
           throwError(
             `Checksum rejected for file '${basename}' with checksum ${path.basename(
-              data.checksumFilepath
-            )}`
-          )
+              data.checksumFilepath,
+            )}`,
+          ),
       )
       // Extract files into their platform folder
       .then(() =>
@@ -255,35 +255,35 @@ function extract(data: Data): Promise<void> {
               strip: 1,
               cwd: data.platformFolderPath,
               preserveOwner: false,
-              Z: true
-            })
+              Z: true,
+            }),
       )
       .then(() => {
         // Remove pact-publish as it's getting deprecated
         const publishPath = path.resolve(
           data.platformFolderPath,
-          "bin",
-          `pact-publish${util.isWindows() ? ".bat" : ""}`
+          'bin',
+          `pact-publish${util.isWindows() ? '.bat' : ''}`,
         );
         if (fs.existsSync(publishPath)) {
           fs.unlinkSync(publishPath);
         }
-        console.log(chalk.green("Extraction done."));
+        console.log(chalk.green('Extraction done.'));
       })
       .then(() => {
         console.log(
-          "\n\n" +
+          '\n\n' +
             chalk.bgYellow(
-              chalk.black("### If you") +
-                chalk.red(" ❤ ") +
-                chalk.black("Pact and want to support us, please donate here:")
+              chalk.black('### If you') +
+                chalk.red(' ❤ ') +
+                chalk.black('Pact and want to support us, please donate here:'),
             ) +
-            chalk.blue(" http://donate.pact.io/node") +
-            "\n\n"
+            chalk.blue(' http://donate.pact.io/node') +
+            '\n\n',
         );
       })
       .catch((e: any) =>
-        throwError(`Extraction failed for ${data.filepath}: ${e}`)
+        throwError(`Extraction failed for ${data.filepath}: ${e}`),
       )
   );
 }
@@ -298,7 +298,7 @@ function setup(platform?: string, arch?: string): Promise<Data> {
     isWindows: util.isWindows(platform),
     platform: entry.platform,
     arch: entry.arch,
-    platformFolderPath: path.resolve(__dirname, entry.folderName)
+    platformFolderPath: path.resolve(__dirname, entry.folderName),
   });
 }
 
@@ -309,7 +309,7 @@ function join(...paths: string[]): string {
 function downloadFileRetry(
   url: string,
   filepath: string,
-  retry: number = 3
+  retry: number = 3,
 ): Promise<any> {
   return new Promise((resolve: () => void, reject: (e: string) => void) => {
     let len = 0;
@@ -317,15 +317,15 @@ function downloadFileRetry(
     let time = Date.now();
     request({
       url,
-      headers: { "User-Agent": "https://github.com/pact-foundation/pact-node" }
+      headers: { 'User-Agent': 'https://github.com/pact-foundation/pact-node' },
     })
-      .on("error", (e: string) => reject(e))
+      .on('error', (e: string) => reject(e))
       .on(
-        "response",
+        'response',
         (res: http.IncomingMessage) =>
-          (len = parseInt(res.headers["content-length"] as string, 10))
+          (len = parseInt(res.headers['content-length'] as string, 10)),
       )
-      .on("data", (chunk: any[]) => {
+      .on('data', (chunk: any[]) => {
         downloaded += chunk.length;
         // Only show download progress every second
         const now = Date.now();
@@ -333,15 +333,15 @@ function downloadFileRetry(
           time = now;
           console.log(
             chalk.gray(
-              `Downloaded ${((100 * downloaded) / len).toFixed(2)}%...`
-            )
+              `Downloaded ${((100 * downloaded) / len).toFixed(2)}%...`,
+            ),
           );
         }
       })
       .pipe(fs.createWriteStream(filepath))
-      .on("finish", () => resolve());
+      .on('finish', () => resolve());
   }).catch((e: string) =>
-    retry-- === 0 ? throwError(e) : downloadFileRetry(url, filepath, retry)
+    retry-- === 0 ? throwError(e) : downloadFileRetry(url, filepath, retry),
   );
 }
 
@@ -361,7 +361,7 @@ export function getBinaryEntry(platform?: string, arch?: string): BinaryEntry {
     }
   }
   throw throwError(
-    `Cannot find binary for platform '${platform}' with architecture '${arch}'.`
+    `Cannot find binary for platform '${platform}' with architecture '${arch}'.`,
   );
 }
 
@@ -372,28 +372,28 @@ export function downloadChecksums() {
       setup(value.platform, value.arch).then((data: Data) =>
         downloadFileRetry(
           data.checksumDownloadPath,
-          data.checksumFilepath
+          data.checksumFilepath,
         ).then(
           () => {
             console.log(
               chalk.green(
                 `Finished downloading checksum ${path.basename(
-                  data.checksumFilepath
-                )}`
-              )
+                  data.checksumFilepath,
+                )}`,
+              ),
             );
             return data;
           },
           (e: string) =>
             throwError(
-              `Error downloading checksum from ${data.checksumDownloadPath}: ${e}`
-            )
-        )
-      )
-    )
+              `Error downloading checksum from ${data.checksumDownloadPath}: ${e}`,
+            ),
+        ),
+      ),
+    ),
   ).then(
-    () => console.log(chalk.green("All checksums downloaded.")),
-    (e: string) => throwError(`Checksum Download Failed Unexpectedly: ${e}`)
+    () => console.log(chalk.green('All checksums downloaded.')),
+    (e: string) => throwError(`Checksum Download Failed Unexpectedly: ${e}`),
   );
 }
 
@@ -401,9 +401,9 @@ export default (platform?: string, arch?: string) =>
   setup(platform, arch)
     .then(d => download(d))
     .then(d => extract(d))
-    .then(() => console.log(chalk.green("Pact Standalone Binary is ready.")))
+    .then(() => console.log(chalk.green('Pact Standalone Binary is ready.')))
     .catch((e: string) =>
-      throwError(`Postinstalled Failed Unexpectedly: ${e}`)
+      throwError(`Postinstalled Failed Unexpectedly: ${e}`),
     );
 
 export interface PackageConfig {

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -10,7 +10,12 @@ const tar = require("tar");
 const chalk = require("chalk");
 const sumchecker = require("sumchecker");
 // Sets the request default for all calls through npm environment variables for proxy
-const request = Request.defaults({proxy: process.env.npm_config_https_proxy || process.env.npm_config_proxy || undefined});
+const request = Request.defaults({
+  proxy:
+    process.env.npm_config_https_proxy ||
+    process.env.npm_config_proxy ||
+    undefined
+});
 
 // Get latest version from https://github.com/pact-foundation/pact-ruby-standalone/releases
 export const PACT_STANDALONE_VERSION = "1.69.0";
@@ -19,326 +24,414 @@ const HTTP_REGEX = /^http(s?):\/\//;
 const CONFIG = createConfig();
 
 const CIs = [
-	"CI",
-	"CONTINUOUS_INTEGRATION",
-	"ABSTRUSE_BUILD_DIR",
-	"APPVEYOR",
-	"BUDDY_WORKSPACE_URL",
-	"BUILDKITE",
-	"CF_BUILD_URL",
-	"CIRCLECI",
-	"CODEBUILD_BUILD_ARN",
-	"CONCOURSE_URL",
-	"DRONE",
-	"GITLAB_CI",
-	"GO_SERVER_URL",
-	"JENKINS_URL",
-	"PROBO_ENVIRONMENT",
-	"SEMAPHORE",
-	"SHIPPABLE",
-	"TDDIUM",
-	"TEAMCITY_VERSION",
-	"TF_BUILD",
-	"TRAVIS",
-	"WERCKER_ROOT",
+  "CI",
+  "CONTINUOUS_INTEGRATION",
+  "ABSTRUSE_BUILD_DIR",
+  "APPVEYOR",
+  "BUDDY_WORKSPACE_URL",
+  "BUILDKITE",
+  "CF_BUILD_URL",
+  "CIRCLECI",
+  "CODEBUILD_BUILD_ARN",
+  "CONCOURSE_URL",
+  "DRONE",
+  "GITLAB_CI",
+  "GO_SERVER_URL",
+  "JENKINS_URL",
+  "PROBO_ENVIRONMENT",
+  "SEMAPHORE",
+  "SHIPPABLE",
+  "TDDIUM",
+  "TEAMCITY_VERSION",
+  "TF_BUILD",
+  "TRAVIS",
+  "WERCKER_ROOT"
 ];
 
 export function createConfig(): Config {
-	const packageConfig = findPackageConfig(path.resolve(__dirname, "..", ".."));
-	const PACT_BINARY_LOCATION = packageConfig.binaryLocation || PACT_DEFAULT_LOCATION;
-	const CHECKSUM_SUFFIX = ".checksum";
+  const packageConfig = findPackageConfig(path.resolve(__dirname, "..", ".."));
+  const PACT_BINARY_LOCATION =
+    packageConfig.binaryLocation || PACT_DEFAULT_LOCATION;
+  const CHECKSUM_SUFFIX = ".checksum";
 
-	return {
-		doNotTrack: packageConfig.doNotTrack || process.env.PACT_DO_NOT_TRACK !== undefined || false,
-		binaries: [
-			{
-				platform: "win32",
-				binary: `pact-${PACT_STANDALONE_VERSION}-win32.zip`,
-				binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-win32.zip${CHECKSUM_SUFFIX}`,
-				downloadLocation: PACT_BINARY_LOCATION,
-				folderName: `win32-${PACT_STANDALONE_VERSION}`
-			},
-			{
-				platform: "darwin",
-				binary: `pact-${PACT_STANDALONE_VERSION}-osx.tar.gz`,
-				binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-osx.tar.gz${CHECKSUM_SUFFIX}`,
-				downloadLocation: PACT_BINARY_LOCATION,
-				folderName: `darwin-${PACT_STANDALONE_VERSION}`
-			},
-			{
-				platform: "linux",
-				arch: "x64",
-				binary: `pact-${PACT_STANDALONE_VERSION}-linux-x86_64.tar.gz`,
-				binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-linux-x86_64.tar.gz${CHECKSUM_SUFFIX}`,
-				downloadLocation: PACT_BINARY_LOCATION,
-				folderName: `linux-x64-${PACT_STANDALONE_VERSION}`
-			},
-			{
-				platform: "linux",
-				arch: "ia32",
-				binary: `pact-${PACT_STANDALONE_VERSION}-linux-x86.tar.gz`,
-				binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-linux-x86.tar.gz${CHECKSUM_SUFFIX}`,
-				downloadLocation: PACT_BINARY_LOCATION,
-				folderName: `linux-ia32-${PACT_STANDALONE_VERSION}`
-			}
-		]
-	};
+  return {
+    doNotTrack:
+      packageConfig.doNotTrack ||
+      process.env.PACT_DO_NOT_TRACK !== undefined ||
+      false,
+    binaries: [
+      {
+        platform: "win32",
+        binary: `pact-${PACT_STANDALONE_VERSION}-win32.zip`,
+        binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-win32.zip${CHECKSUM_SUFFIX}`,
+        downloadLocation: PACT_BINARY_LOCATION,
+        folderName: `win32-${PACT_STANDALONE_VERSION}`
+      },
+      {
+        platform: "darwin",
+        binary: `pact-${PACT_STANDALONE_VERSION}-osx.tar.gz`,
+        binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-osx.tar.gz${CHECKSUM_SUFFIX}`,
+        downloadLocation: PACT_BINARY_LOCATION,
+        folderName: `darwin-${PACT_STANDALONE_VERSION}`
+      },
+      {
+        platform: "linux",
+        arch: "x64",
+        binary: `pact-${PACT_STANDALONE_VERSION}-linux-x86_64.tar.gz`,
+        binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-linux-x86_64.tar.gz${CHECKSUM_SUFFIX}`,
+        downloadLocation: PACT_BINARY_LOCATION,
+        folderName: `linux-x64-${PACT_STANDALONE_VERSION}`
+      },
+      {
+        platform: "linux",
+        arch: "ia32",
+        binary: `pact-${PACT_STANDALONE_VERSION}-linux-x86.tar.gz`,
+        binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-linux-x86.tar.gz${CHECKSUM_SUFFIX}`,
+        downloadLocation: PACT_BINARY_LOCATION,
+        folderName: `linux-ia32-${PACT_STANDALONE_VERSION}`
+      }
+    ]
+  };
 }
 
-function findPackageConfig(location: string, tries: number = 10): PackageConfig {
-	if (tries === 0) {
-		return {};
-	}
-	const packagePath = path.resolve(location, "package.json");
-	if (fs.existsSync(packagePath)) {
-		const config = require(packagePath).config;
-		if (config && (config.pact_binary_location || config.pact_do_not_track)) {
-			return {
-				binaryLocation: getBinaryLocation(config.pact_binary_location, location),
-				doNotTrack: config.pact_do_not_track
-			};
-		}
-	}
+function findPackageConfig(
+  location: string,
+  tries: number = 10
+): PackageConfig {
+  if (tries === 0) {
+    return {};
+  }
+  const packagePath = path.resolve(location, "package.json");
+  if (fs.existsSync(packagePath)) {
+    const config = require(packagePath).config;
+    if (config && (config.pact_binary_location || config.pact_do_not_track)) {
+      return {
+        binaryLocation: getBinaryLocation(
+          config.pact_binary_location,
+          location
+        ),
+        doNotTrack: config.pact_do_not_track
+      };
+    }
+  }
 
-	return findPackageConfig(path.resolve(location, ".."), tries - 1);
+  return findPackageConfig(path.resolve(location, ".."), tries - 1);
 }
 
-function getBinaryLocation(location: string, basePath: string): string | undefined {
-	// Check if location is valid and is a string
-	if (!location || typeof location !== "string" || location.length === 0) {
-		return undefined;
-	}
+function getBinaryLocation(
+  location: string,
+  basePath: string
+): string | undefined {
+  // Check if location is valid and is a string
+  if (!location || typeof location !== "string" || location.length === 0) {
+    return undefined;
+  }
 
-	// Check if it's a URL, if not, try to resolve the path to work with either absolute or relative paths
-	return HTTP_REGEX.test(location) ? location : path.resolve(basePath, location);
+  // Check if it's a URL, if not, try to resolve the path to work with either absolute or relative paths
+  return HTTP_REGEX.test(location)
+    ? location
+    : path.resolve(basePath, location);
 }
 
 function download(data: Data): Promise<Data> {
-	console.log(chalk.gray(`Installing Pact Standalone Binary for ${data.platform}.`));
-	return new Promise((resolve: (f: Data) => void, reject: (e: string) => void) => {
-		if (fs.existsSync(path.resolve(data.filepath))) {
-			console.log(chalk.yellow("Binary already downloaded, skipping..."));
-			return resolve(data);
-		}
-		console.log(chalk.yellow(`Downloading Pact Standalone Binary v${PACT_STANDALONE_VERSION} for platform ${data.platform} from ${data.binaryDownloadPath}`));
+  console.log(
+    chalk.gray(`Installing Pact Standalone Binary for ${data.platform}.`)
+  );
+  return new Promise(
+    (resolve: (f: Data) => void, reject: (e: string) => void) => {
+      if (fs.existsSync(path.resolve(data.filepath))) {
+        console.log(chalk.yellow("Binary already downloaded, skipping..."));
+        return resolve(data);
+      }
+      console.log(
+        chalk.yellow(
+          `Downloading Pact Standalone Binary v${PACT_STANDALONE_VERSION} for platform ${data.platform} from ${data.binaryDownloadPath}`
+        )
+      );
 
-		// Track downloads through Google Analytics unless testing or don't want to be tracked
-		if (!CONFIG.doNotTrack) {
-			console.log(chalk.gray("Please note: we are tracking this download anonymously to gather important usage statistics. " +
-				"To disable tracking, set 'pact_do_not_track: true' in your package.json 'config' section."));
-			// Trying to find all environment variables of all possible CI services to get more accurate stats
-			// but it's still not 100% since not all systems have unique environment variables for their CI server
-			const isCI = CIs.some((key) => process.env[key] !== undefined);
-			request.post({
-				url: "https://www.google-analytics.com/collect",
-				form: {
-					v: 1,
-					tid: "UA-117778936-1", // Tracking ID / Property ID.
-					cid: Math.round(2147483647 * Math.random()).toString(), // Anonymous Client ID.
-					t: "screenview", // Screenview hit type.
-					an: "pact-install", // App name.
-					av: require("../package.json").version, // App version.
-					aid: "pact-node", // App Id.
-					aiid: `standalone-${PACT_STANDALONE_VERSION}`, // App Installer Id.
-					cd: `download-node-${data.platform}-${isCI ? "ci" : "user"}`,
-					aip: true, // Anonymise IP address
-				}
-			}).on("error", () => {
-			}); // Ignore all errors
-		}
+      // Track downloads through Google Analytics unless testing or don't want to be tracked
+      if (!CONFIG.doNotTrack) {
+        console.log(
+          chalk.gray(
+            "Please note: we are tracking this download anonymously to gather important usage statistics. " +
+              "To disable tracking, set 'pact_do_not_track: true' in your package.json 'config' section."
+          )
+        );
+        // Trying to find all environment variables of all possible CI services to get more accurate stats
+        // but it's still not 100% since not all systems have unique environment variables for their CI server
+        const isCI = CIs.some(key => process.env[key] !== undefined);
+        request
+          .post({
+            url: "https://www.google-analytics.com/collect",
+            form: {
+              v: 1,
+              tid: "UA-117778936-1", // Tracking ID / Property ID.
+              cid: Math.round(2147483647 * Math.random()).toString(), // Anonymous Client ID.
+              t: "screenview", // Screenview hit type.
+              an: "pact-install", // App name.
+              av: require("../package.json").version, // App version.
+              aid: "pact-node", // App Id.
+              aiid: `standalone-${PACT_STANDALONE_VERSION}`, // App Installer Id.
+              cd: `download-node-${data.platform}-${isCI ? "ci" : "user"}`,
+              aip: true // Anonymise IP address
+            }
+          })
+          .on("error", () => {}); // Ignore all errors
+      }
 
-		// Get archive of release
-		// If URL, download via HTTP
-		if (HTTP_REGEX.test(data.binaryDownloadPath)) {
-			downloadFileRetry(data.binaryDownloadPath, data.filepath)
-				.then(
-					() => {
-						console.log(chalk.green(`Finished downloading binary to ${data.filepath}`));
-						resolve(data);
-					},
-					(e: string) => reject(`Error downloading binary from ${data.binaryDownloadPath}: ${e}`)
-				);
-		} else if (fs.existsSync(data.binaryDownloadPath)) {
-			// Or else it might be a local file, try to copy it over to the correct directory
-			fs.createReadStream(data.binaryDownloadPath)
-				.on("error", (e: string) => reject(`Error reading the file at '${data.binaryDownloadPath}': ${e}`))
-				.pipe(
-					fs.createWriteStream(data.filepath)
-						.on("error", (e: string) => reject(`Error writing the file to '${data.filepath}': ${e}`))
-						.on("close", () => resolve(data))
-				);
-		} else {
-			reject(`Could not get binary from '${data.binaryDownloadPath}' as it's not a URL and does not exist at the path specified.`);
-		}
-	});
+      // Get archive of release
+      // If URL, download via HTTP
+      if (HTTP_REGEX.test(data.binaryDownloadPath)) {
+        downloadFileRetry(data.binaryDownloadPath, data.filepath).then(
+          () => {
+            console.log(
+              chalk.green(`Finished downloading binary to ${data.filepath}`)
+            );
+            resolve(data);
+          },
+          (e: string) =>
+            reject(
+              `Error downloading binary from ${data.binaryDownloadPath}: ${e}`
+            )
+        );
+      } else if (fs.existsSync(data.binaryDownloadPath)) {
+        // Or else it might be a local file, try to copy it over to the correct directory
+        fs.createReadStream(data.binaryDownloadPath)
+          .on("error", (e: string) =>
+            reject(
+              `Error reading the file at '${data.binaryDownloadPath}': ${e}`
+            )
+          )
+          .pipe(
+            fs
+              .createWriteStream(data.filepath)
+              .on("error", (e: string) =>
+                reject(`Error writing the file to '${data.filepath}': ${e}`)
+              )
+              .on("close", () => resolve(data))
+          );
+      } else {
+        reject(
+          `Could not get binary from '${data.binaryDownloadPath}' as it's not a URL and does not exist at the path specified.`
+        );
+      }
+    }
+  );
 }
 
 function extract(data: Data): Promise<void> {
+  // If platform folder exists, binary already installed, skip to next step.
+  if (fs.existsSync(data.platformFolderPath)) {
+    return Promise.resolve();
+  }
 
-	// If platform folder exists, binary already installed, skip to next step.
-	if (fs.existsSync(data.platformFolderPath)) {
-		return Promise.resolve();
-	}
+  // Make sure checksum is available
+  if (!fs.existsSync(data.checksumFilepath)) {
+    throwError(`Checksum file missing from standalone directory. Aborting.`);
+  }
 
-	// Make sure checksum is available
-	if (!fs.existsSync(data.checksumFilepath)) {
-		throwError(`Checksum file missing from standalone directory. Aborting.`);
-	}
+  fs.mkdirSync(data.platformFolderPath);
+  console.log(chalk.yellow(`Extracting binary from ${data.filepath}.`));
 
-	fs.mkdirSync(data.platformFolderPath);
-	console.log(chalk.yellow(`Extracting binary from ${data.filepath}.`));
-
-	// Validate checksum to make sure it's the correct binary
-	const basename = path.basename(data.filepath);
-	return sumchecker("sha1", data.checksumFilepath, __dirname, basename)
-		.then(
-			() => console.log(chalk.green(`Checksum passed for '${basename}'.`)),
-			() => throwError(`Checksum rejected for file '${basename}' with checksum ${path.basename(data.checksumFilepath)}`)
-		)
-		// Extract files into their platform folder
-		.then(() => data.isWindows ?
-			decompress(data.filepath, data.platformFolderPath, {strip: 1}) :
-			tar.x({
-				file: data.filepath,
-				strip: 1,
-                cwd: data.platformFolderPath,
-                preserveOwner: false,
-				Z: true
-			})
-		)
-		.then(() => {
-			// Remove pact-publish as it's getting deprecated
-			const publishPath = path.resolve(data.platformFolderPath, "bin", `pact-publish${util.isWindows() ? ".bat" : ""}`);
-			if (fs.existsSync(publishPath)) {
-				fs.unlinkSync(publishPath);
-			}
-			console.log(chalk.green("Extraction done."));
-		})
-		.then(() => {
-			console.log(
-				"\n\n" +
-				chalk.bgYellow(
-					chalk.black("### If you") +
-					chalk.red(" ❤ ") +
-					chalk.black("Pact and want to support us, please donate here:")
-				) +
-				chalk.blue(" http://donate.pact.io/node") +
-				"\n\n"
-			);
-		})
-		.catch((e: any) => throwError(`Extraction failed for ${data.filepath}: ${e}`));
+  // Validate checksum to make sure it's the correct binary
+  const basename = path.basename(data.filepath);
+  return (
+    sumchecker("sha1", data.checksumFilepath, __dirname, basename)
+      .then(
+        () => console.log(chalk.green(`Checksum passed for '${basename}'.`)),
+        () =>
+          throwError(
+            `Checksum rejected for file '${basename}' with checksum ${path.basename(
+              data.checksumFilepath
+            )}`
+          )
+      )
+      // Extract files into their platform folder
+      .then(() =>
+        data.isWindows
+          ? decompress(data.filepath, data.platformFolderPath, { strip: 1 })
+          : tar.x({
+              file: data.filepath,
+              strip: 1,
+              cwd: data.platformFolderPath,
+              preserveOwner: false,
+              Z: true
+            })
+      )
+      .then(() => {
+        // Remove pact-publish as it's getting deprecated
+        const publishPath = path.resolve(
+          data.platformFolderPath,
+          "bin",
+          `pact-publish${util.isWindows() ? ".bat" : ""}`
+        );
+        if (fs.existsSync(publishPath)) {
+          fs.unlinkSync(publishPath);
+        }
+        console.log(chalk.green("Extraction done."));
+      })
+      .then(() => {
+        console.log(
+          "\n\n" +
+            chalk.bgYellow(
+              chalk.black("### If you") +
+                chalk.red(" ❤ ") +
+                chalk.black("Pact and want to support us, please donate here:")
+            ) +
+            chalk.blue(" http://donate.pact.io/node") +
+            "\n\n"
+        );
+      })
+      .catch((e: any) =>
+        throwError(`Extraction failed for ${data.filepath}: ${e}`)
+      )
+  );
 }
 
 function setup(platform?: string, arch?: string): Promise<Data> {
-	const entry = getBinaryEntry(platform, arch);
-	return Promise.resolve({
-		binaryDownloadPath: join(entry.downloadLocation, entry.binary),
-		checksumDownloadPath: join(PACT_DEFAULT_LOCATION, entry.binaryChecksum),
-		filepath: path.resolve(__dirname, entry.binary),
-		checksumFilepath: path.resolve(__dirname, entry.binaryChecksum),
-		isWindows: util.isWindows(platform),
-		platform: entry.platform,
-		arch: entry.arch,
-		platformFolderPath: path.resolve(__dirname, entry.folderName)
-	});
+  const entry = getBinaryEntry(platform, arch);
+  return Promise.resolve({
+    binaryDownloadPath: join(entry.downloadLocation, entry.binary),
+    checksumDownloadPath: join(PACT_DEFAULT_LOCATION, entry.binaryChecksum),
+    filepath: path.resolve(__dirname, entry.binary),
+    checksumFilepath: path.resolve(__dirname, entry.binaryChecksum),
+    isWindows: util.isWindows(platform),
+    platform: entry.platform,
+    arch: entry.arch,
+    platformFolderPath: path.resolve(__dirname, entry.folderName)
+  });
 }
 
 function join(...paths: string[]): string {
-	return HTTP_REGEX.test(paths[0]) ? urljoin(...paths) : path.join(...paths);
+  return HTTP_REGEX.test(paths[0]) ? urljoin(...paths) : path.join(...paths);
 }
 
-function downloadFileRetry(url: string, filepath: string, retry: number = 3): Promise<any> {
-	return new Promise((resolve: () => void, reject: (e: string) => void) => {
-		let len = 0;
-		let downloaded = 0;
-		let time = Date.now();
-		request({ url, headers: { 'User-Agent': 'https://github.com/pact-foundation/pact-node' } })
-			.on("error", (e: string) => reject(e))
-			.on("response", (res: http.IncomingMessage) => len = parseInt(res.headers["content-length"] as string, 10))
-			.on("data", (chunk: any[]) => {
-				downloaded += chunk.length;
-				// Only show download progress every second
-				const now = Date.now();
-				if (now - time > 1000) {
-					time = now;
-					console.log(chalk.gray(`Downloaded ${(100 * downloaded / len).toFixed(2)}%...`));
-				}
-			})
-			.pipe(fs.createWriteStream(filepath))
-			.on("finish", () => resolve());
-	}).catch((e: string) => retry-- === 0 ? throwError(e) : downloadFileRetry(url, filepath, retry));
+function downloadFileRetry(
+  url: string,
+  filepath: string,
+  retry: number = 3
+): Promise<any> {
+  return new Promise((resolve: () => void, reject: (e: string) => void) => {
+    let len = 0;
+    let downloaded = 0;
+    let time = Date.now();
+    request({
+      url,
+      headers: { "User-Agent": "https://github.com/pact-foundation/pact-node" }
+    })
+      .on("error", (e: string) => reject(e))
+      .on(
+        "response",
+        (res: http.IncomingMessage) =>
+          (len = parseInt(res.headers["content-length"] as string, 10))
+      )
+      .on("data", (chunk: any[]) => {
+        downloaded += chunk.length;
+        // Only show download progress every second
+        const now = Date.now();
+        if (now - time > 1000) {
+          time = now;
+          console.log(
+            chalk.gray(
+              `Downloaded ${((100 * downloaded) / len).toFixed(2)}%...`
+            )
+          );
+        }
+      })
+      .pipe(fs.createWriteStream(filepath))
+      .on("finish", () => resolve());
+  }).catch((e: string) =>
+    retry-- === 0 ? throwError(e) : downloadFileRetry(url, filepath, retry)
+  );
 }
 
 function throwError(msg: string): never {
-	throw new Error(chalk.red(`Error while installing binary: ${msg}`));
+  throw new Error(chalk.red(`Error while installing binary: ${msg}`));
 }
 
 export function getBinaryEntry(platform?: string, arch?: string): BinaryEntry {
-	platform = platform || process.platform;
-	arch = arch || process.arch;
-	for (let value of CONFIG.binaries) {
-		if (value.platform === platform && (value.arch ? value.arch === arch : true)) {
-			return value;
-		}
-	}
-	throw throwError(`Cannot find binary for platform '${platform}' with architecture '${arch}'.`);
+  platform = platform || process.platform;
+  arch = arch || process.arch;
+  for (let value of CONFIG.binaries) {
+    if (
+      value.platform === platform &&
+      (value.arch ? value.arch === arch : true)
+    ) {
+      return value;
+    }
+  }
+  throw throwError(
+    `Cannot find binary for platform '${platform}' with architecture '${arch}'.`
+  );
 }
 
 export function downloadChecksums() {
-	console.log(chalk.gray(`Downloading All Pact Standalone Binary Checksums.`));
-	return Promise.all(
-		CONFIG.binaries.map((value) =>
-			setup(value.platform, value.arch)
-				.then((data: Data) =>
-					downloadFileRetry(data.checksumDownloadPath, data.checksumFilepath)
-						.then(
-							() => {
-								console.log(chalk.green(`Finished downloading checksum ${path.basename(data.checksumFilepath)}`));
-								return data;
-							},
-							(e: string) => throwError(`Error downloading checksum from ${data.checksumDownloadPath}: ${e}`)
-						)
-				)
-		)
-	).then(
-		() => console.log(chalk.green("All checksums downloaded.")),
-		(e: string) => throwError(`Checksum Download Failed Unexpectedly: ${e}`)
-	);
+  console.log(chalk.gray(`Downloading All Pact Standalone Binary Checksums.`));
+  return Promise.all(
+    CONFIG.binaries.map(value =>
+      setup(value.platform, value.arch).then((data: Data) =>
+        downloadFileRetry(
+          data.checksumDownloadPath,
+          data.checksumFilepath
+        ).then(
+          () => {
+            console.log(
+              chalk.green(
+                `Finished downloading checksum ${path.basename(
+                  data.checksumFilepath
+                )}`
+              )
+            );
+            return data;
+          },
+          (e: string) =>
+            throwError(
+              `Error downloading checksum from ${data.checksumDownloadPath}: ${e}`
+            )
+        )
+      )
+    )
+  ).then(
+    () => console.log(chalk.green("All checksums downloaded.")),
+    (e: string) => throwError(`Checksum Download Failed Unexpectedly: ${e}`)
+  );
 }
 
 export default (platform?: string, arch?: string) =>
-	setup(platform, arch)
-		.then((d) => download(d))
-		.then((d) => extract(d))
-		.then(() => console.log(chalk.green("Pact Standalone Binary is ready.")))
-		.catch((e: string) => throwError(`Postinstalled Failed Unexpectedly: ${e}`));
+  setup(platform, arch)
+    .then(d => download(d))
+    .then(d => extract(d))
+    .then(() => console.log(chalk.green("Pact Standalone Binary is ready.")))
+    .catch((e: string) =>
+      throwError(`Postinstalled Failed Unexpectedly: ${e}`)
+    );
 
 export interface PackageConfig {
-	binaryLocation?: string;
-	doNotTrack?: boolean;
+  binaryLocation?: string;
+  doNotTrack?: boolean;
 }
 
 export interface Config {
-	doNotTrack: boolean;
-	binaries: BinaryEntry[];
+  doNotTrack: boolean;
+  binaries: BinaryEntry[];
 }
 
 export interface Data {
-	binaryDownloadPath: string;
-	checksumDownloadPath: string;
-	filepath: string;
-	checksumFilepath: string;
-	platform: string;
-	isWindows: boolean;
-	arch?: string;
-	platformFolderPath?: string;
+  binaryDownloadPath: string;
+  checksumDownloadPath: string;
+  filepath: string;
+  checksumFilepath: string;
+  platform: string;
+  isWindows: boolean;
+  arch?: string;
+  platformFolderPath?: string;
 }
 
 export interface BinaryEntry {
-	platform: string;
-	arch?: string;
-	binary: string;
-	binaryChecksum: string;
-	downloadLocation: string;
-	folderName: string;
+  platform: string;
+  arch?: string;
+  binary: string;
+  binaryChecksum: string;
+  downloadLocation: string;
+  folderName: string;
 }

--- a/test/integration/broker-mock.ts
+++ b/test/integration/broker-mock.ts
@@ -1,465 +1,531 @@
-import q = require("q");
-import express = require("express");
-import * as http from "http";
-import {auth, returnJson} from "./data-utils";
-const cors = require("cors");
-const _ = require("underscore");
-const bodyParser = require("body-parser");
+import q = require('q');
+import express = require('express');
+import * as http from 'http';
+import { auth, returnJson } from './data-utils';
+const cors = require('cors');
+const _ = require('underscore');
+const bodyParser = require('body-parser');
 
 export default (port: number): q.Promise<http.Server> => {
-	const BROKER_HOST = `http://localhost:${port}`;
-	const server: express.Express = express();
-	server.use(cors());
-	server.use(bodyParser.json());
-	server.use(bodyParser.urlencoded({extended: true}));
+  const BROKER_HOST = `http://localhost:${port}`;
+  const server: express.Express = express();
+  server.use(cors());
+  server.use(bodyParser.json());
+  server.use(bodyParser.urlencoded({ extended: true }));
 
-	function pactFunction(req: express.Request, res: express.Response) {
-		if (
-			_.isEmpty(req.body) ||
-			// 2. Is there a consumer, provider and version in the request?
-			_.isEmpty(req.params.consumer) || _.isEmpty(req.params.provider) || _.isEmpty(req.params.version)
-		) {
-			return res.sendStatus(400);
-		}
-		return res.status(201).json({
-			"consumer": {"name": "consumer"},
-			"provider": {"name": "publisher"},
-			"interactions": [{
-				"description": "Greeting",
-				"request": {"method": "GET", "path": "/"},
-				"response": {"status": 200, "headers": {}, "body": {"greeting": "Hello"}}
-			}],
-			"metadata": {"pactSpecificationVersion": "2.0.0"},
-			"createdAt": "2017-11-06T13:06:48+00:00",
-			"_links": {
-				"self": {
-					"title": "Pact",
-					"name": "Pact between consumer (v1.0.0) and publisher",
-					"href": `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/version/1.0.0`
-				},
-				"pb:consumer": {
-					"title": "Consumer",
-					"name": "consumer",
-					"href": `${BROKER_HOST}/pacticipants/consumer`
-				},
-				"pb:consumer-version": {
-					"title": "Consumer version",
-					"name": "1.0.0",
-					"href": `${BROKER_HOST}/pacticipants/consumer/versions/1.0.0`
-				},
-				"pb:provider": {
-					"title": "Provider",
-					"name": "publisher",
-					"href": `${BROKER_HOST}/pacticipants/publisher`
-				},
-				"pb:latest-pact-version": {
-					"title": "Latest version of this pact",
-					"href": `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/latest`
-				},
-				"pb:all-pact-versions": {
-					"title": "All version of this pact",
-					"href": `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/versions`
-				},
-				"pb:latest-untagged-pact-version": {
-					"title": "Latest untagged version of this pact",
-					"href": `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/latest-untagged`
-				},
-				"pb:latest-tagged-pact-version": {
-					"title": "Latest tagged version of this pact",
-					"href": `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/latest/{tag}`,
-					"templated": true
-				},
-				"pb:previous-distinct": {
-					"title": "Previous distinct version of this pact",
-					"href": `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/version/1.0.0/previous-distinct`
-				},
-				"pb:diff-previous-distinct": {
-					"title": "Diff with previous distinct version of this pact",
-					"href": `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/version/1.0.0/diff/previous-distinct`
-				},
-				"pb:pact-webhooks": {
-					"title": "Webhooks for the pact between consumer and publisher",
-					"href": `${BROKER_HOST}/webhooks/provider/publisher/consumer/consumer`
-				},
-				"pb:tag-prod-version": {
-					"title": "PUT to this resource to tag this consumer version as 'production'",
-					"href": `${BROKER_HOST}/pacticipants/consumer/versions/1.0.0/tags/prod`
-				},
-				"pb:tag-version": {
-					"title": "PUT to this resource to tag this consumer version",
-					"href": `${BROKER_HOST}/pacticipants/consumer/versions/1.0.0/tags/{tag}`
-				},
-				"pb:publish-verification-results": {
-					"title": "Publish verification results",
-					"href": `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/pact-version/7c36fc0ded24117ec189db3f54fadffc23a56d68/verification-results`
-				},
-				"curies": [{"name": "pb", "href": `${BROKER_HOST}/doc/{rel}`, "templated": true}]
-			}
-		});
-	}
+  function pactFunction(req: express.Request, res: express.Response) {
+    if (
+      _.isEmpty(req.body) ||
+      // 2. Is there a consumer, provider and version in the request?
+      _.isEmpty(req.params.consumer) ||
+      _.isEmpty(req.params.provider) ||
+      _.isEmpty(req.params.version)
+    ) {
+      return res.sendStatus(400);
+    }
+    return res.status(201).json({
+      consumer: { name: 'consumer' },
+      provider: { name: 'publisher' },
+      interactions: [
+        {
+          description: 'Greeting',
+          request: { method: 'GET', path: '/' },
+          response: { status: 200, headers: {}, body: { greeting: 'Hello' } },
+        },
+      ],
+      metadata: { pactSpecificationVersion: '2.0.0' },
+      createdAt: '2017-11-06T13:06:48+00:00',
+      _links: {
+        self: {
+          title: 'Pact',
+          name: 'Pact between consumer (v1.0.0) and publisher',
+          href: `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/version/1.0.0`,
+        },
+        'pb:consumer': {
+          title: 'Consumer',
+          name: 'consumer',
+          href: `${BROKER_HOST}/pacticipants/consumer`,
+        },
+        'pb:consumer-version': {
+          title: 'Consumer version',
+          name: '1.0.0',
+          href: `${BROKER_HOST}/pacticipants/consumer/versions/1.0.0`,
+        },
+        'pb:provider': {
+          title: 'Provider',
+          name: 'publisher',
+          href: `${BROKER_HOST}/pacticipants/publisher`,
+        },
+        'pb:latest-pact-version': {
+          title: 'Latest version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/latest`,
+        },
+        'pb:all-pact-versions': {
+          title: 'All version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/versions`,
+        },
+        'pb:latest-untagged-pact-version': {
+          title: 'Latest untagged version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/latest-untagged`,
+        },
+        'pb:latest-tagged-pact-version': {
+          title: 'Latest tagged version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/latest/{tag}`,
+          templated: true,
+        },
+        'pb:previous-distinct': {
+          title: 'Previous distinct version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/version/1.0.0/previous-distinct`,
+        },
+        'pb:diff-previous-distinct': {
+          title: 'Diff with previous distinct version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/version/1.0.0/diff/previous-distinct`,
+        },
+        'pb:pact-webhooks': {
+          title: 'Webhooks for the pact between consumer and publisher',
+          href: `${BROKER_HOST}/webhooks/provider/publisher/consumer/consumer`,
+        },
+        'pb:tag-prod-version': {
+          title:
+            "PUT to this resource to tag this consumer version as 'production'",
+          href: `${BROKER_HOST}/pacticipants/consumer/versions/1.0.0/tags/prod`,
+        },
+        'pb:tag-version': {
+          title: 'PUT to this resource to tag this consumer version',
+          href: `${BROKER_HOST}/pacticipants/consumer/versions/1.0.0/tags/{tag}`,
+        },
+        'pb:publish-verification-results': {
+          title: 'Publish verification results',
+          href: `${BROKER_HOST}/pacts/provider/publisher/consumer/consumer/pact-version/7c36fc0ded24117ec189db3f54fadffc23a56d68/verification-results`,
+        },
+        curies: [
+          { name: 'pb', href: `${BROKER_HOST}/doc/{rel}`, templated: true },
+        ],
+      },
+    });
+  }
 
-	function tagPactFunction(req: express.Request, res: express.Response) {
-		if (_.isEmpty(req.params.consumer) || _.isEmpty(req.params.version) || _.isEmpty(req.params.tag)) {
-			return res.sendStatus(400);
-		}
-		return res.sendStatus(201);
-	}
+  function tagPactFunction(req: express.Request, res: express.Response) {
+    if (
+      _.isEmpty(req.params.consumer) ||
+      _.isEmpty(req.params.version) ||
+      _.isEmpty(req.params.tag)
+    ) {
+      return res.sendStatus(400);
+    }
+    return res.sendStatus(201);
+  }
 
-	server.get("/somebrokenpact", returnJson({}));
+  server.get('/somebrokenpact', returnJson({}));
 
-	server.get("/somepact", returnJson({
-		"consumer": {
-			"name": "anotherclient"
-		},
-		"provider": {
-			"name": "they"
-		}
-	}));
+  server.get(
+    '/somepact',
+    returnJson({
+      consumer: {
+        name: 'anotherclient',
+      },
+      provider: {
+        name: 'they',
+      },
+    }),
+  );
 
-	// Pretend to be a Pact Broker (https://github.com/bethesque/pact_broker) for integration tests
-	server.put("/pacts/provider/:provider/consumer/:consumer/version/:version", pactFunction);
+  // Pretend to be a Pact Broker (https://github.com/bethesque/pact_broker) for integration tests
+  server.put(
+    '/pacts/provider/:provider/consumer/:consumer/version/:version',
+    pactFunction,
+  );
 
-	// Authenticated calls...
-	server.put("/auth/pacts/provider/:provider/consumer/:consumer/version/:version", auth, pactFunction);
+  // Authenticated calls...
+  server.put(
+    '/auth/pacts/provider/:provider/consumer/:consumer/version/:version',
+    auth,
+    pactFunction,
+  );
 
-	// Tagging
-	server.put("/pacticipant/:consumer/version/:version/tags/:tag", tagPactFunction);
-	server.put("/auth/pacticipant/:consumer/version/:version/tags/:tag", tagPactFunction);
+  // Tagging
+  server.put(
+    '/pacticipant/:consumer/version/:version/tags/:tag',
+    tagPactFunction,
+  );
+  server.put(
+    '/auth/pacticipant/:consumer/version/:version/tags/:tag',
+    tagPactFunction,
+  );
 
-	// Matrix
-	server.get("/matrix", (req: express.Request, res: express.Response) => {
-	if (req.query.q[0].pacticipant === "Foo") {
-		return res.json({
-			"summary": {
-			  "deployable": true,
-			  "reason": "some text",
-			  "unknown": 1
-			},
-			"matrix": [
-			  {
-				"consumer": {
-				  "name": "Foo",
-				  "version": {
-					"number": "4"
-				  }
-				},
-				"provider": {
-				  "name": "Bar",
-				  "version": {
-					"number": "5"
-				  }
-				},
-				"verificationResult": {
-				  "verifiedAt": "2017-10-10T12:49:04+11:00",
-				  "success": true
-				},
-				"pact": {
-				  "createdAt": "2017-10-10T12:49:04+11:00"
-				}
-			  }
-			]
-		  });
-	} else {
-		return res.json({
-			"summary": {
-			  "deployable": false,
-			  "reason": "some text",
-			  "unknown": 1
-			},
-			"matrix": [
-			  {
-				"consumer": {
-				  "name": "FooFail",
-				  "version": {
-					"number": "4"
-				  }
-				},
-				"provider": {
-				  "name": "Bar",
-				  "version": {
-					"number": "5"
-				  }
-				},
-				"verificationResult": {
-				  "verifiedAt": "2017-10-10T12:49:04+11:00",
-				  "success": false
-				},
-				"pact": {
-				  "createdAt": "2017-10-10T12:49:04+11:00"
-				}
-			  }
-			]
-		  });
-	}
-});
+  // Matrix
+  server.get('/matrix', (req: express.Request, res: express.Response) => {
+    if (req.query.q[0].pacticipant === 'Foo') {
+      return res.json({
+        summary: {
+          deployable: true,
+          reason: 'some text',
+          unknown: 1,
+        },
+        matrix: [
+          {
+            consumer: {
+              name: 'Foo',
+              version: {
+                number: '4',
+              },
+            },
+            provider: {
+              name: 'Bar',
+              version: {
+                number: '5',
+              },
+            },
+            verificationResult: {
+              verifiedAt: '2017-10-10T12:49:04+11:00',
+              success: true,
+            },
+            pact: {
+              createdAt: '2017-10-10T12:49:04+11:00',
+            },
+          },
+        ],
+      });
+    } else {
+      return res.json({
+        summary: {
+          deployable: false,
+          reason: 'some text',
+          unknown: 1,
+        },
+        matrix: [
+          {
+            consumer: {
+              name: 'FooFail',
+              version: {
+                number: '4',
+              },
+            },
+            provider: {
+              name: 'Bar',
+              version: {
+                number: '5',
+              },
+            },
+            verificationResult: {
+              verifiedAt: '2017-10-10T12:49:04+11:00',
+              success: false,
+            },
+            pact: {
+              createdAt: '2017-10-10T12:49:04+11:00',
+            },
+          },
+        ],
+      });
+    }
+  });
 
-	// Get root HAL links
-	server.get("/", returnJson({
-		"_links": {
-			"self": {
-				"href": BROKER_HOST,
-				"title": "Index",
-				"templated": false
-			},
-			"pb:publish-pact": {
-				"href": `${BROKER_HOST}/pacts/provider/{provider}/consumer/{consumer}/version/{consumerApplicationVersion}`,
-				"title": "Publish a pact",
-				"templated": true
-			},
-			"pb:latest-pact-versions": {
-				"href": `${BROKER_HOST}/pacts/latest`,
-				"title": "Latest pact version",
-				"templated": false
-			},
-			"pb:pacticipants": {
-				"href": `${BROKER_HOST}/pacticipants`,
-				"title": "Pacticipants",
-				"templated": false
-			},
-			"pb:latest-provider-pacts": {
-				"href": `${BROKER_HOST}/pacts/provider/{provider}/latest`,
-				"title": "Latest pacts by provider",
-				"templated": true
-			},
-			"pb:latest-provider-pacts-with-tag": {
-				"href": `${BROKER_HOST}/pacts/provider/{provider}/latest/{tag}`,
-				"title": "Latest pacts by provider with a specified tag",
-				"templated": true
-			},
-			"pb:webhooks": {
-				"href": `${BROKER_HOST}/webhooks`,
-				"title": "Webhooks",
-				"templated": false
-			},
-			"curies": [{
-				"name": "pb",
-				"href": `${BROKER_HOST}/doc/{rel}`,
-				"templated": true
-			}]
-		}
-	}));
+  // Get root HAL links
+  server.get(
+    '/',
+    returnJson({
+      _links: {
+        self: {
+          href: BROKER_HOST,
+          title: 'Index',
+          templated: false,
+        },
+        'pb:publish-pact': {
+          href: `${BROKER_HOST}/pacts/provider/{provider}/consumer/{consumer}/version/{consumerApplicationVersion}`,
+          title: 'Publish a pact',
+          templated: true,
+        },
+        'pb:latest-pact-versions': {
+          href: `${BROKER_HOST}/pacts/latest`,
+          title: 'Latest pact version',
+          templated: false,
+        },
+        'pb:pacticipants': {
+          href: `${BROKER_HOST}/pacticipants`,
+          title: 'Pacticipants',
+          templated: false,
+        },
+        'pb:latest-provider-pacts': {
+          href: `${BROKER_HOST}/pacts/provider/{provider}/latest`,
+          title: 'Latest pacts by provider',
+          templated: true,
+        },
+        'pb:latest-provider-pacts-with-tag': {
+          href: `${BROKER_HOST}/pacts/provider/{provider}/latest/{tag}`,
+          title: 'Latest pacts by provider with a specified tag',
+          templated: true,
+        },
+        'pb:webhooks': {
+          href: `${BROKER_HOST}/webhooks`,
+          title: 'Webhooks',
+          templated: false,
+        },
+        curies: [
+          {
+            name: 'pb',
+            href: `${BROKER_HOST}/doc/{rel}`,
+            templated: true,
+          },
+        ],
+      },
+    }),
+  );
 
-	// Get pacts by Provider "notfound"
-	server.get("/pacts/provider/notfound/latest", (req: express.Request, res: express.Response) => res.sendStatus(404));
+  // Get pacts by Provider "notfound"
+  server.get(
+    '/pacts/provider/notfound/latest',
+    (req: express.Request, res: express.Response) => res.sendStatus(404),
+  );
 
-	// Get pacts by Provider "nolinks"
-	server.get("/pacts/provider/nolinks/latest", returnJson({
-		"_links": {
-			"self": {
-				"href": `${BROKER_HOST}/pacts/provider/nolinks/latest/sit4`,
-				"title": "Latest pact version for the provider nolinks with tag \"sit4\""
-			},
-			"provider": {
-				"href": `${BROKER_HOST}/pacticipants/nolinks`,
-				"title": "bobby"
-			},
-			"pacts": []
-		}
-	}));
+  // Get pacts by Provider "nolinks"
+  server.get(
+    '/pacts/provider/nolinks/latest',
+    returnJson({
+      _links: {
+        self: {
+          href: `${BROKER_HOST}/pacts/provider/nolinks/latest/sit4`,
+          title: 'Latest pact version for the provider nolinks with tag "sit4"',
+        },
+        provider: {
+          href: `${BROKER_HOST}/pacticipants/nolinks`,
+          title: 'bobby',
+        },
+        pacts: [],
+      },
+    }),
+  );
 
-	// Get pacts by Provider (all)
-	server.get("/pacts/provider/:provider/latest", returnJson({
-		"_links": {
-			"self": {
-				"href": `${BROKER_HOST}/pacts/provider/bobby/latest/sit4`,
-				"title": "Latest pact version for the provider bobby with tag \"sit4\""
-			},
-			"provider": {
-				"href": `${BROKER_HOST}/pacticipants/bobby`,
-				"title": "bobby"
-			},
-			"pacts": [{
-				"href": `${BROKER_HOST}/pacts/provider/bobby/consumer/billy/version/1.0.0`,
-				"title": "Pact between billy (v1.0.0) and bobby",
-				"name": "billy"
-			}, {
-				"href": `${BROKER_HOST}/pacts/provider/bobby/consumer/someotherguy/version/1.0.0`,
-				"title": "Pact between someotherguy (v1.0.0) and bobby",
-				"name": "someotherguy"
-			}]
-		}
-	}));
+  // Get pacts by Provider (all)
+  server.get(
+    '/pacts/provider/:provider/latest',
+    returnJson({
+      _links: {
+        self: {
+          href: `${BROKER_HOST}/pacts/provider/bobby/latest/sit4`,
+          title: 'Latest pact version for the provider bobby with tag "sit4"',
+        },
+        provider: {
+          href: `${BROKER_HOST}/pacticipants/bobby`,
+          title: 'bobby',
+        },
+        pacts: [
+          {
+            href: `${BROKER_HOST}/pacts/provider/bobby/consumer/billy/version/1.0.0`,
+            title: 'Pact between billy (v1.0.0) and bobby',
+            name: 'billy',
+          },
+          {
+            href: `${BROKER_HOST}/pacts/provider/bobby/consumer/someotherguy/version/1.0.0`,
+            title: 'Pact between someotherguy (v1.0.0) and bobby',
+            name: 'someotherguy',
+          },
+        ],
+      },
+    }),
+  );
 
-	// Get pacts by Provider and Tag
-	server.get("/pacts/provider/:provider/latest/:tag", returnJson({
-		"_links": {
-			"self": {
-				"href": "https://test.pact.dius.com.au/pacts/provider/notfound/latest",
-				"title": "Latest pact version for the provider bobby"
-			},
-			"provider": {
-				"href": "https://test.pact.dius.com.au/pacticipant/bobby",
-				"title": "bobby"
-			},
-			"pacts": [{
-				"href": "https://test.pact.dius.com.au/pacts/provider/bobby/consumer/billy/version/1.0.0",
-				"title": "Pact between billy (v1.0.0) and bobby",
-				"name": "billy"
-			}, {
-				"href": "https://test.pact.dius.com.au/pacts/provider/bobby/consumer/someotherguy/version/1.0.0",
-				"title": "Pact between someotherguy (v1.0.0) and bobby",
-				"name": "someotherguy"
-			}]
-		}
-	}));
+  // Get pacts by Provider and Tag
+  server.get(
+    '/pacts/provider/:provider/latest/:tag',
+    returnJson({
+      _links: {
+        self: {
+          href: 'https://test.pact.dius.com.au/pacts/provider/notfound/latest',
+          title: 'Latest pact version for the provider bobby',
+        },
+        provider: {
+          href: 'https://test.pact.dius.com.au/pacticipant/bobby',
+          title: 'bobby',
+        },
+        pacts: [
+          {
+            href:
+              'https://test.pact.dius.com.au/pacts/provider/bobby/consumer/billy/version/1.0.0',
+            title: 'Pact between billy (v1.0.0) and bobby',
+            name: 'billy',
+          },
+          {
+            href:
+              'https://test.pact.dius.com.au/pacts/provider/bobby/consumer/someotherguy/version/1.0.0',
+            title: 'Pact between someotherguy (v1.0.0) and bobby',
+            name: 'someotherguy',
+          },
+        ],
+      },
+    }),
+  );
 
-	server.get("/noauth/pacts/provider/they/consumer/me/latest", returnJson({
-		"consumer": {
-			"name": "me"
-		},
-		"provider": {
-			"name": "they"
-		},
-		"interactions": [{
-			"description": "Provider state success",
-			"provider_state": "There is a greeting",
-			"request": {
-				"method": "GET",
-				"path": "/somestate"
-			},
-			"response": {
-				"status": 200,
-				"headers": {},
-				"body": {
-					"greeting": "State data!"
-				}
-			}
-		}],
-		"metadata": {
-			"pactSpecificationVersion": "2.0.0"
-		},
-		"updatedAt": "2016-05-15T00:09:33+00:00",
-		"createdAt": "2016-05-15T00:09:06+00:00",
-		"_links": {
-			"self": {
-				"title": "Pact",
-				"name": "Pact between me (v1.0.0) and they",
-				"href": `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0`
-			},
-			"pb:consumer": {
-				"title": "Consumer",
-				"name": "me",
-				"href": `${BROKER_HOST}/pacticipants/me`
-			},
-			"pb:provider": {
-				"title": "Provider",
-				"name": "they",
-				"href": `${BROKER_HOST}/pacticipants/they`
-			},
-			"pb:latest-pact-version": {
-				"title": "Pact",
-				"name": "Latest version of this pact",
-				"href": `${BROKER_HOST}/pacts/provider/they/consumer/me/latest`
-			},
-			"pb:previous-distinct": {
-				"title": "Pact",
-				"name": "Previous distinct version of this pact",
-				"href": `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct`
-			},
-			"pb:diff-previous-distinct": {
-				"title": "Diff",
-				"name": "Diff with previous distinct version of this pact",
-				"href": `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct`
-			},
-			"pb:pact-webhooks": {
-				"title": "Webhooks for the pact between me and they",
-				"href": `${BROKER_HOST}/webhooks/provider/they/consumer/me`
-			},
-			"pb:tag-prod-version": {
-				"title": "Tag this version as \"production\"",
-				"href": `${BROKER_HOST}/pacticipants/me/versions/1.0.0/tags/prod`
-			},
-			"pb:tag-version": {
-				"title": "Tag version",
-				"href": `${BROKER_HOST}/pacticipants/me/versions/1.0.0/tags/{tag}`
-			},
-			"curies": [{
-				"name": "pb",
-				"href": `${BROKER_HOST}/doc/{rel}`,
-				"templated": true
-			}]
-		}
-	}));
+  server.get(
+    '/noauth/pacts/provider/they/consumer/me/latest',
+    returnJson({
+      consumer: {
+        name: 'me',
+      },
+      provider: {
+        name: 'they',
+      },
+      interactions: [
+        {
+          description: 'Provider state success',
+          provider_state: 'There is a greeting',
+          request: {
+            method: 'GET',
+            path: '/somestate',
+          },
+          response: {
+            status: 200,
+            headers: {},
+            body: {
+              greeting: 'State data!',
+            },
+          },
+        },
+      ],
+      metadata: {
+        pactSpecificationVersion: '2.0.0',
+      },
+      updatedAt: '2016-05-15T00:09:33+00:00',
+      createdAt: '2016-05-15T00:09:06+00:00',
+      _links: {
+        self: {
+          title: 'Pact',
+          name: 'Pact between me (v1.0.0) and they',
+          href: `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0`,
+        },
+        'pb:consumer': {
+          title: 'Consumer',
+          name: 'me',
+          href: `${BROKER_HOST}/pacticipants/me`,
+        },
+        'pb:provider': {
+          title: 'Provider',
+          name: 'they',
+          href: `${BROKER_HOST}/pacticipants/they`,
+        },
+        'pb:latest-pact-version': {
+          title: 'Pact',
+          name: 'Latest version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/they/consumer/me/latest`,
+        },
+        'pb:previous-distinct': {
+          title: 'Pact',
+          name: 'Previous distinct version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct`,
+        },
+        'pb:diff-previous-distinct': {
+          title: 'Diff',
+          name: 'Diff with previous distinct version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct`,
+        },
+        'pb:pact-webhooks': {
+          title: 'Webhooks for the pact between me and they',
+          href: `${BROKER_HOST}/webhooks/provider/they/consumer/me`,
+        },
+        'pb:tag-prod-version': {
+          title: 'Tag this version as "production"',
+          href: `${BROKER_HOST}/pacticipants/me/versions/1.0.0/tags/prod`,
+        },
+        'pb:tag-version': {
+          title: 'Tag version',
+          href: `${BROKER_HOST}/pacticipants/me/versions/1.0.0/tags/{tag}`,
+        },
+        curies: [
+          {
+            name: 'pb',
+            href: `${BROKER_HOST}/doc/{rel}`,
+            templated: true,
+          },
+        ],
+      },
+    }),
+  );
 
-	server.get("/noauth/pacts/provider/they/consumer/anotherclient/latest", returnJson({
-		"consumer": {
-			"name": "anotherclient"
-		},
-		"provider": {
-			"name": "they"
-		},
-		"interactions": [{
-			"description": "Provider state success",
-			"provider_state": "There is a greeting",
-			"request": {
-				"method": "GET",
-				"path": "/somestate"
-			},
-			"response": {
-				"status": 200,
-				"headers": {},
-				"body": {
-					"greeting": "State data!"
-				}
-			}
-		}],
-		"metadata": {
-			"pactSpecificationVersion": "2.0.0"
-		},
-		"updatedAt": "2016-05-15T00:09:33+00:00",
-		"createdAt": "2016-05-15T00:09:06+00:00",
-		"_links": {
-			"self": {
-				"title": "Pact",
-				"name": "Pact between me (v1.0.0) and they",
-				"href": `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0`
-			},
-			"pb:consumer": {
-				"title": "Consumer",
-				"name": "anotherclient",
-				"href": `${BROKER_HOST}/pacticipants/me`
-			},
-			"pb:provider": {
-				"title": "Provider",
-				"name": "they",
-				"href": `${BROKER_HOST}/pacticipants/they`
-			},
-			"pb:latest-pact-version": {
-				"title": "Pact",
-				"name": "Latest version of this pact",
-				"href": `${BROKER_HOST}/pacts/provider/they/consumer/me/latest`
-			},
-			"pb:previous-distinct": {
-				"title": "Pact",
-				"name": "Previous distinct version of this pact",
-				"href": `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct`
-			},
-			"pb:diff-previous-distinct": {
-				"title": "Diff",
-				"name": "Diff with previous distinct version of this pact",
-				"href": `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct`
-			},
-			"pb:pact-webhooks": {
-				"title": "Webhooks for the pact between me and they",
-				"href": `${BROKER_HOST}/webhooks/provider/they/consumer/me`
-			},
-			"pb:tag-prod-version": {
-				"title": "Tag this version as \"production\"",
-				"href": `${BROKER_HOST}/pacticipants/me/versions/1.0.0/tags/prod`
-			},
-			"pb:tag-version": {
-				"title": "Tag version",
-				"href": `${BROKER_HOST}/pacticipants/me/versions/1.0.0/tags/{tag}`
-			},
-			"curies": [{
-				"name": "pb",
-				"href": `${BROKER_HOST}/doc/{rel}`,
-				"templated": true
-			}]
-		}
-	}));
+  server.get(
+    '/noauth/pacts/provider/they/consumer/anotherclient/latest',
+    returnJson({
+      consumer: {
+        name: 'anotherclient',
+      },
+      provider: {
+        name: 'they',
+      },
+      interactions: [
+        {
+          description: 'Provider state success',
+          provider_state: 'There is a greeting',
+          request: {
+            method: 'GET',
+            path: '/somestate',
+          },
+          response: {
+            status: 200,
+            headers: {},
+            body: {
+              greeting: 'State data!',
+            },
+          },
+        },
+      ],
+      metadata: {
+        pactSpecificationVersion: '2.0.0',
+      },
+      updatedAt: '2016-05-15T00:09:33+00:00',
+      createdAt: '2016-05-15T00:09:06+00:00',
+      _links: {
+        self: {
+          title: 'Pact',
+          name: 'Pact between me (v1.0.0) and they',
+          href: `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0`,
+        },
+        'pb:consumer': {
+          title: 'Consumer',
+          name: 'anotherclient',
+          href: `${BROKER_HOST}/pacticipants/me`,
+        },
+        'pb:provider': {
+          title: 'Provider',
+          name: 'they',
+          href: `${BROKER_HOST}/pacticipants/they`,
+        },
+        'pb:latest-pact-version': {
+          title: 'Pact',
+          name: 'Latest version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/they/consumer/me/latest`,
+        },
+        'pb:previous-distinct': {
+          title: 'Pact',
+          name: 'Previous distinct version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0/previous-distinct`,
+        },
+        'pb:diff-previous-distinct': {
+          title: 'Diff',
+          name: 'Diff with previous distinct version of this pact',
+          href: `${BROKER_HOST}/pacts/provider/they/consumer/me/version/1.0.0/diff/previous-distinct`,
+        },
+        'pb:pact-webhooks': {
+          title: 'Webhooks for the pact between me and they',
+          href: `${BROKER_HOST}/webhooks/provider/they/consumer/me`,
+        },
+        'pb:tag-prod-version': {
+          title: 'Tag this version as "production"',
+          href: `${BROKER_HOST}/pacticipants/me/versions/1.0.0/tags/prod`,
+        },
+        'pb:tag-version': {
+          title: 'Tag version',
+          href: `${BROKER_HOST}/pacticipants/me/versions/1.0.0/tags/{tag}`,
+        },
+        curies: [
+          {
+            name: 'pb',
+            href: `${BROKER_HOST}/doc/{rel}`,
+            templated: true,
+          },
+        ],
+      },
+    }),
+  );
 
-	const deferred = q.defer<http.Server>();
-	let s = server.listen(port, () => deferred.resolve());
-	return deferred.promise.then(() => s);
+  const deferred = q.defer<http.Server>();
+  let s = server.listen(port, () => deferred.resolve());
+  return deferred.promise.then(() => s);
 };

--- a/test/integration/data-utils.ts
+++ b/test/integration/data-utils.ts
@@ -1,20 +1,30 @@
-import express = require("express");
-const basicAuth = require("basic-auth");
+import express = require('express');
+const basicAuth = require('basic-auth');
 
-export function returnJsonFile(filename: string): (req: express.Request, res: express.Response) => express.Response {
-	return returnJson(require(filename));
+export function returnJsonFile(
+  filename: string,
+): (req: express.Request, res: express.Response) => express.Response {
+  return returnJson(require(filename));
 }
 
-export function returnJson(json: any): (req: express.Request, res: express.Response) => express.Response {
-	return (req, res) => res.json(json);
+export function returnJson(
+  json: any,
+): (req: express.Request, res: express.Response) => express.Response {
+  return (req, res) => res.json(json);
 }
 
-export function auth(req: express.Request, res: express.Response, next: express.NextFunction): express.Response {
-	const user = basicAuth(req);
-	if (user && user.name === "foo" && user.pass === "bar") {
-		next();
-	} else {
-		res.set("WWW-Authenticate", "Basic realm=Authorization Required").sendStatus(401);
-	}
-	return res;
+export function auth(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): express.Response {
+  const user = basicAuth(req);
+  if (user && user.name === 'foo' && user.pass === 'bar') {
+    next();
+  } else {
+    res
+      .set('WWW-Authenticate', 'Basic realm=Authorization Required')
+      .sendStatus(401);
+  }
+  return res;
 }

--- a/test/integration/provider-mock.ts
+++ b/test/integration/provider-mock.ts
@@ -1,73 +1,111 @@
-import express = require("express");
-import q = require("q");
-import * as http from "http";
-import {returnJson, returnJsonFile, auth} from "./data-utils";
-const cors = require("cors");
-const bodyParser = require("body-parser");
+import express = require('express');
+import q = require('q');
+import * as http from 'http';
+import { returnJson, returnJsonFile, auth } from './data-utils';
+const cors = require('cors');
+const bodyParser = require('body-parser');
 
 export default (port: number): q.Promise<http.Server> => {
-	const server: express.Express = express();
-	server.use(cors());
-	server.use(bodyParser.json());
-	server.use(bodyParser.urlencoded({
-		extended: true
-	}));
+  const server: express.Express = express();
+  server.use(cors());
+  server.use(bodyParser.json());
+  server.use(
+    bodyParser.urlencoded({
+      extended: true,
+    }),
+  );
 
-	let stateData = "";
+  let stateData = '';
 
-	server.get("/", returnJson({greeting: "Hello"}));
+  server.get('/', returnJson({ greeting: 'Hello' }));
 
-	server.get("/fail", returnJson({greeting: "Oh noes!"}));
+  server.get('/fail', returnJson({ greeting: 'Oh noes!' }));
 
-	server.get("/provider-states", returnJson({me: ["There is a greeting"], anotherclient: ["There is a greeting"]}));
+  server.get(
+    '/provider-states',
+    returnJson({
+      me: ['There is a greeting'],
+      anotherclient: ['There is a greeting'],
+    }),
+  );
 
-	server.post("/provider-state", (req: express.Request, res: express.Response) => {
-		stateData = "State data!";
-		return res.json({
-			greeting: stateData
-		});
-	});
+  server.post(
+    '/provider-state',
+    (req: express.Request, res: express.Response) => {
+      stateData = 'State data!';
+      return res.json({
+        greeting: stateData,
+      });
+    },
+  );
 
-	server.get("/somestate", (req: express.Request, res: express.Response) => {
-		return res.json({
-			greeting: stateData
-		});
-	});
+  server.get('/somestate', (req: express.Request, res: express.Response) => {
+    return res.json({
+      greeting: stateData,
+    });
+  });
 
-	server.post("/", (req: express.Request, res: express.Response) => {
-		return res.json({
-			greeting: `Hello ${req.body.name}`
-		});
-	});
+  server.post('/', (req: express.Request, res: express.Response) => {
+    return res.json({
+      greeting: `Hello ${req.body.name}`,
+    });
+  });
 
-	server.get("/contract/:name", (req: express.Request, res: express.Response) => {
-		const fileName = req.params.name;
-		res.sendFile(fileName, {
-			root: __dirname,
-			dotfiles: "deny",
-			headers: {
-				"x-timestamp": Date.now(),
-				"x-sent": true
-			}
-		}, (err) => {
-			if (err) {
-				console.log(err);
-				res.status(500).end();
-			} else {
-				console.log("Sent:", fileName);
-			}
-		});
-	});
+  server.get(
+    '/contract/:name',
+    (req: express.Request, res: express.Response) => {
+      const fileName = req.params.name;
+      res.sendFile(
+        fileName,
+        {
+          root: __dirname,
+          dotfiles: 'deny',
+          headers: {
+            'x-timestamp': Date.now(),
+            'x-sent': true,
+          },
+        },
+        err => {
+          if (err) {
+            console.log(err);
+            res.status(500).end();
+          } else {
+            console.log('Sent:', fileName);
+          }
+        },
+      );
+    },
+  );
 
-	// Verification result
-	server.post("/pacts/provider/:provider/consumer/:consumer/pact-version/:version/verification-results",
-		returnJsonFile("./data/get-provider_they-consumer_me-latest.json"));
-	server.get("/pacts/provider/they/consumer/me/latest", auth, returnJsonFile("./data/get-provider_they-consumer_me-latest.json"));
-	server.get("/pacts/provider/they/consumer/anotherclient/latest", auth, returnJsonFile("./data/get-provider_they-consumer_anotherclient-latest.json"));
-	server.get("/noauth/pacts/provider/they/consumer/me/latest", returnJsonFile("./data/get-noauth-provider_they-consumer_me-latest.json"));
-	server.get("/noauth/pacts/provider/they/consumer/anotherclient/latest", returnJsonFile("./data/get-noauth-provider_they-consumer_anotherclient-latest.json"));
+  // Verification result
+  server.post(
+    '/pacts/provider/:provider/consumer/:consumer/pact-version/:version/verification-results',
+    returnJsonFile('./data/get-provider_they-consumer_me-latest.json'),
+  );
+  server.get(
+    '/pacts/provider/they/consumer/me/latest',
+    auth,
+    returnJsonFile('./data/get-provider_they-consumer_me-latest.json'),
+  );
+  server.get(
+    '/pacts/provider/they/consumer/anotherclient/latest',
+    auth,
+    returnJsonFile(
+      './data/get-provider_they-consumer_anotherclient-latest.json',
+    ),
+  );
+  server.get(
+    '/noauth/pacts/provider/they/consumer/me/latest',
+    returnJsonFile('./data/get-noauth-provider_they-consumer_me-latest.json'),
+  );
+  server.get(
+    '/noauth/pacts/provider/they/consumer/anotherclient/latest',
+    returnJsonFile(
+      './data/get-noauth-provider_they-consumer_anotherclient-latest.json',
+    ),
+  );
 
-	const deferred = q.defer<http.Server>();
-	let s = server.listen(port, () => deferred.resolve());
-	return deferred.promise.then(() => s);
+  const deferred = q.defer<http.Server>();
+  let s = server.listen(port, () => deferred.resolve());
+  return deferred.promise.then(() => s);
 };

--- a/test/message.integration.spec.ts
+++ b/test/message.integration.spec.ts
@@ -1,43 +1,46 @@
-import chai = require("chai");
-import chaiAsPromised = require("chai-as-promised");
-import fs = require("fs");
-import messageFactory from "../src/message";
-import path = require("path");
-import logger from "../src/logger";
+import chai = require('chai');
+import chaiAsPromised = require('chai-as-promised');
+import fs = require('fs');
+import messageFactory from '../src/message';
+import path = require('path');
+import logger from '../src/logger';
 chai.use(chaiAsPromised);
 
-const rimraf = require("rimraf");
+const rimraf = require('rimraf');
 const expect = chai.expect;
 
-describe("Message Integration Spec", () => {
-	const pactDir = (process && process.mainModule) ? `${path.dirname(process.mainModule.filename)}/pacts` : "/tmp/pacts";
-	const contractFile = `${pactDir}/consumer-provider.json`;
+describe('Message Integration Spec', () => {
+  const pactDir =
+    process && process.mainModule
+      ? `${path.dirname(process.mainModule.filename)}/pacts`
+      : '/tmp/pacts';
+  const contractFile = `${pactDir}/consumer-provider.json`;
 
-	const validJSON = `{ "description": "a test mesage", "content": { "name": "Mary" } }`;
+  const validJSON = `{ "description": "a test mesage", "content": { "name": "Mary" } }`;
 
-	context("when given a successful contract", () => {
-		before(() => {
-			try {
-				if (fs.statSync(contractFile)) {
-					rimraf(pactDir, () => logger.debug("removed existing pacts"));
-				}
-			} catch (e) {}
-		});
+  context('when given a successful contract', () => {
+    before(() => {
+      try {
+        if (fs.statSync(contractFile)) {
+          rimraf(pactDir, () => logger.debug('removed existing pacts'));
+        }
+      } catch (e) {}
+    });
 
-		it("should return a successful promise", (done) => {
-			const message = messageFactory({
-				consumer: "consumer",
-				provider: "provider",
-				dir: `${pactDir}`,
-				content: validJSON
-			});
+    it('should return a successful promise', done => {
+      const message = messageFactory({
+        consumer: 'consumer',
+        provider: 'provider',
+        dir: `${pactDir}`,
+        content: validJSON,
+      });
 
-			const promise = message.createMessage();
+      const promise = message.createMessage();
 
-			promise.then(() => {
-				expect(fs.statSync(contractFile).isFile()).to.eql(true);
-				done();
-			});
-		});
-	});
+      promise.then(() => {
+        expect(fs.statSync(contractFile).isFile()).to.eql(true);
+        done();
+      });
+    });
+  });
 });

--- a/test/publisher.integration.spec.ts
+++ b/test/publisher.integration.spec.ts
@@ -1,146 +1,178 @@
-import path = require("path");
-import chai = require("chai");
-import logger from "../src/logger";
-import chaiAsPromised = require("chai-as-promised");
-import publisherFactory from "../src/publisher";
-import brokerMock from "./integration/broker-mock";
-import * as http from "http";
+import path = require('path');
+import chai = require('chai');
+import logger from '../src/logger';
+import chaiAsPromised = require('chai-as-promised');
+import publisherFactory from '../src/publisher';
+import brokerMock from './integration/broker-mock';
+import * as http from 'http';
 
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
-describe("Publish Spec", () => {
-	let server: http.Server;
-	const PORT = Math.floor(Math.random() * 999) + 9000;
-	const pactBrokerBaseUrl = `http://localhost:${PORT}`;
-	const authenticatedPactBrokerBaseUrl = `${pactBrokerBaseUrl}/auth`;
+describe('Publish Spec', () => {
+  let server: http.Server;
+  const PORT = Math.floor(Math.random() * 999) + 9000;
+  const pactBrokerBaseUrl = `http://localhost:${PORT}`;
+  const authenticatedPactBrokerBaseUrl = `${pactBrokerBaseUrl}/auth`;
 
-	before(() => brokerMock(PORT).then((s) => {
-		logger.debug(`Pact Broker Mock listening on port: ${PORT}`);
-		server = s;
-	}));
+  before(() =>
+    brokerMock(PORT).then(s => {
+      logger.debug(`Pact Broker Mock listening on port: ${PORT}`);
+      server = s;
+    }),
+  );
 
-	after(() => server.close());
+  after(() => server.close());
 
-	context("when publishing a to a broker", () => {
-		context("without authentication", () => {
-			context("and the Pact contract is valid", () => {
-				it("should successfully publish all Pacts", () => {
-					const publisher = publisherFactory({
-						pactBroker: pactBrokerBaseUrl,
-						pactFilesOrDirs: [path.resolve(__dirname, "integration/publish/publish-success.json")],
-						consumerVersion: "1.0.0"
-					});
+  context('when publishing a to a broker', () => {
+    context('without authentication', () => {
+      context('and the Pact contract is valid', () => {
+        it('should successfully publish all Pacts', () => {
+          const publisher = publisherFactory({
+            pactBroker: pactBrokerBaseUrl,
+            pactFilesOrDirs: [
+              path.resolve(
+                __dirname,
+                'integration/publish/publish-success.json',
+              ),
+            ],
+            consumerVersion: '1.0.0',
+          });
 
-					expect(publisher).to.be.a("object");
-					expect(publisher).to.respondTo("publish");
-					return expect(publisher.publish()).to.eventually.be.fulfilled;
-				});
+          expect(publisher).to.be.a('object');
+          expect(publisher).to.respondTo('publish');
+          return expect(publisher.publish()).to.eventually.be.fulfilled;
+        });
 
-				it("should successfully tag all Pacts with `test` and `latest`", () => {
-					const publisher = publisherFactory({
-						pactBroker: pactBrokerBaseUrl,
-						pactFilesOrDirs: [path.resolve(__dirname, "integration/publish/publish-success.json")],
-						consumerVersion: "1.0.0",
-						tags: ["test", "latest"]
-					});
+        it('should successfully tag all Pacts with `test` and `latest`', () => {
+          const publisher = publisherFactory({
+            pactBroker: pactBrokerBaseUrl,
+            pactFilesOrDirs: [
+              path.resolve(
+                __dirname,
+                'integration/publish/publish-success.json',
+              ),
+            ],
+            consumerVersion: '1.0.0',
+            tags: ['test', 'latest'],
+          });
 
-					expect(publisher).to.be.a("object");
-					expect(publisher).to.respondTo("publish");
-					return expect(publisher.publish()).to.eventually.be.fulfilled;
-				});
-			});
-			context("and the Pact contract is invalid", () => {
-				it("should report an unsuccessful push", () => {
-					const publisher = publisherFactory({
-						pactBroker: pactBrokerBaseUrl,
-						pactFilesOrDirs: [path.resolve(__dirname, "integration/publish/publish-fail.json")],
-						consumerVersion: "1.0.0"
-					});
+          expect(publisher).to.be.a('object');
+          expect(publisher).to.respondTo('publish');
+          return expect(publisher.publish()).to.eventually.be.fulfilled;
+        });
+      });
+      context('and the Pact contract is invalid', () => {
+        it('should report an unsuccessful push', () => {
+          const publisher = publisherFactory({
+            pactBroker: pactBrokerBaseUrl,
+            pactFilesOrDirs: [
+              path.resolve(__dirname, 'integration/publish/publish-fail.json'),
+            ],
+            consumerVersion: '1.0.0',
+          });
 
-					expect(publisher).to.be.a("object");
-					expect(publisher).to.respondTo("publish");
-					return expect(publisher.publish()).to.eventually.be.rejected;
-				});
-			});
-		});
+          expect(publisher).to.be.a('object');
+          expect(publisher).to.respondTo('publish');
+          return expect(publisher.publish()).to.eventually.be.rejected;
+        });
+      });
+    });
 
-		context("with authentication", () => {
-			context("and valid credentials", () => {
-				it("should return a sucessful promise", () => {
-					const publisher = publisherFactory({
-						pactBroker: authenticatedPactBrokerBaseUrl,
-						pactFilesOrDirs: [path.resolve(__dirname, "integration/publish/publish-success.json")],
-						consumerVersion: "1.0.0",
-						pactBrokerUsername: "foo",
-						pactBrokerPassword: "bar"
-					});
+    context('with authentication', () => {
+      context('and valid credentials', () => {
+        it('should return a sucessful promise', () => {
+          const publisher = publisherFactory({
+            pactBroker: authenticatedPactBrokerBaseUrl,
+            pactFilesOrDirs: [
+              path.resolve(
+                __dirname,
+                'integration/publish/publish-success.json',
+              ),
+            ],
+            consumerVersion: '1.0.0',
+            pactBrokerUsername: 'foo',
+            pactBrokerPassword: 'bar',
+          });
 
-					expect(publisher).to.be.a("object");
-					expect(publisher).to.respondTo("publish");
-					return expect(publisher.publish()).to.eventually.be.fulfilled;
-				});
-			});
+          expect(publisher).to.be.a('object');
+          expect(publisher).to.respondTo('publish');
+          return expect(publisher.publish()).to.eventually.be.fulfilled;
+        });
+      });
 
-			context("and invalid credentials", () => {
-				it("should return a rejected promise", () => {
-					const publisher = publisherFactory({
-						pactBroker: authenticatedPactBrokerBaseUrl,
-						pactFilesOrDirs: [path.resolve(__dirname, "integration/publish/publish-success.json")],
-						consumerVersion: "1.0.0",
-						pactBrokerUsername: "not",
-						pactBrokerPassword: "right"
-					});
+      context('and invalid credentials', () => {
+        it('should return a rejected promise', () => {
+          const publisher = publisherFactory({
+            pactBroker: authenticatedPactBrokerBaseUrl,
+            pactFilesOrDirs: [
+              path.resolve(
+                __dirname,
+                'integration/publish/publish-success.json',
+              ),
+            ],
+            consumerVersion: '1.0.0',
+            pactBrokerUsername: 'not',
+            pactBrokerPassword: 'right',
+          });
 
-					expect(publisher).to.be.a("object");
-					expect(publisher).to.respondTo("publish");
-					return expect(publisher.publish()).to.eventually.be.rejected;
-				});
-			});
-		});
+          expect(publisher).to.be.a('object');
+          expect(publisher).to.respondTo('publish');
+          return expect(publisher.publish()).to.eventually.be.rejected;
+        });
+      });
+    });
+  });
 
-	});
+  context('when publishing a directory of Pacts to a Broker', () => {
+    context('and the directory contains only valid Pact contracts', () => {
+      it('should asynchronously send all Pacts to the Broker', () => {
+        const publisher = publisherFactory({
+          pactBroker: pactBrokerBaseUrl,
+          pactFilesOrDirs: [
+            path.resolve(__dirname, 'integration/publish/pactDirTests'),
+          ],
+          consumerVersion: '1.0.0',
+        });
 
-	context("when publishing a directory of Pacts to a Broker", () => {
-		context("and the directory contains only valid Pact contracts", () => {
-			it("should asynchronously send all Pacts to the Broker", () => {
-				const publisher = publisherFactory({
-					pactBroker: pactBrokerBaseUrl,
-					pactFilesOrDirs: [path.resolve(__dirname, "integration/publish/pactDirTests")],
-					consumerVersion: "1.0.0"
-				});
+        expect(publisher).to.be.a('object');
+        expect(publisher).to.respondTo('publish');
+        return expect(publisher.publish()).to.eventually.be.fulfilled;
+      });
 
-				expect(publisher).to.be.a("object");
-				expect(publisher).to.respondTo("publish");
-				return expect(publisher.publish()).to.eventually.be.fulfilled;
-			});
+      it('should successfully tag all Pacts sent with `test` and `latest`', () => {
+        const publisher = publisherFactory({
+          pactBroker: pactBrokerBaseUrl,
+          pactFilesOrDirs: [
+            path.resolve(__dirname, 'integration/publish/pactDirTests'),
+          ],
+          consumerVersion: '1.0.0',
+          tags: ['test', 'latest'],
+        });
 
-			it("should successfully tag all Pacts sent with `test` and `latest`", () => {
-				const publisher = publisherFactory({
-					pactBroker: pactBrokerBaseUrl,
-					pactFilesOrDirs: [path.resolve(__dirname, "integration/publish/pactDirTests")],
-					consumerVersion: "1.0.0",
-					tags: ["test", "latest"]
-				});
+        expect(publisher).to.be.a('object');
+        expect(publisher).to.respondTo('publish');
+        return expect(publisher.publish()).to.eventually.be.fulfilled;
+      });
+    });
 
-				expect(publisher).to.be.a("object");
-				expect(publisher).to.respondTo("publish");
-				return expect(publisher.publish()).to.eventually.be.fulfilled;
-			});
-		});
+    context('and the directory contains Pact and non-Pact contracts', () => {
+      it('should asynchronously send only the Pact contracts to the broker', () => {
+        const publisher = publisherFactory({
+          pactBroker: pactBrokerBaseUrl,
+          pactFilesOrDirs: [
+            path.resolve(
+              __dirname,
+              'integration/publish/pactDirTestsWithOtherStuff',
+            ),
+          ],
+          consumerVersion: '1.0.0',
+        });
 
-		context("and the directory contains Pact and non-Pact contracts", () => {
-			it("should asynchronously send only the Pact contracts to the broker", () => {
-				const publisher = publisherFactory({
-					pactBroker: pactBrokerBaseUrl,
-					pactFilesOrDirs: [path.resolve(__dirname, "integration/publish/pactDirTestsWithOtherStuff")],
-					consumerVersion: "1.0.0"
-				});
-
-				expect(publisher).to.be.a("object");
-				expect(publisher).to.respondTo("publish");
-				return expect(publisher.publish()).to.eventually.be.fulfilled;
-			});
-		});
-	});
+        expect(publisher).to.be.a('object');
+        expect(publisher).to.respondTo('publish');
+        return expect(publisher.publish()).to.eventually.be.fulfilled;
+      });
+    });
+  });
 });

--- a/test/verifier.integration.spec.ts
+++ b/test/verifier.integration.spec.ts
@@ -1,234 +1,272 @@
-import verifierFactory from "../src/verifier";
-import chai = require("chai");
-import path = require("path");
-import chaiAsPromised = require("chai-as-promised");
-import providerMock from "./integration/provider-mock";
-import * as http from "http";
+import verifierFactory from '../src/verifier';
+import chai = require('chai');
+import path = require('path');
+import chaiAsPromised = require('chai-as-promised');
+import providerMock from './integration/provider-mock';
+import * as http from 'http';
 
 const expect = chai.expect;
 chai.use(chaiAsPromised);
 
-describe("Verifier Integration Spec", () => {
+describe('Verifier Integration Spec', () => {
+  let server: http.Server;
+  const PORT = 9123;
+  const providerBaseUrl = `http://localhost:${PORT}`;
+  const providerStatesSetupUrl = `${providerBaseUrl}/provider-state`;
+  const pactBrokerBaseUrl = `http://localhost:${PORT}`;
+  const monkeypatchFile: string = path.resolve(__dirname, 'monkeypatch.rb');
 
-	let server: http.Server;
-	const PORT = 9123;
-	const providerBaseUrl = `http://localhost:${PORT}`;
-	const providerStatesSetupUrl = `${providerBaseUrl}/provider-state`;
-	const pactBrokerBaseUrl = `http://localhost:${PORT}`;
-	const monkeypatchFile: string = path.resolve(__dirname, "monkeypatch.rb");
+  before(() =>
+    providerMock(PORT).then(s => {
+      console.log(`Pact Broker Mock listening on port: ${PORT}`);
+      server = s;
+    }),
+  );
 
-	before(() => providerMock(PORT).then((s) => {
-		console.log(`Pact Broker Mock listening on port: ${PORT}`);
-		server = s;
-	}));
+  after(() => server.close());
 
-	after(() => server.close());
+  context('when given a successful contract', () => {
+    context('with spaces in the file path', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl: providerBaseUrl,
+            pactUrls: [
+              path.resolve(
+                __dirname,
+                'integration/me-they-weird path-success.json',
+              ),
+            ],
+          }).verify(),
+        ).to.eventually.be.fulfilled);
+    });
 
-	context("when given a successful contract", () => {
-		context("with spaces in the file path", () => {
-			it("should return a successful promise", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/me-they-weird path-success.json")]
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
+    context('without provider states', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl: providerBaseUrl,
+            pactUrls: [
+              path.resolve(__dirname, 'integration/me-they-success.json'),
+            ],
+          }).verify(),
+        ).to.eventually.be.fulfilled);
+    });
 
-		context("without provider states", () => {
-			it("should return a successful promise", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/me-they-success.json")]
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
+    context('with Provider States', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl: providerBaseUrl,
+            pactUrls: [
+              path.resolve(__dirname, 'integration/me-they-states.json'),
+            ],
+            providerStatesSetupUrl: providerStatesSetupUrl,
+          }).verify(),
+        ).to.eventually.be.fulfilled);
+    });
 
-		context("with Provider States", () => {
-			it("should return a successful promise", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/me-they-states.json")],
-						providerStatesSetupUrl: providerStatesSetupUrl
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
+    context('with POST data', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl: providerBaseUrl,
+            pactUrls: [
+              path.resolve(__dirname, 'integration/me-they-post-success.json'),
+            ],
+          }).verify(),
+        ).to.eventually.be.fulfilled);
+    });
 
-		context("with POST data", () => {
-			it("should return a successful promise", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/me-they-post-success.json")]
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
+    context('with POST data and regex validation', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl: providerBaseUrl,
+            pactUrls: [
+              path.resolve(
+                __dirname,
+                'integration/me-they-post-regex-success.json',
+              ),
+            ],
+          }).verify(),
+        ).to.eventually.be.fulfilled);
+    });
 
-		context("with POST data and regex validation", () => {
-			it("should return a successful promise", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/me-they-post-regex-success.json")]
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
+    context('with monkeypatch file specified', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl: providerBaseUrl,
+            pactUrls: [
+              path.resolve(__dirname, 'integration/me-they-success.json'),
+            ],
+            monkeypatch: monkeypatchFile,
+          }).verify(),
+        ).to.eventually.be.fulfilled);
+    });
+  });
 
-		context("with monkeypatch file specified", () => {
-			it("should return a successful promise", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/me-they-success.json")],
-						monkeypatch: monkeypatchFile
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
-	});
+  context('when given a failing contract', () => {
+    it('should return a rejected promise', () =>
+      expect(
+        verifierFactory({
+          providerBaseUrl: providerBaseUrl,
+          pactUrls: [path.resolve(__dirname, 'integration/me-they-fail.json')],
+        }).verify(),
+      ).to.eventually.be.rejected);
+  });
 
-	context("when given a failing contract", () => {
-		it("should return a rejected promise", () =>
-			expect(
-				verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/me-they-fail.json")]
-				}).verify()
-			).to.eventually.be.rejected
-		);
-	});
+  context('when given multiple successful API calls in a contract', () => {
+    it('should return a successful promise', () =>
+      expect(
+        verifierFactory({
+          providerBaseUrl: providerBaseUrl,
+          pactUrls: [path.resolve(__dirname, 'integration/me-they-multi.json')],
+          providerStatesSetupUrl: providerStatesSetupUrl,
+        }).verify(),
+      ).to.eventually.be.fulfilled);
+  });
 
-	context("when given multiple successful API calls in a contract", () => {
-		it("should return a successful promise", () =>
-			expect(
-				verifierFactory({
-					providerBaseUrl: providerBaseUrl,
-					pactUrls: [path.resolve(__dirname, "integration/me-they-multi.json")],
-					providerStatesSetupUrl: providerStatesSetupUrl
-				}).verify()
-			).to.eventually.be.fulfilled
-		);
-	});
+  context('when given multiple contracts', () => {
+    context('from a local file', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl: providerBaseUrl,
+            pactUrls: [
+              path.resolve(__dirname, 'integration/me-they-success.json'),
+              path.resolve(__dirname, 'integration/me-they-multi.json'),
+            ],
+            providerStatesSetupUrl: providerStatesSetupUrl,
+          }).verify(),
+        ).to.eventually.be.fulfilled);
+    });
 
-	context("when given multiple contracts", () => {
-		context("from a local file", () => {
-			it("should return a successful promise", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/me-they-success.json"), path.resolve(__dirname, "integration/me-they-multi.json")],
-						providerStatesSetupUrl: providerStatesSetupUrl
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
+    context('from a Pact Broker', () => {
+      context('without authentication', () => {
+        it('should return a successful promise', () =>
+          expect(
+            verifierFactory({
+              providerBaseUrl: providerBaseUrl,
+              pactUrls: [
+                `${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/me/latest`,
+                `${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/anotherclient/latest`,
+              ],
+              providerStatesSetupUrl: providerStatesSetupUrl,
+            }).verify(),
+          ).to.eventually.be.fulfilled);
+      });
 
-		context("from a Pact Broker", () => {
-			context("without authentication", () => {
-				it("should return a successful promise", () =>
-					expect(
-						verifierFactory({
-							providerBaseUrl: providerBaseUrl,
-							pactUrls: [`${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/me/latest`,
-								`${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/anotherclient/latest`],
-							providerStatesSetupUrl: providerStatesSetupUrl
-						}).verify()
-					).to.eventually.be.fulfilled
-				);
-			});
+      context('with authentication', () => {
+        context('and a valid user/password', () => {
+          it('should return a successful promise', () =>
+            expect(
+              verifierFactory({
+                providerBaseUrl: providerBaseUrl,
+                pactUrls: [
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`,
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`,
+                ],
+                providerStatesSetupUrl: providerStatesSetupUrl,
+                pactBrokerUsername: 'foo',
+                pactBrokerPassword: 'bar',
+              }).verify(),
+            ).to.eventually.be.fulfilled);
+        });
 
-			context("with authentication", () => {
-				context("and a valid user/password", () => {
-					it("should return a successful promise", () =>
-						expect(
-							verifierFactory({
-								providerBaseUrl: providerBaseUrl,
-								pactUrls: [`${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`, `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`],
-								providerStatesSetupUrl: providerStatesSetupUrl,
-								pactBrokerUsername: "foo",
-								pactBrokerPassword: "bar"
-							}).verify()
-						).to.eventually.be.fulfilled
-					);
-				});
+        context('and an invalid user/password', () => {
+          it('should return a rejected promise', () =>
+            expect(
+              verifierFactory({
+                providerBaseUrl: providerBaseUrl,
+                pactUrls: [
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`,
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`,
+                ],
+                providerStatesSetupUrl: providerStatesSetupUrl,
+                pactBrokerUsername: 'foo',
+                pactBrokerPassword: 'baaoeur',
+              }).verify(),
+            ).to.eventually.be.rejected);
 
-				context("and an invalid user/password", () => {
-					it("should return a rejected promise", () =>
-						expect(
-							verifierFactory({
-								providerBaseUrl: providerBaseUrl,
-								pactUrls: [`${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`, `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`],
-								providerStatesSetupUrl: providerStatesSetupUrl,
-								pactBrokerUsername: "foo",
-								pactBrokerPassword: "baaoeur"
-							}).verify()
-						).to.eventually.be.rejected
-					);
+          it('should return the verifier error output in the returned promise', () =>
+            expect(
+              verifierFactory({
+                providerBaseUrl: providerBaseUrl,
+                pactUrls: [
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`,
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`,
+                ],
+                providerStatesSetupUrl: providerStatesSetupUrl,
+                pactBrokerUsername: 'foo',
+                pactBrokerPassword: 'baaoeur',
+              }).verify(),
+            ).to.eventually.be.rejected);
+        });
+      });
+    });
+  });
 
-					it("should return the verifier error output in the returned promise", () =>
-						expect(
-							verifierFactory({
-								providerBaseUrl: providerBaseUrl,
-								pactUrls: [`${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`, `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`],
-								providerStatesSetupUrl: providerStatesSetupUrl,
-								pactBrokerUsername: "foo",
-								pactBrokerPassword: "baaoeur"
-							}).verify()
-						).to.eventually.be.rejected
-					);
-				});
-			});
-		});
-	});
+  context('when publishing verification results to a Pact Broker', () => {
+    context('and there is a valid Pact file with spaces in the path', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl: providerBaseUrl,
+            pactUrls: [
+              path.resolve(
+                __dirname,
+                'integration/publish-verification-example weird path-success.json',
+              ),
+            ],
+            providerStatesSetupUrl: providerStatesSetupUrl,
+            publishVerificationResult: true,
+            providerVersion: '1.0.0',
+          }).verify(),
+        ).to.eventually.be.fulfilled);
+    });
 
-	context("when publishing verification results to a Pact Broker", () => {
-		context("and there is a valid Pact file with spaces in the path", () => {
-			it("should return a successful promise", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/publish-verification-example weird path-success.json")],
-						providerStatesSetupUrl: providerStatesSetupUrl,
-						publishVerificationResult: true,
-						providerVersion: "1.0.0"
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
+    context(
+      'and there is a valid verification HAL link in the Pact file',
+      () => {
+        it('should return a successful promise', () =>
+          expect(
+            verifierFactory({
+              providerBaseUrl: providerBaseUrl,
+              pactUrls: [
+                path.resolve(
+                  __dirname,
+                  'integration/publish-verification-example-success.json',
+                ),
+              ],
+              providerStatesSetupUrl: providerStatesSetupUrl,
+              publishVerificationResult: true,
+              providerVersion: '1.0.0',
+            }).verify(),
+          ).to.eventually.be.fulfilled);
+      },
+    );
 
-		context("and there is a valid verification HAL link in the Pact file", () => {
-			it("should return a successful promise", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/publish-verification-example-success.json")],
-						providerStatesSetupUrl: providerStatesSetupUrl,
-						publishVerificationResult: true,
-						providerVersion: "1.0.0"
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
-
-		context("and there is an invalid verification HAL link in the Pact file", () => {
-			it("should fail with an error", () =>
-				expect(
-					verifierFactory({
-						providerBaseUrl: providerBaseUrl,
-						pactUrls: [path.resolve(__dirname, "integration/publish-verification-example-fail.json")],
-						providerStatesSetupUrl: providerStatesSetupUrl,
-						publishVerificationResult: true,
-						providerVersion: "1.0.0"
-					}).verify()
-				).to.eventually.be.fulfilled
-			);
-		});
-	});
+    context(
+      'and there is an invalid verification HAL link in the Pact file',
+      () => {
+        it('should fail with an error', () =>
+          expect(
+            verifierFactory({
+              providerBaseUrl: providerBaseUrl,
+              pactUrls: [
+                path.resolve(
+                  __dirname,
+                  'integration/publish-verification-example-fail.json',
+                ),
+              ],
+              providerStatesSetupUrl: providerStatesSetupUrl,
+              publishVerificationResult: true,
+              providerVersion: '1.0.0',
+            }).verify(),
+          ).to.eventually.be.fulfilled);
+      },
+    );
+  });
 });

--- a/tslint.json
+++ b/tslint.json
@@ -1,31 +1,34 @@
 {
-	"extends": "tslint:recommended",
-	"rules": {
-		"curly": true,
-		"indent": "tabs",
-		"no-console": false,
-		"max-line-length": {
-			"options": 200
-		},
-		"trailing-comma": false,
-		"object-literal-sort-keys": false,
-		"no-reference": false,
-		"no-trailing-whitespace": false,
-		"typedef-whitespace": false,
-		"whitespace": false,
-		"interface-name": false,
-		"ordered-imports": false,
-		"variable-name": false,
-		"no-var-requires": false,
-		"object-literal-shorthand": false,
-		"no-empty": false,
-		"max-classes-per-file": false,
-		"prefer-const": false,
-		"no-unused-expression": false,
-		"forin": false,
-		"object-literal-key-quotes": false
-	},
-	"jsRules": {
-		"curly": true
-	}
+  "extends": [
+    "tslint:recommended",
+    "tslint-config-prettier"
+  ],
+  "rules": {
+    "curly": true,
+    "indent": "tabs",
+    "no-console": false,
+    "max-line-length": {
+      "options": 200
+    },
+    "trailing-comma": false,
+    "object-literal-sort-keys": false,
+    "no-reference": false,
+    "no-trailing-whitespace": false,
+    "typedef-whitespace": false,
+    "whitespace": false,
+    "interface-name": false,
+    "ordered-imports": false,
+    "variable-name": false,
+    "no-var-requires": false,
+    "object-literal-shorthand": false,
+    "no-empty": false,
+    "max-classes-per-file": false,
+    "prefer-const": false,
+    "no-unused-expression": false,
+    "forin": false,
+    "object-literal-key-quotes": false
+  },
+  "jsRules": {
+    "curly": true
+  }
 }


### PR DESCRIPTION
I added prettier integration so that the development experience is a bit nicer, and ended up needing to upgrade typescript while chasing down some compile errors.

At some point, we'll need to move away from ts-lint - it's going to be deprecated in favour of eslint.