### PR TITLE
fix(ci): build against Visual Studio 2026 on Windows (rebuild)

### DIFF
--- a/script/ci/prebuild.sh
+++ b/script/ci/prebuild.sh
@@ -34,6 +34,32 @@ npm --version
 echo "OS: $OS"
 echo "ARCH: $ARCH"
 
+# The Windows runner images now ship Visual Studio 2026, whose version
+# node-gyp only learned to recognise in 12.1.0. Older versions detect the
+# install, fail to read its version and abort with "Could not find any
+# Visual Studio installation to use", so the native build cannot run at
+# all. node-gyp is bundled with npm, and 12.1.0 first shipped in npm 11.6.3.
+if [[ $OS == win32 ]]; then
+  MIN_NPM_VERSION=11.6.3
+  MIN_NODE_GYP_VERSION=12.1.0
+
+  if ! version_gte "$(npm --version)" "${MIN_NPM_VERSION}"; then
+    log "npm $(npm --version) bundles a node-gyp that cannot detect Visual Studio 2026, upgrading"
+    npm install --global "npm@>=${MIN_NPM_VERSION}"
+  fi
+
+  require_min_version npm "$(npm --version)" "${MIN_NPM_VERSION}"
+
+  NODE_GYP_BIN="$(npm root --global)/npm/node_modules/node-gyp/bin/node-gyp.js"
+  if [[ -f ${NODE_GYP_BIN} ]]; then
+    require_min_version node-gyp "$(node "${NODE_GYP_BIN}" --version)" "${MIN_NODE_GYP_VERSION}"
+  else
+    error "Could not find the node-gyp bundled with npm at ${NODE_GYP_BIN}"
+    echo "   - unable to verify it is new enough to detect Visual Studio 2026"
+    exit 1
+  fi
+fi
+
 ./script/download-libs.sh
 npm ci --ignore-scripts || npm i --ignore-scripts
 export npm_config_target=${NODE_VERSION}

--- a/script/lib/robust-bash.sh
+++ b/script/lib/robust-bash.sh
@@ -49,4 +49,34 @@ if [ -z "${LIB_ROBUST_BASH_SH:-}" ]; then
       exit 1
     fi
   }
+
+  # Compare two dotted versions, returning success when the first is
+  # greater than or equal to the second.
+  #
+  # Comparison is delegated to node, which every script here already
+  # depends on, so that it behaves identically on the macOS, Linux and
+  # Git Bash environments the builds run in.
+  function version_gte {
+    node -e '
+      const parse = (v) => String(v).replace(/^v/, "").split(".").map((n) => Number.parseInt(n, 10) || 0);
+      const [a, b] = [parse(process.argv[1]), parse(process.argv[2])];
+      for (let i = 0; i < Math.max(a.length, b.length); i++) {
+        const [x, y] = [a[i] || 0, b[i] || 0];
+        if (x !== y) process.exit(x > y ? 0 : 1);
+      }
+      process.exit(0);
+    ' "${1:-0}" "${2:-0}"
+  }
+
+  # Check that a tool meets a minimum version, and fail the script if it
+  # does not. Takes a human readable name, the actual version and the
+  # minimum required version.
+  function require_min_version {
+    if version_gte "${2:-}" "${3:-}"; then
+      log "${1:-} ${2:-} satisfies the minimum of ${3:-}"
+    else
+      error "${1:-} ${2:-} is older than the required minimum of ${3:-}"
+      exit 1
+    fi
+  }
 fi


### PR DESCRIPTION
## Problem

The Windows prebuild has been failing at compile time:

```
gyp ERR! find VS unknown version "undefined" found at
          "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
gyp ERR! stack Error: Could not find any Visual Studio installation to use
```

The `windows-latest` runner image now ships **Visual Studio 2026** (internal version 18.x). `node-gyp` only learned to recognise that version in **12.1.0** — earlier versions locate the installation, fail to parse its version, and abort. See [nodejs/node-gyp#3282](https://github.com/nodejs/node-gyp/issues/3282).

The runner is on Node 22.23.1, whose bundled npm carries node-gyp 11.5.0, so no Windows prebuild can be produced at all.

This matters beyond the prebuild job. Because pull request test jobs fetch prebuilt libraries from the latest pre-release and assert that every expected file is present, a missing Windows asset fails **every test job on every platform** for every open pull request.

## Changes

- Upgrade npm to `>=11.6.3` on the Windows prebuild, the first release to bundle node-gyp 12.1.0. Guarded so it is a no-op once the runner image ships a new enough npm.
- Assert the resulting npm **and** node-gyp versions instead of trusting the upgrade, so a future toolchain regression fails immediately with a clear message rather than resurfacing as an opaque compiler error.
- Add `version_gte` and `require_min_version` to `script/lib/robust-bash.sh`. Version comparison is delegated to node, which these scripts already depend on, so it behaves identically across macOS, Linux and Git Bash.

Scoped to the `win32` branch; other platforms are untouched.

## Verification

`version_gte` was tested across 12 cases: the real-world versions, numeric rather than lexical ordering (`11.10.0 >= 11.6.3`, which a string compare gets wrong), the leading `v` that `node-gyp --version` emits, and uneven segment counts.

`require_min_version` was confirmed to exit 1 and halt the script on failure. The Windows block was simulated with a stubbed npm across three paths: old npm upgrades then passes, current npm skips the upgrade, and non-Windows does not run the block at all. The bundled node-gyp path resolves correctly via `npm root --global`.

## Note

Titled `(rebuild)` so this PR runs the prebuild jobs itself rather than fetching the incomplete pre-release, which is what lets it verify the fix and go green while `v20.0.1` is still missing its Windows asset.

Complements #909, which prevents a transient upload failure from dropping an asset in the first place. This PR is what unblocks the currently failing Renovate PRs: merging it lets master rebuild and republish `win32-x64.tar.gz`.

Generated with Claude Code