### PR TITLE
chore(deps): update dependency typescript to v7

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,26 @@ on:
 
 jobs:
 
+  static_checks:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_VERSION: 22
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - run: npm ci --ignore-scripts
+
+      - run: npm run check
+
+      - run: npm run typecheck
+
   create_pre_release:
     runs-on: ubuntu-latest
     steps:

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,9 @@
 {
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "files": {
+    // Pact files written by the integration tests, reformatted on every run
+    "includes": ["**", "!test/__testoutput__"]
+  },
   "linter": {
     "enabled": true,
     "rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "protobufjs": "8.7.1",
         "rimraf": "6.1.3",
         "sinon": "22.1.0",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
         "vitest": "4.1.10"
       },
       "engines": {
@@ -1364,6 +1364,346 @@
       "license": "MIT",
       "dependencies": {
         "url-join": "*"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -4833,17 +5173,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undefsafe": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "download-libs": "npm run clean && bash script/download-libs.sh",
     "clean-libs": "rimraf 'ffi'",
     "build": "tsc --project tsconfig.build.json",
+    "typecheck": "tsc --project tsconfig.json",
     "release": "commit-and-tag-version",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@pact-foundation/pact-core",
   "version": "20.0.0",
   "description": "Core of @pact-foundation/pact. You almost certainly don't want to depend on this directly.",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "homepage": "https://github.com/pact-foundation/pact-js-core#readme",
-  "types": "src/index.d.ts",
+  "types": "dist/index.d.ts",
   "os": [
     "darwin",
     "linux",
@@ -90,7 +90,7 @@
     "semver": "7.8.5"
   },
   "scripts": {
-    "clean": "rimraf -g '{src,test}/**/*.{js,map,d.ts}' 'package.zip' '.tmp' 'tmp'",
+    "clean": "rimraf -g 'dist' 'package.zip' '.tmp' 'tmp'",
     "lint": "biome lint",
     "lint:fix": "biome lint --write",
     "format": "biome format",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "protobufjs": "8.7.1",
     "rimraf": "6.1.3",
     "sinon": "22.1.0",
-    "typescript": "5.9.3",
+    "typescript": "7.0.2",
     "vitest": "4.1.10"
   },
   "overrides": {

--- a/src/ffi/types.ts
+++ b/src/ffi/types.ts
@@ -9,54 +9,44 @@ export type FfiMessageHandle = number;
 
 export type FfiSpecificationVersion = 0 | 1 | 2 | 3 | 4 | 5;
 
-export const FfiSpecificationVersion: Record<string, FfiSpecificationVersion> =
-  {
-    SPECIFICATION_VERSION_UNKNOWN: 0,
-    SPECIFICATION_VERSION_V1: 1,
-    SPECIFICATION_VERSION_V1_1: 2,
-    SPECIFICATION_VERSION_V2: 3,
-    SPECIFICATION_VERSION_V3: 4,
-    SPECIFICATION_VERSION_V4: 5,
-  };
+export const FfiSpecificationVersion = {
+  SPECIFICATION_VERSION_UNKNOWN: 0,
+  SPECIFICATION_VERSION_V1: 1,
+  SPECIFICATION_VERSION_V1_1: 2,
+  SPECIFICATION_VERSION_V2: 3,
+  SPECIFICATION_VERSION_V3: 4,
+  SPECIFICATION_VERSION_V4: 5,
+} as const satisfies Record<string, FfiSpecificationVersion>;
 
 export type FfiWritePactResponse = 0 | 1 | 2 | 3;
 
-export const FfiWritePactResponse: Record<string, FfiWritePactResponse> = {
+export const FfiWritePactResponse = {
   SUCCESS: 0,
   GENERAL_PANIC: 1,
   UNABLE_TO_WRITE_PACT_FILE: 2,
   MOCK_SERVER_NOT_FOUND: 3,
-};
+} as const satisfies Record<string, FfiWritePactResponse>;
 
 export type FfiWriteMessagePactResponse = 0 | 1 | 2;
 
-export const FfiWriteMessagePactResponse: Record<
-  string,
-  FfiWriteMessagePactResponse
-> = {
+export const FfiWriteMessagePactResponse = {
   SUCCESS: 0,
   UNABLE_TO_WRITE_PACT_FILE: 1,
   MESSAGE_HANDLE_INVALID: 2,
-};
+} as const satisfies Record<string, FfiWriteMessagePactResponse>;
 
 export type FfiConfigurePluginResponse = 0 | 1 | 2 | 3;
 
-export const FfiConfigurePluginResponse: Record<
-  string,
-  FfiConfigurePluginResponse
-> = {
+export const FfiConfigurePluginResponse = {
   SUCCESS: 0,
   GENERAL_PANIC: 1,
   FAILED_TO_LOAD_PLUGIN: 2,
   PACT_HANDLE_INVALID: 3,
-};
+} as const satisfies Record<string, FfiConfigurePluginResponse>;
 
 export type FfiPluginInteractionResponse = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-export const FfiPluginInteractionResponse: Record<
-  string,
-  FfiPluginInteractionResponse
-> = {
+export const FfiPluginInteractionResponse = {
   SUCCESS: 0,
   A_GENERAL_PANIC_WAS_CAUGHT: 1,
   MOCK_SERVER_HAS_ALREADY_BEEN_STARTED: 2,
@@ -64,7 +54,7 @@ export const FfiPluginInteractionResponse: Record<
   CONTENT_TYPE_IS_NOT_VALID: 4,
   CONTENTS_JSON_IS_NOT_VALID_JSON: 5,
   PLUGIN_RETURNED_AN_ERROR: 6,
-};
+} as const satisfies Record<string, FfiPluginInteractionResponse>;
 
 export type FfiInteractionPart = 0 | 1;
 

--- a/test/consumer.integration.spec.ts
+++ b/test/consumer.integration.spec.ts
@@ -437,7 +437,7 @@ describe('FFI integration test for the HTTP Consumer API', () => {
   });
 
   // Should only run this if the plugin is installed
-  const skipPluginTests = process.env.SKIP_PLUGIN_TESTS === 'true';
+  const skipPluginTests = process.env['SKIP_PLUGIN_TESTS'] === 'true';
   (skipPluginTests ? describe.skip : describe)(
     'using a plugin (protobufs)',
     () => {

--- a/test/integration/grpc-utils.ts
+++ b/test/integration/grpc-utils.ts
@@ -1,0 +1,17 @@
+import * as grpc from '@grpc/grpc-js';
+import type { PackageDefinition } from '@grpc/proto-loader';
+
+/**
+ * Resolve the `routeguide.RouteGuide` service out of a dynamically loaded
+ * package definition, which the gRPC typings can only describe as an untyped
+ * tree of namespaces, services and message types.
+ */
+export const loadRouteGuide = (
+  definition: PackageDefinition,
+): grpc.ServiceClientConstructor => {
+  const routeguide = grpc.loadPackageDefinition(definition)[
+    'routeguide'
+  ] as grpc.GrpcObject;
+
+  return routeguide['RouteGuide'] as grpc.ServiceClientConstructor;
+};

--- a/test/integration/provider-mock.ts
+++ b/test/integration/provider-mock.ts
@@ -55,7 +55,7 @@ export default (port: number): Promise<http.Server> => {
 
   server.get(
     '/contract/:name',
-    (req: express.Request, res: express.Response) => {
+    (req: express.Request<{ name: string }>, res: express.Response) => {
       const fileName = req.params.name;
       res.sendFile(
         fileName,

--- a/test/matt.consumer.integration.spec.ts
+++ b/test/matt.consumer.integration.spec.ts
@@ -37,7 +37,7 @@ const sendMattMessageTCP = (
   });
 };
 
-const skipPluginTests = process.env.SKIP_PLUGIN_TESTS === 'true';
+const skipPluginTests = process.env['SKIP_PLUGIN_TESTS'] === 'true';
 (skipPluginTests ? describe.skip : describe)('MATT protocol test', () => {
   let provider: ConsumerPact;
   let tcpProvider: ConsumerMessagePact;

--- a/test/matt.provider.integration.spec.ts
+++ b/test/matt.provider.integration.spec.ts
@@ -49,7 +49,7 @@ const startTCPServer = (host: string, port: number) => {
   });
 };
 
-const skipPluginTests = process.env.SKIP_PLUGIN_TESTS === 'true';
+const skipPluginTests = process.env['SKIP_PLUGIN_TESTS'] === 'true';
 (skipPluginTests ? describe.skip : describe)('MATT protocol test', () => {
   setLogLevel('info');
 

--- a/test/message.integration.spec.ts
+++ b/test/message.integration.spec.ts
@@ -7,18 +7,16 @@ import * as rimraf from 'rimraf';
 import { type ConsumerMessagePact, makeConsumerMessagePact } from '../src';
 import { FfiSpecificationVersion } from '../src/ffi/types';
 import { setLogLevel } from '../src/logger';
+import { loadRouteGuide } from './integration/grpc-utils';
 
 const getFeature = async (address: string, protoFile: string) => {
   const def = await load(protoFile);
-  const { routeguide } = grpc.loadPackageDefinition(def);
+  const RouteGuide = loadRouteGuide(def);
 
-  const client = new routeguide.RouteGuide(
-    address,
-    grpc.credentials.createInsecure(),
-  );
+  const client = new RouteGuide(address, grpc.credentials.createInsecure());
 
   return new Promise<unknown>((resolve, reject) => {
-    client.GetFeature(
+    client['GetFeature'](
       {
         latitude: 180,
         longitude: 200,
@@ -279,7 +277,7 @@ describe('FFI integration test for the Message Consumer API', () => {
       });
     });
 
-    const skipPluginTests = process.env.SKIP_PLUGIN_TESTS === 'true';
+    const skipPluginTests = process.env['SKIP_PLUGIN_TESTS'] === 'true';
     (skipPluginTests ? describe.skip : describe)(
       'with plugin contents (gRPC)',
       () => {

--- a/test/plugin-verifier.integration.spec.ts
+++ b/test/plugin-verifier.integration.spec.ts
@@ -5,6 +5,7 @@ import bodyParser from 'body-parser';
 import cors from 'cors';
 import express from 'express';
 import verifierFactory from '../src/verifier';
+import { loadRouteGuide } from './integration/grpc-utils';
 
 const HTTP_PORT = 50051;
 const GRPC_PORT = 50052;
@@ -20,11 +21,11 @@ const getGRPCServer = () => {
     oneofs: true,
   };
   const packageDefinition = loadSync(PROTO_PATH, options);
-  const { routeguide } = grpc.loadPackageDefinition(packageDefinition);
+  const routeGuide = loadRouteGuide(packageDefinition);
 
   const server = new grpc.Server();
 
-  server.addService(routeguide.RouteGuide.service, {
+  server.addService(routeGuide.service, {
     // biome-ignore lint/suspicious/noExplicitAny: gRPC service handlers loaded via dynamic proto definition have no static type for their callback
     getFeature: (_: unknown, callback: any) => {
       callback(null, {
@@ -72,15 +73,12 @@ const startHTTPServer = (port: number): Promise<http.Server> => {
 
 const getFeature = async (address: string, protoFile: string) => {
   const def = loadSync(protoFile);
-  const { routeguide } = grpc.loadPackageDefinition(def);
+  const RouteGuide = loadRouteGuide(def);
 
-  const client = new routeguide.RouteGuide(
-    address,
-    grpc.credentials.createInsecure(),
-  );
+  const client = new RouteGuide(address, grpc.credentials.createInsecure());
 
   return new Promise<unknown>((resolve, reject) => {
-    client.GetFeature(
+    client['GetFeature'](
       {
         latitude: 180,
         longitude: 200,
@@ -96,7 +94,7 @@ const getFeature = async (address: string, protoFile: string) => {
   });
 };
 
-const skipPluginTests = process.env.SKIP_PLUGIN_TESTS === 'true';
+const skipPluginTests = process.env['SKIP_PLUGIN_TESTS'] === 'true';
 (skipPluginTests ? describe.skip : describe)(
   'Plugin Verifier Integration Spec',
   () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "exclude": ["**/__mocks__", "**/*.spec.ts", "test/**/*"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,14 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": true,
+    "declaration": true,
+    "stripInternal": true,
+    "types": ["node"]
   },
-  "exclude": ["**/__mocks__", "**/*.spec.ts", "test/**/*"]
+  "include": ["src"],
+  "exclude": ["**/__mocks__", "**/*.spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,10 @@
   "$schema": "https://www.schemastore.org/tsconfig",
   "extends": "@tsconfig/node22",
   "compilerOptions": {
-    "outDir": "dist",
-    "sourceMap": true,
-    "declaration": true,
+    "noEmit": true,
     "types": ["node", "vitest/globals"],
-    "stripInternal": true,
     "noPropertyAccessFromIndexSignature": true
   },
-  "include": ["src", "test"],
+  "include": ["src", "test", "vitest.config.ts"],
   "exclude": ["node_modules"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     globals: true,
     testTimeout: 60000,
     pool: 'forks',
-    maxForks: 1,
     retry: 2,
     sequence: { concurrent: false },
     include: ['src/**/*.spec.ts', 'test/**/*.spec.ts'],


### PR DESCRIPTION
Supersedes #921, which cannot pass on its own.

## Why Renovate's PR fails

Every `Test *` job dies at the same step, `npm run build`:

```
error TS5011: The common source directory of 'tsconfig.build.json' is './src'.
The 'rootDir' setting must be explicitly set to this or another path to adjust
your output's file layout.
```

TypeScript 6 removed the implicit inference of the common source directory, so emitting to an `outDir` now requires `rootDir` to be stated. That is the only thing standing between this repo and TypeScript 7 — there are no type errors in `src`.

Fixing it surfaced three further problems, each in its own commit below.

## Commits

**`fix(build): set rootDir explicitly for the build config`**

One line. Set to the directory that was already being inferred, so the emitted layout is byte-for-byte identical (60 files, same paths) and it still compiles on 5.9.

**`fix(types): resolve type errors in the test suite`**

The test sources have never been type checked — the build config excludes them and vitest transpiles without checking — so 20 errors had accumulated unnoticed. Most came from one source: the FFI enum-like constants in `src/ffi/types.ts` were annotated `Record<string, T>`, which erased their keys and pushed every access through an index signature. `as const satisfies` keeps the values checked against their union while exposing the keys, fixing 12 errors at the source rather than at each call site. The rest are the gRPC package definition (dynamic shape, assertion now in a shared test helper) and an Express route typed so `params.name` is `string` rather than express 5's `string | string[]`.

**`ci: type check and lint the whole repository`**

Nothing type checked the tests or `vitest.config.ts`, and **lint has not run in CI since the Biome migration** — #885 removed `format:check` and `lint` from `build-and-test.sh` on the understanding that a check job covered them, but no such job existed.

The two tsconfigs are split along the lines they were already drifting towards: the root config checks everything and emits nothing (what an editor and the new `npm run typecheck` see), the build config owns the emit settings and narrows to what ships. A `static_checks` job runs both plus `npm run check`, once, independently of the platform matrix since neither needs the native libraries.

Turning this on immediately caught a dead `maxForks: 1` in the vitest config — not a valid Vitest option at any version (v1–3 wanted `poolOptions.forks.maxForks`, v4 wants `maxWorkers`), so it has always been silently ignored. Removed; behaviour is unchanged and test parallelism is preserved. The flakiness it appeared to guard against is already handled by the `retry: 2` beside it.

**`fix(package): point the entry points at the compiled output`**

`main` and `types` still referred to `src`, which stopped being where the compiler writes when the build moved to an `outDir`, and `.npmignore` strips the sources from the tarball. **The published package cannot resolve its own entry point:**

```console
$ npm pack @pact-foundation/pact-core@20.0.0 && node -e "require('./package')"
MODULE_NOT_FOUND: Cannot find module '.../package/src/index.js'.
Please verify that the package.json has a valid "main" entry
```

Both now point at `dist`, and `clean` removes that directory rather than the stale in-place build artifacts.

**`chore(deps): update dependency typescript to v7`**

The bump itself, matching #921.

## Verification

- `npm run typecheck` and `npm run build` clean under **both 5.9.3 and 7.0.2**
- `npm run check` passes
- Emitted layout identical between 5.9.3 and 7.0.2; the only content differences are two declaration files TypeScript 7 writes more compactly (`typeof` alias, hoisted function declaration) — semantically equivalent
- Packed tarball resolves and loads, exporting the real API
- Test suite: **85/86**, unchanged before and after. The one failure (`consumer.integration.spec.ts > with multipart data`) reproduces on unmodified `master` and is unrelated.
