### PR TITLE
feat: Add new branch consumerVersionSelector options to verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ ConsumerVersionSelector {
   released?: boolean; 
   environment?: string;
   fallbackTag?: string;
+  branch?: string;
+  mainBranch?: boolean;
+  matchingBranch?: boolean;
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2541,6 +2541,21 @@
         "@types/node": "*"
       }
     },
+    "@types/sinon": {
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.11.tgz",
+      "integrity": "sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
+      "integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/node": "9.4.6",
     "@types/promise-timeout": "^1.3.0",
     "@types/rimraf": "^2.0.2",
+    "@types/sinon": "^9.0.11",
     "@types/tar": "^4.0.3",
     "@types/underscore": "1.8.7",
     "@types/unixify": "^1.0.0",

--- a/src/verifier/types.ts
+++ b/src/verifier/types.ts
@@ -9,6 +9,9 @@ export interface ConsumerVersionSelector {
   released?: boolean;
   environment?: string;
   fallbackTag?: string;
+  branch?: string;
+  mainBranch?: boolean;
+  matchingBranch?: boolean;
 }
 
 export interface VerifierOptions {

--- a/src/verifier/validateOptions.ts
+++ b/src/verifier/validateOptions.ts
@@ -79,7 +79,9 @@ export const validateOptions = (o: VerifierOptions): VerifierOptions => {
       'released',
       'environment',
       'fallbackTag',
-      'latest',
+      'branch',
+      'mainBranch',
+      'matchingBranch',
     ];
     options.consumerVersionSelectors.forEach((selector) => {
       if (selector.tag === 'latest') {


### PR DESCRIPTION
This implements the pact-js-core side of issue https://github.com/pact-foundation/pact-js/issues/757 