### PR TITLE
fix(ci): survive transient failures when publishing release assets

### DIFF
--- a/script/ci/check-release-libs.sh
+++ b/script/ci/check-release-libs.sh
@@ -90,30 +90,30 @@ ls *.gz | xargs -n1 tar -xzf
 rm *.tar.gz
 ls -1 prebuilds/**
 
-[[ -f prebuilds/darwin-arm64/libpact_ffi.dylib ]] || ERRORS='prebuilds/darwin-arm64/libpact_ffi.dylib'
-[[ -f prebuilds/darwin-arm64/node.napi.node ]] || ERRORS='prebuilds/darwin-arm64/node.napi.node'
+[[ -f prebuilds/darwin-arm64/libpact_ffi.dylib ]] || ERRORS+=('prebuilds/darwin-arm64/libpact_ffi.dylib')
+[[ -f prebuilds/darwin-arm64/node.napi.node ]] || ERRORS+=('prebuilds/darwin-arm64/node.napi.node')
 
-[[ -f prebuilds/darwin-x64/libpact_ffi.dylib ]] || ERRORS='prebuilds/darwin-x64/libpact_ffi.dylib'
-[[ -f prebuilds/darwin-x64/node.napi.node ]] || ERRORS='prebuilds/darwin-x64/node.napi.node'
+[[ -f prebuilds/darwin-x64/libpact_ffi.dylib ]] || ERRORS+=('prebuilds/darwin-x64/libpact_ffi.dylib')
+[[ -f prebuilds/darwin-x64/node.napi.node ]] || ERRORS+=('prebuilds/darwin-x64/node.napi.node')
 
-[[ -f prebuilds/linux-arm64/libpact_ffi.so ]] || ERRORS='prebuilds/linux-arm64/libpact_ffi.so'
-[[ -f prebuilds/linux-arm64/node.napi.node ]] || ERRORS='prebuilds/linux-arm64/node.napi.node'
+[[ -f prebuilds/linux-arm64/libpact_ffi.so ]] || ERRORS+=('prebuilds/linux-arm64/libpact_ffi.so')
+[[ -f prebuilds/linux-arm64/node.napi.node ]] || ERRORS+=('prebuilds/linux-arm64/node.napi.node')
 
-[[ -f prebuilds/linux-arm64/libpact_ffi_musl.so ]] || ERRORS='prebuilds/linux-arm64/libpact_ffi_musl.so'
-[[ -f prebuilds/linux-arm64/node.napi.musl.node ]] || ERRORS='prebuilds/linux-arm64/node.napi.musl.node'
+[[ -f prebuilds/linux-arm64/libpact_ffi_musl.so ]] || ERRORS+=('prebuilds/linux-arm64/libpact_ffi_musl.so')
+[[ -f prebuilds/linux-arm64/node.napi.musl.node ]] || ERRORS+=('prebuilds/linux-arm64/node.napi.musl.node')
 
-[[ -f prebuilds/linux-x64/libpact_ffi.so ]] || ERRORS='prebuilds/linux-x64/libpact_ffi.so'
-[[ -f prebuilds/linux-x64/node.napi.node ]] || ERRORS='prebuilds/linux-x64/node.napi.node'
+[[ -f prebuilds/linux-x64/libpact_ffi.so ]] || ERRORS+=('prebuilds/linux-x64/libpact_ffi.so')
+[[ -f prebuilds/linux-x64/node.napi.node ]] || ERRORS+=('prebuilds/linux-x64/node.napi.node')
 
-[[ -f prebuilds/linux-x64/libpact_ffi_musl.so ]] || ERRORS='prebuilds/linux-x64/libpact_ffi_musl.so'
-[[ -f prebuilds/linux-x64/node.napi.musl.node ]] || ERRORS='prebuilds/linux-x64/node.napi.musl.node'
+[[ -f prebuilds/linux-x64/libpact_ffi_musl.so ]] || ERRORS+=('prebuilds/linux-x64/libpact_ffi_musl.so')
+[[ -f prebuilds/linux-x64/node.napi.musl.node ]] || ERRORS+=('prebuilds/linux-x64/node.napi.musl.node')
 
-[[ -f prebuilds/win32-x64/pact_ffi.dll ]] || ERRORS='prebuilds/win32-x64/pact_ffi.dll'
-[[ -f prebuilds/win32-x64/node.napi.node ]] || ERRORS='prebuilds/win32-x64/node.napi.node'
+[[ -f prebuilds/win32-x64/pact_ffi.dll ]] || ERRORS+=('prebuilds/win32-x64/pact_ffi.dll')
+[[ -f prebuilds/win32-x64/node.napi.node ]] || ERRORS+=('prebuilds/win32-x64/node.napi.node')
 
-if [ ! -z "${ERRORS:-}" ]; then
+if [ "${#ERRORS[@]}" -gt 0 ]; then
     echo "The following files are missing from the release:"
-    echo $ERRORS
+    printf '  - %s\n' "${ERRORS[@]}"
     exit 1
 else
     echo "All release files are present"

--- a/script/ci/release.sh
+++ b/script/ci/release.sh
@@ -48,7 +48,7 @@ if [ "${GH_CREATE_PRE_RELEASE:-}" = true ]; then
   exit 0
 elif [ "${GH_PRE_RELEASE_UPLOAD:-}" = true ]; then
   echo "Uploading pre-release ${NEXT_TAG}"
-  gh release upload ${NEXT_TAG} prebuilds/*.tar.gz --repo ${REPO} --clobber
+  retry gh release upload ${NEXT_TAG} prebuilds/*.tar.gz --repo ${REPO} --clobber
   exit 0
 fi
 

--- a/script/lib/robust-bash.sh
+++ b/script/lib/robust-bash.sh
@@ -34,6 +34,33 @@ if [ -z "${LIB_ROBUST_BASH_SH:-}" ]; then
     fi
   }
 
+  # Retry a command with exponential backoff, so that a transient
+  # failure from a remote service doesn't fail the whole build.
+  #
+  # Tunable with RETRY_MAX_ATTEMPTS and RETRY_INITIAL_DELAY.
+  function retry {
+    local max_attempts="${RETRY_MAX_ATTEMPTS:-5}"
+    local delay="${RETRY_INITIAL_DELAY:-5}"
+    local attempt=1
+
+    while true; do
+      if "$@"; then
+        return 0
+      fi
+
+      if [ "$attempt" -ge "$max_attempts" ]; then
+        error "Command failed after ${max_attempts} attempts: $*"
+        return 1
+      fi
+
+      warn "Attempt ${attempt}/${max_attempts} failed: $*"
+      log "Retrying in ${delay}s"
+      sleep "$delay"
+      attempt=$((attempt + 1))
+      delay=$((delay * 2))
+    done
+  }
+
   # Check to see that we have a required environment variable set,
   # and fail the script if it is not set.
   #


### PR DESCRIPTION
## Problem

A transient `HTTP 502` while uploading the Windows prebuild to the `v20.0.1` pre-release on 2026-06-08 left that release with only 6 of its 7 assets — `win32-x64.tar.gz` never made it.

Pull request test jobs do not build anything themselves. They fetch the prebuilt libraries from the latest pre-release via `check-release-libs.sh`, which asserts that all 14 expected files are present. That assertion is platform independent, so a single missing Windows asset failed **every test job on every platform for every open pull request** — 24 jobs each across all open Renovate PRs, Linux and macOS included.

A one-off blip in the GitHub API should not have that blast radius, and should not require a maintainer to notice and republish by hand.

## Changes

- Add a `retry` helper to `script/lib/robust-bash.sh` with exponential backoff, tunable via `RETRY_MAX_ATTEMPTS` and `RETRY_INITIAL_DELAY`.
- Wrap the `gh release upload` in `script/ci/release.sh` with it.
- `check-release-libs.sh` collected its failures with `ERRORS='...'` — a plain assignment rather than an append — so it only ever named the **last** missing file. It now appends and reports all of them, which is a large part of why this was slow to diagnose.

## Verification

The `retry` helper was exercised against a command that succeeds on the third attempt, one that always fails, and one that succeeds immediately, confirming backoff, correct exit-code propagation, and no spurious retries.

The asset check was tested on bash 3.2 for both the missing-files case (all missing files listed, exit 1) and the all-present case, confirming `"${#ERRORS[@]}"` is safe on an empty array under `set -u`.

## Note

This prevents recurrence but cannot self-heal an already-incomplete release. Republishing is currently blocked by a **separate** problem: the `windows-latest` runner image now ships Visual Studio 18, which `node-gyp` 11.5.0 cannot detect, so the Windows prebuild fails at compile time. That needs its own fix before the Renovate PRs recover.

Generated with Claude Code