### PR TITLE
fix: Correct the config for using custom ca file

### DIFF
--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -164,7 +164,9 @@ function downloadFileRetry(
 					'User-Agent': 'https://github.com/pact-foundation/pact-node',
 				},
 				strictSSL: config.read()['strict-ssl'],
-				ca,
+				agentOptions: {
+					ca: ca,
+				},
 			})
 				.on('error', (e: string) => reject(e))
 				.on(


### PR DESCRIPTION
When behind a proxy that implements SSL interception the CA file was not being set correctly.

I couldn't think of a way to add tests for this but if a way can be suggested I'm happy to implement them. I have however tested this locally behind an intercepting proxy.

This could possibly fix https://github.com/pact-foundation/pact-js/issues/485