### PR TITLE
fix: update standalone to 1.82.2

### DIFF
--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -23,7 +23,7 @@ const request = Request.defaults({
 });
 
 // Get latest version from https://github.com/pact-foundation/pact-ruby-standalone/releases
-export const PACT_STANDALONE_VERSION = '1.82.1';
+export const PACT_STANDALONE_VERSION = '1.82.2';
 const PACT_DEFAULT_LOCATION = `https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_STANDALONE_VERSION}/`;
 const HTTP_REGEX = /^http(s?):\/\//;
 


### PR DESCRIPTION
For https://github.com/pact-foundation/pact-ruby-standalone/issues/49