### PR TITLE
fix: correcting the cafile setup for postinstall download

### DIFF
--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -156,7 +156,7 @@ function downloadFileRetry(
 			let time = Date.now();
 			let ca = config.read()['cafile'];
 			if (ca) {
-				ca = fs.readFileSync(config.read()['cafile']);
+				ca = fs.readFileSync(ca);
 			}
 			request({
 				url,

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -154,8 +154,8 @@ function downloadFileRetry(
 			let len = 0;
 			let downloaded = 0;
 			let time = Date.now();
-			let ca = null;
-			if (config.read()['cafile']) {
+			let ca = config.read()['cafile'];
+			if (ca) {
 				ca = fs.readFileSync(config.read()['cafile']);
 			}
 			request({

--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -154,13 +154,17 @@ function downloadFileRetry(
 			let len = 0;
 			let downloaded = 0;
 			let time = Date.now();
+			let ca = null;
+			if (config.read()['cafile']) {
+				ca = fs.readFileSync(config.read()['cafile']);
+			}
 			request({
 				url,
 				headers: {
 					'User-Agent': 'https://github.com/pact-foundation/pact-node',
 				},
 				strictSSL: config.read()['strict-ssl'],
-				ca: config.read()['cafile'],
+				ca,
 			})
 				.on('error', (e: string) => reject(e))
 				.on(


### PR DESCRIPTION
fix for issue discovered whilst trying to use pactjs

https://github.com/pact-foundation/pact-js/issues/427

CA config does not work when a cafile is specified in .npmrc