### PR TITLE
feat: Add new branch consumerVersionSelector options to verifier

### DIFF
--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -265,9 +265,9 @@ export class Verifier {
       this.__argMapping
     );
     const output: Array<string | Buffer> = [];
-    instance.stdout.on('data', l => output.push(l));
-    instance.stderr.on('data', l => output.push(l));
-    instance.once('close', code => {
+    instance.stdout.on('data', (l) => output.push(l));
+    instance.stderr.on('data', (l) => output.push(l));
+    instance.once('close', (code) => {
       const o = output.join('\n');
       code === 0 ? deferred.resolve(o) : deferred.reject(new Error(o));
     });
@@ -311,6 +311,9 @@ export interface ConsumerVersionSelector
   released?: boolean;
   environment?: string;
   fallbackTag?: string;
+  branch?: string;
+  mainBranch?: boolean;
+  matchingBranch?: boolean;
 }
 
 interface CurrentVerifierOptions {


### PR DESCRIPTION
This implements the pact-js-core side of issue pact-foundation/pact-js#757 for the `pact-node` branch.