### PR TITLE
fix(server): remove force-clone of options

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -74,7 +74,6 @@ export class Server extends AbstractService {
 
 		// Need to uppercase logLevel for ruby
 		if (options.logLevel) {
-			opts = JSON.parse(JSON.stringify(options));
 			opts.logLevel = options.logLevel.toUpperCase() as LogLevel;
 		}
 


### PR DESCRIPTION
In porting over amended changes from https://github.com/pact-foundation/pact-js/pull/489, my tests were routinely failing because the suite couldn't start the server with `logLevel` provided.

<img width="2077" alt="Screen Shot 2020-08-26 at 1 29 17 AM" src="https://user-images.githubusercontent.com/29997/91280423-952c0c00-e73b-11ea-93cd-ebe925fcdef1.png">

Then I discovered I had the same behavior in `master` when running tests locally.

Then I discovered [the latest CI build for `master` was failing for the same reason](https://travis-ci.org/github/pact-foundation/pact-node/builds/716505875).

Removing this line fixes the build locally for me. Marking this as a draft PR to see what CI does when it's submitted, or if anyone else has ideas about why this is failing. 🤷‍♀️ 

cc @TimothyJones 