### PR TITLE
fix: set strictSSL on custom downloads from NPM config. Fixes #211

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3009,6 +3009,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "figgy-pudding": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -4498,8 +4503,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "7.0.4",
@@ -4954,6 +4958,56 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "libnpmconfig": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+      "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "find-up": "^3.0.0",
+        "ini": "^1.3.5"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        }
       }
     },
     "lie": {
@@ -6084,8 +6138,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "chalk": "2.3.1",
     "check-types": "7.3.0",
     "cross-spawn": "^7.0.1",
+    "libnpmconfig": "^1.2.1",
     "mkdirp": "0.5.1",
     "q": "1.5.1",
     "request": "2.87.0",

--- a/standalone/install.spec.ts
+++ b/standalone/install.spec.ts
@@ -4,7 +4,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as chai from 'chai';
-import { BinaryEntry, Config, useStrictSSL } from './install';
+import { BinaryEntry, Config } from './install';
 
 const expect = chai.expect;
 
@@ -18,27 +18,6 @@ describe('Install', () => {
       delete require.cache[key];
     }
   });
-
-  describe('#useStrictSSL', () => {
-    afterEach(() => {
-      delete process.env['npm_config_strict-ssl']
-    })
-    describe('when "strict-ssl" is specified in an NPM configuration', () => {
-      it('returns a true', () => {
-        process.env['npm_config_strict-ssl'] = "true"
-        expect(useStrictSSL()).to.be.true
-      })
-      it('returns a false', () => {
-        process.env['npm_config_strict-ssl'] = "false"
-        expect(useStrictSSL()).to.be.false
-      })
-    })
-    describe('when "strict-ssl" is not specified in any NPM configuration', () => {
-      it('returns true', () => {
-        expect(useStrictSSL()).to.be.true
-      })
-    })
-  })
 
   function createConfig(): Config {
     return require('./install').createConfig();

--- a/standalone/install.spec.ts
+++ b/standalone/install.spec.ts
@@ -4,7 +4,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as chai from 'chai';
-import { BinaryEntry, Config } from './install';
+import { BinaryEntry, Config, useStrictSSL } from './install';
 
 const expect = chai.expect;
 
@@ -18,6 +18,27 @@ describe('Install', () => {
       delete require.cache[key];
     }
   });
+
+  describe('#useStrictSSL', () => {
+    afterEach(() => {
+      delete process.env['npm_config_strict-ssl']
+    })
+    describe('when "strict-ssl" is specified in an NPM configuration', () => {
+      it('returns a true', () => {
+        process.env['npm_config_strict-ssl'] = "true"
+        expect(useStrictSSL()).to.be.true
+      })
+      it('returns a false', () => {
+        process.env['npm_config_strict-ssl'] = "false"
+        expect(useStrictSSL()).to.be.false
+      })
+    })
+    describe('when "strict-ssl" is not specified in any NPM configuration', () => {
+      it('returns true', () => {
+        expect(useStrictSSL()).to.be.true
+      })
+    })
+  })
 
   function createConfig(): Config {
     return require('./install').createConfig();

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -144,11 +144,6 @@ const CIs = [
 	'WERCKER_ROOT',
 ];
 
-export function useStrictSSL(): boolean {
-	const prop = config.read()['strict-ssl']
-	return prop === "true" || prop === undefined || prop === ""
-}
-
 function downloadFileRetry(
 	url: string,
 	filepath: string,
@@ -164,7 +159,8 @@ function downloadFileRetry(
 				headers: {
 					'User-Agent': 'https://github.com/pact-foundation/pact-node',
 				},
-				strictSSL: useStrictSSL()
+				strictSSL: config.read()['strict-ssl'],
+				ca: config.read()['cafile'],
 			})
 				.on('error', (e: string) => reject(e))
 				.on(

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -3,12 +3,14 @@ import * as Request from 'request';
 import unzipper = require('unzipper');
 import tar = require('tar');
 import pactEnvironment from '../src/pact-environment';
-// we have to u se ES6 imports as it's providing correct types for chalk.
+// we have to use ES6 imports as it's providing correct types for chalk.
 import chalk from 'chalk';
-
 import path = require('path');
 import fs = require('fs');
 import urljoin = require('url-join');
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const config = require('libnpmconfig')
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const sumchecker = require('sumchecker');
 
@@ -142,6 +144,11 @@ const CIs = [
 	'WERCKER_ROOT',
 ];
 
+export function useStrictSSL(): boolean {
+	const prop = config.read()['strict-ssl']
+	return prop === "true" || prop === undefined || prop === ""
+}
+
 function downloadFileRetry(
 	url: string,
 	filepath: string,
@@ -157,6 +164,7 @@ function downloadFileRetry(
 				headers: {
 					'User-Agent': 'https://github.com/pact-foundation/pact-node',
 				},
+				strictSSL: useStrictSSL()
 			})
 				.on('error', (e: string) => reject(e))
 				.on(


### PR DESCRIPTION
Uses `libnpmconfig` to cascade through the various npm config layers and set the property on the download object.

Didn't like exporting the function in order to test it, but I needed a few tests around it at the time. Perhaps they can go now?