### PR TITLE
feat: deprecate consumerVersionTag and providerVersionTag. Fixes #218

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ pact.verifyPacts({
 | `pactBrokerUrl`         | false     | string  | Base URL of the Pact Broker from which to retrieve the pacts. Required if `pactUrls` not given.                                                                        |
 | `provider`                  | false     | string  | Name of the provider if fetching from a Broker                                                             |
 | `consumerVersionSelectors`        | false     | ConsumerVersionSelector\|array  | Use [Selectors](https://docs.pact.io/selectors) to is a way we specify which pacticipants and versions we want to use when configuring verifications.                                                         |
-| `consumerVersionTag`        | false     | string\|array  | Retrieve the latest pacts with given tag(s)                                                        |
-| `providerVersionTag`        | false     | string\|array  |  Tag(s) to apply to the provider application |
+| `consumerVersionTags`        | false     | string\|array  | Retrieve the latest pacts with given tag(s)                                                        |
+| `providerVersionTags`        | false     | string\|array  |  Tag(s) to apply to the provider application |
 | `pactUrls`                  | false     | array   | Array of local pact file paths or HTTP-based URLs. Required if _not_ using a Pact Broker.                  |
 | `providerStatesSetupUrl`    | false     | string  | URL to send PUT requests to setup a given provider state                                                   |
 | `pactBrokerUsername`        | false     | string  | Username for Pact Broker basic authentication                                                              |

--- a/src/verifier.spec.ts
+++ b/src/verifier.spec.ts
@@ -1,7 +1,10 @@
 import path = require('path');
 import chai = require('chai');
 import chaiAsPromised = require('chai-as-promised');
-import verifierFactory, { VerifierOptions } from './verifier';
+import verifierFactory, {
+	VerifierOptions,
+	DeprecatedVerifierOptions,
+} from './verifier';
 
 const expect = chai.expect;
 chai.use(chaiAsPromised);
@@ -57,7 +60,7 @@ describe('Verifier Spec', () => {
 			expect(() =>
 				verifierFactory({
 					providerStatesSetupUrl: 'http://foo/provider-states/setup',
-				} as VerifierOptions),
+				} as VerifierOptions & DeprecatedVerifierOptions),
 			).to.throw(Error);
 		});
 	});
@@ -249,7 +252,7 @@ describe('Verifier Spec', () => {
 		});
 	});
 
-	context('when consumerVersionTag is not provided', () => {
+	context('when consumerVersionTags is not provided', () => {
 		it('should not fail', () => {
 			expect(() =>
 				verifierFactory({
@@ -260,6 +263,17 @@ describe('Verifier Spec', () => {
 		});
 	});
 
+	context('when consumerVersionTags is provided as a string', () => {
+		it('should convert the argument to an array', () => {
+			const v = verifierFactory({
+				providerBaseUrl: 'http://localhost',
+				pactUrls: [path.dirname(currentDir)],
+				consumerVersionTags: 'tag-1',
+			});
+
+			expect(v.options.consumerVersionTags).to.deep.eq(['tag-1']);
+		});
+	});
 	context('when consumerVersionTag is provided as a string', () => {
 		it('should convert the argument to an array', () => {
 			const v = verifierFactory({
@@ -272,19 +286,35 @@ describe('Verifier Spec', () => {
 		});
 	});
 
-	context('when consumerVersionTag is provided as an array', () => {
+	context('when consumerVersionTags is provided as an array', () => {
 		it('should not fail', () => {
 			expect(() =>
 				verifierFactory({
 					providerBaseUrl: 'http://localhost',
 					pactUrls: [path.dirname(currentDir)],
-					consumerVersionTag: ['tag-1'],
+					consumerVersionTags: ['tag-1'],
 				}),
 			).to.not.throw(Error);
 		});
 	});
 
-	context('when providerVersionTag is not provided', () => {
+	context(
+		'when consumerVersionTags and consumerVersionTag are provided',
+		() => {
+			it('should fail', () => {
+				expect(() => {
+					verifierFactory({
+						providerBaseUrl: 'http://localhost',
+						pactUrls: [path.dirname(currentDir)],
+						consumerVersionTags: ['tag-1'],
+						consumerVersionTag: ['tag-1'],
+					});
+				}).to.throw(Error);
+			});
+		},
+	);
+
+	context('when providerVersionTags is not provided', () => {
 		it('should not fail', () => {
 			expect(() =>
 				verifierFactory({
@@ -292,6 +322,18 @@ describe('Verifier Spec', () => {
 					pactUrls: [path.dirname(currentDir)],
 				}),
 			).to.not.throw(Error);
+		});
+	});
+
+	context('when providerVersionTags is provided as a string', () => {
+		it('should convert the argument to an array', () => {
+			const v = verifierFactory({
+				providerBaseUrl: 'http://localhost',
+				pactUrls: [path.dirname(currentDir)],
+				providerVersionTags: 'tag-1',
+			});
+
+			expect(v.options.providerVersionTags).to.deep.eq(['tag-1']);
 		});
 	});
 
@@ -307,17 +349,33 @@ describe('Verifier Spec', () => {
 		});
 	});
 
-	context('when providerVersionTag is provided as an array', () => {
+	context('when providerVersionTags is provided as an array', () => {
 		it('should not fail', () => {
 			expect(() =>
 				verifierFactory({
 					providerBaseUrl: 'http://localhost',
 					pactUrls: [path.dirname(currentDir)],
-					providerVersionTag: ['tag-1'],
+					providerVersionTags: ['tag-1'],
 				}),
 			).to.not.throw(Error);
 		});
 	});
+
+	context(
+		'when providerVersionTags and providerVersionTag are provided',
+		() => {
+			it('should fail', () => {
+				expect(() => {
+					verifierFactory({
+						providerBaseUrl: 'http://localhost',
+						pactUrls: [path.dirname(currentDir)],
+						providerVersionTags: ['tag-1'],
+						providerVersionTag: ['tag-1'],
+					});
+				}).to.throw(Error);
+			});
+		},
+	);
 
 	context('when using a bearer token', () => {
 		context('and specifies a username or password', () => {


### PR DESCRIPTION
* Adds `consumerVersionTags` and `providerVersionTags` as options that _only_ accept arrays. I think accepting a string or array is unnecessary.
* Logs deprecation warning if `consumerVersionTag` and `providerVersionTag` is used
* Supports both options until a major version bump.