### PR TITLE
feat: add consumer version selectors and pending pacts to verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ pact.verifyPacts({
 | `providerBaseUrl`           | true      | string  | Running API provider host endpoint.                                                                        |
 | `pactBrokerUrl`         | false     | string  | Base URL of the Pact Broker from which to retrieve the pacts. Required if `pactUrls` not given.                                                                        |
 | `provider`                  | false     | string  | Name of the provider if fetching from a Broker                                                             |
+| `consumerVersionSelectors`        | false     | ConsumerVersionSelector\|array  | Use [Selectors](https://docs.pact.io/selectors) to is a way we specify which pacticipants and versions we want to use when configuring verifications.                                                         |
 | `consumerVersionTag`        | false     | string\|array  | Retrieve the latest pacts with given tag(s)                                                        |
 | `providerVersionTag`        | false     | string\|array  |  Tag(s) to apply to the provider application |
 | `pactUrls`                  | false     | array   | Array of local pact file paths or HTTP-based URLs. Required if _not_ using a Pact Broker.                  |

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ pact.verifyPacts({
 | `publishVerificationResult` | false     | boolean | Publish verification result to Broker (_NOTE_: you should only enable this during CI builds)               |
 | `customProviderHeaders`     | false     | array   | Header(s) to add to provider state set up and pact verification                                            |  | `requests`. eg 'Authorization: Basic cGFjdDpwYWN0'. |
 | `providerVersion`           | false     | string  | Provider version, required to publish verification result to Broker. Optional otherwise.                   |
+| `enablePending`                   | false     | boolean  | Enable the [pending pacts](https://docs.pact.io/pact_broker/advanced_topics/pending_pacts) feature.       |
 | `timeout`                   | false     | number  | The duration in ms we should wait to confirm verification process was successful. Defaults to 30000.       |
 | `format`                    | false     | string  | What format the verification results are printed in. Options are `json`, `xml`, `progress` and `RspecJunitFormatter` (which is a synonym for `xml`) |
 | `verbose`            | false     | boolean        | Enables verbose output for underlying pact binary. |

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ pact.verifyPacts({
 | `publishVerificationResult` | false     | boolean | Publish verification result to Broker (_NOTE_: you should only enable this during CI builds)               |
 | `customProviderHeaders`     | false     | array   | Header(s) to add to provider state set up and pact verification                                            |  | `requests`. eg 'Authorization: Basic cGFjdDpwYWN0'. |
 | `providerVersion`           | false     | string  | Provider version, required to publish verification result to Broker. Optional otherwise.                   |
-| `enablePending`                   | false     | boolean  | Enable the [pending pacts](https://docs.pact.io/pact_broker/advanced_topics/pending_pacts) feature.       |
+| `enablePending`                   | false     | boolean  | Enable the [pending pacts](https://docs.pact.io/pending) feature.       |
 | `timeout`                   | false     | number  | The duration in ms we should wait to confirm verification process was successful. Defaults to 30000.       |
 | `format`                    | false     | string  | What format the verification results are printed in. Options are `json`, `xml`, `progress` and `RspecJunitFormatter` (which is a synonym for `xml`) |
 | `verbose`            | false     | boolean        | Enables verbose output for underlying pact binary. |

--- a/src/spawn/arguments.spec.ts
+++ b/src/spawn/arguments.spec.ts
@@ -36,6 +36,31 @@ describe('Pact Util Spec', () => {
 				expect(result).to.include('--pact-urls');
 				expect(result).to.include('http://idontexist');
 			});
+			describe("and the argument's value is also an object", () => {
+				it('should serialise the argument value to a JSON string', () => {
+					const result = argsHelper.toArgumentsArray(
+						{
+							consumerVersionSelectors: [
+								{
+									all: true,
+									tag: 'prod',
+								},
+								{
+									tag: 'bar',
+								},
+							],
+						},
+						{ consumerVersionSelectors: '--consumer-version-selector' },
+					);
+
+					expect(result)
+						.to.be.an('array')
+						.that.includes('--consumer-version-selector')
+						.and.includes('{"all":true,"tag":"prod"}')
+						.and.includes('{"tag":"bar"}');
+					expect(result.length).to.be.equal(4);
+				});
+			});
 		});
 		describe('when called with an array', () => {
 			describe('with one element', () => {
@@ -94,6 +119,37 @@ describe('Pact Util Spec', () => {
 						'--version',
 						'v2',
 					]);
+				});
+			});
+			describe("and an argument's value is an object", () => {
+				it('should serialise the argument value to a JSON string', () => {
+					const result = argsHelper.toArgumentsArray(
+						[
+							{
+								consumerVersionSelectors: [
+									{
+										all: true,
+										tag: 'prod',
+									},
+								],
+							},
+							{
+								consumerVersionSelectors: [
+									{
+										tag: 'foo',
+									},
+								],
+							},
+						],
+						{ consumerVersionSelectors: '--consumer-version-selector' },
+					);
+
+					expect(result)
+						.to.be.an('array')
+						.that.includes('--consumer-version-selector')
+						.and.includes('{"all":true,"tag":"prod"}')
+						.and.includes('{"tag":"foo"}');
+					expect(result.length).to.be.equal(4);
 				});
 			});
 		});

--- a/src/spawn/arguments.ts
+++ b/src/spawn/arguments.ts
@@ -27,15 +27,20 @@ export type SpawnArguments = Array<SpawnArgument> | SpawnArgument;
 export const DEFAULT_ARG = 'DEFAULT';
 export const PACT_NODE_NO_VALUE = 'PACT_NODE_NO_VALUE';
 
-const valFor = (v: string): Array<string> =>
-	v !== PACT_NODE_NO_VALUE ? [v] : [];
+const valFor = (v: SpawnArgument): Array<string> => {
+	if (typeof v === 'string') {
+		return v !== PACT_NODE_NO_VALUE ? [v] : [];
+	} else {
+		return [JSON.stringify(v)];
+	}
+};
 
 const mapFor = (mapping: string, v: string): Array<string> =>
 	mapping === DEFAULT_ARG ? valFor(v) : [mapping].concat(valFor(v));
 
 const convertValue = (
 	mapping: string,
-	v: string | Array<string>,
+	v: SpawnArgument | Array<SpawnArgument>,
 ): Array<string> => {
 	if (v && mapping) {
 		return checkTypes.array(v)
@@ -66,7 +71,7 @@ export class Arguments {
 			.reduce(
 				(
 					acc: Array<string>,
-					value: string | Array<string>,
+					value: SpawnArguments | Array<SpawnArguments>,
 					key: string,
 				): Array<string> =>
 					mappings[key] === DEFAULT_ARG

--- a/src/spawn/arguments.ts
+++ b/src/spawn/arguments.ts
@@ -28,11 +28,10 @@ export const DEFAULT_ARG = 'DEFAULT';
 export const PACT_NODE_NO_VALUE = 'PACT_NODE_NO_VALUE';
 
 const valFor = (v: SpawnArgument): Array<string> => {
-	if (typeof v === 'string') {
-		return v !== PACT_NODE_NO_VALUE ? [v] : [];
-	} else {
+	if (typeof v === 'object') {
 		return [JSON.stringify(v)];
 	}
+	return v !== PACT_NODE_NO_VALUE ? [`${v}`] : [];
 };
 
 const mapFor = (mapping: string, v: string): Array<string> =>

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -31,9 +31,11 @@ export class Verifier {
 		pactBrokerToken: '--broker-token',
 		consumerVersionTag: '--consumer-version-tag',
 		providerVersionTag: '--provider-version-tag',
+		consumerVersionSelector: '--consumer-version-selector',
 		publishVerificationResult: '--publish-verification-results',
 		providerVersion: '--provider-app-version',
 		provider: '--provider',
+		enablePending: '--enable-pending',
 		customProviderHeaders: '--custom-provider-header',
 		verbose: '--verbose',
 		monkeypatch: '--monkeypatch',
@@ -50,6 +52,7 @@ export class Verifier {
 		options.timeout = options.timeout || 30000;
 		options.consumerVersionTag = options.consumerVersionTag || [];
 		options.providerVersionTag = options.providerVersionTag || [];
+		options.consumerVersionSelector = options.consumerVersionSelector || [];
 
 		if (
 			options.consumerVersionTag &&
@@ -169,6 +172,10 @@ export class Verifier {
 			checkTypes.assert.string(options.out);
 		}
 
+		if (options.enablePending !== undefined) {
+			checkTypes.assert.boolean(options.enablePending);
+		}
+
 		if (options.tags) {
 			logger.warn(
 				"'tags' has been deprecated as at v8.0.0, please use 'consumerVersionTag' instead",
@@ -219,6 +226,18 @@ export class Verifier {
 // Creates a new instance of the pact server with the specified option
 export default (options: VerifierOptions): Verifier => new Verifier(options);
 
+// A ConsumerVersionSelector is a way we specify which pacticipants and
+// versions we want to use when configuring verifications.
+//
+// See https://docs.pact.io/selectors for more
+export interface ConsumerVersionSelector {
+	pacticipant?: string;
+	tag?: string;
+	version?: string;
+	latest?: boolean;
+	all?: boolean;
+}
+
 export interface VerifierOptions {
 	providerBaseUrl: string;
 	provider?: string;
@@ -230,9 +249,11 @@ export interface VerifierOptions {
 	pactBrokerToken?: string;
 	consumerVersionTag?: string | string[];
 	providerVersionTag?: string | string[];
+	consumerVersionSelector?: ConsumerVersionSelector[];
 	customProviderHeaders?: string[];
 	publishVerificationResult?: boolean;
 	providerVersion?: string;
+	enablePending?: boolean;
 	timeout?: number;
 	tags?: string[];
 	verbose?: boolean;


### PR DESCRIPTION
Implements consumer version selectors (see https://github.com/pact-foundation/pact_broker/issues/307) and pending pacts (see ).

The biggest complication here is that the selectors are specified as JSON strings on the CLI - not something we're well prepared for.

In terms of design options I had a few, most notably:

1. Modify `verifier.ts` to do the JSON marshaling, but that then meant I needed to do nasty things to hide the true option that is passed to the `Arguments` class.
2. Enhance the `SpawnArguments` type to signal that certain properties were basic "string" values vs "JSON" values - but decided against that large refactor.
3. Detect an argument value - if it is an object, marshal to JSON, otherwise fall back to existing behaviour. This is the path I chose, because it was so simple to implement.

I also updated the types in `Arguments` because the values were set as strings, but that is actually an illusion - in reality they are an interface type (`SpawnArguments`), that could have values as primitives (strings, numbers etc.) or in this new case - an interface. 

This was a fairly simple change, but I was concerned about making that class any more complicated, so we may want to revert it.