### PR TITLE
fix(spawn): none pactFileWriteMode throws an exception

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -58,7 +58,7 @@ export class Server extends AbstractService {
     }
 
     checkTypes.assert.includes(
-      ['overwrite', 'update', 'merge'],
+      ['overwrite', 'update', 'merge', 'none'],
       options.pactFileWriteMode,
     );
 


### PR DESCRIPTION
Whilst following the readme to figure out how to not commit to creating a pact file. I found that `none` was a valid option, but when setting it, an exception was being thrown from here.

I will patch it locally for now as I've proven this change works. However, I currently don't know if it will break your tests?