### PR TITLE
fix(test): make the MATT TCP helper survive a not-yet-listening server

### DIFF
--- a/test/matt.consumer.integration.spec.ts
+++ b/test/matt.consumer.integration.spec.ts
@@ -13,29 +13,66 @@ const parseMattMessage = (raw: string): string =>
   raw.replace(/(MATT)+/g, '').trim();
 const generateMattMessage = (raw: string): string => `MATT${raw}MATT`;
 
+const CONNECT_TIMEOUT_MS = 10000;
+const CONNECT_RETRY_MS = 50;
+
 const sendMattMessageTCP = (
   message: string,
   host: string,
   port: number,
-): Promise<string> => {
-  const socket = net.connect({
-    port,
-    host,
-  });
+  deadline: number = Date.now() + CONNECT_TIMEOUT_MS,
+): Promise<string> =>
+  new Promise<string>((resolve, reject) => {
+    const socket = net.connect({ port, host });
+    let settled = false;
 
-  const res = socket.write(`${generateMattMessage(message)}\n`);
-
-  if (!res) {
-    throw Error('unable to connect to host');
-  }
-
-  return new Promise((resolve) => {
-    socket.on('data', (data) => {
-      resolve(parseMattMessage(data.toString()));
+    const settle = (action: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       socket.destroy();
+      action();
+    };
+
+    socket.on('connect', () => {
+      socket.write(`${generateMattMessage(message)}\n`);
+    });
+
+    socket.on('data', (data) => {
+      settle(() => resolve(parseMattMessage(data.toString())));
+    });
+
+    socket.on('close', () => {
+      settle(() =>
+        reject(
+          new Error(
+            `connection to ${host}:${port} closed before a MATT message arrived`,
+          ),
+        ),
+      );
+    });
+
+    socket.on('error', (err: NodeJS.ErrnoException) => {
+      // The mock server reports its port before the plugin is necessarily
+      // accepting on it, so a refused connection is retried until the deadline
+      // rather than failing the test.
+      if (err.code === 'ECONNREFUSED' && Date.now() < deadline) {
+        settle(() => {
+          setTimeout(
+            () =>
+              sendMattMessageTCP(message, host, port, deadline).then(
+                resolve,
+                reject,
+              ),
+            CONNECT_RETRY_MS,
+          );
+        });
+        return;
+      }
+      settle(() => reject(err));
     });
   });
-};
 
 const skipPluginTests = process.env['SKIP_PLUGIN_TESTS'] === 'true';
 (skipPluginTests ? describe.skip : describe)('MATT protocol test', () => {


### PR DESCRIPTION
Fixes the dominant cause of "one matrix element failed, click re-run".

## The signature

A failing job whose tests all passed:

```
 Test Files  10 passed (10)
      Tests  86 passed (86)
     Errors  2 errors
...
##[error]Process completed with exit code 1.
```

The errors:

```
Uncaught Exception
Error: connect ECONNREFUSED 127.0.0.1:65276
 ❯ TCPConnectWrap.afterConnect [as oncomplete] node:net:1706:16
This error originated in "test/matt.consumer.integration.spec.ts"
```

and, in the same run:

```
✓ generates a pact with success 144131ms (retry x2)
```

## Root cause

`sendMattMessageTCP` attached **no `error` handler** to its socket. `pactffiCreateMockServerForTransport` returns a port before the plugin is necessarily accepting on it, so the connection is sometimes refused — and a socket with no `error` listener raises an **uncaught exception**. Vitest counts uncaught exceptions against the run regardless of test results, so the job exits 1 while reporting every test passed.

The promise compounded it by only ever resolving, never rejecting. A refused attempt therefore hung until the 60s `testTimeout` rather than failing fast, so the `retry: 2` that eventually rescued the test cost two more timeouts — hence the 144-second test above.

That is the whole "re-run and it goes green" loop: the retries mask the flake, the leaked exceptions still fail the job, and a fresh run usually wins the race.

Reproduction of the old helper against a port nothing is listening on:

```
$ node repro-socket.js
UNCAUGHT EXCEPTION: ECONNREFUSED — this is what fails the vitest run
```

The promise never settles, so nothing rejects and nothing is logged against the test.

## The fix

- attach an `error` handler and reject, so a failure can never escape as an uncaught exception
- write on `connect` rather than before it (the old `socket.write(...)` return check could not detect a refused connection, since writes are buffered until connected)
- reject on premature `close`, so a dead connection fails in milliseconds instead of hanging for 60s
- retry a refused connection until a 10s deadline, addressing the underlying race rather than relying on vitest-level retries

The same reproduction against the new helper:

```
PASS case 1: promise rejected cleanly (ECONNREFUSED)
PASS case 2: retried until ready, got "tcpworld"
```

## Verification

- `test/matt.consumer.integration.spec.ts` passes in **550ms with no retries**, versus 144s with `retry x2` in the failing CI run — 3 consecutive local runs, all clean, zero unhandled errors
- full suite unchanged at 85/86, and the run no longer reports any `Errors`
- `npm run typecheck` and `npm run check` pass
- this was the only unguarded socket in the repo (`grep` for `net.connect` / `createConnection` finds no others)

## Not fixed here

The remaining failure, `consumer.integration.spec.ts > with multipart data`, is a **separate and upstream** problem. The native library logs

```
WARN pact_matching::binary_utils: Could not get the tokio runtime,
     will try start a new one: there is no reactor running
```

and the mock server then answers the multipart request with a 500. That is inside `libpact_ffi` 0.5.4, not in this repository, so it needs an FFI fix or bump rather than a change here. It reproduces deterministically on macOS arm64 and intermittently in CI.
