### PR TITLE
chore: remove snyk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@biomejs/biome": "2.5.6",
         "@grpc/grpc-js": "1.14.4",
         "@grpc/proto-loader": "0.8.1",
-        "@snyk/protect": "1.1306.1",
         "@tsconfig/node22": "22.0.5",
         "@types/basic-auth": "1.1.8",
         "@types/check-types": "11.2.2",
@@ -1088,19 +1087,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@snyk/protect": {
-      "version": "1.1306.1",
-      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.1306.1.tgz",
-      "integrity": "sha512-Ez+MJBSyl5/xK1+IEEPnMG1tJNOIEvoCIiCU+sjfcgL9VwrT29u1tOy/AA5PXrrlj0sEI8GUL377PWEtYU5dWQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "snyk-protect": "bin/snyk-protect"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@standard-schema/spec": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@biomejs/biome": "2.5.6",
     "@grpc/grpc-js": "1.14.4",
     "@grpc/proto-loader": "0.8.1",
-    "@snyk/protect": "1.1306.1",
     "@tsconfig/node22": "22.0.5",
     "@types/basic-auth": "1.1.8",
     "@types/check-types": "11.2.2",


### PR DESCRIPTION
Renovate has been raising upgrade PRs for `@snyk/protect` (e.g. `renovate/snyk-protect-1.x`), but Snyk is no longer part of this project's security tooling.

The package was left behind as a `devDependency` when Snyk was removed in #659, and nothing uses it:

- no `.snyk` policy file in the repo
- no npm script invoking `snyk-protect` (the usual `prepare` hook is absent)
- no CI workflow referencing Snyk

This drops the dependency and regenerates the lockfile. The historical CHANGELOG entries mentioning Snyk are left untouched.

Once this lands, the Renovate branch for `@snyk/protect` can be closed.